### PR TITLE
Update aws-resource-directoryservice-microsoftad.md

### DIFF
--- a/doc_source/aws-resource-directoryservice-microsoftad.md
+++ b/doc_source/aws-resource-directoryservice-microsoftad.md
@@ -1,6 +1,6 @@
 # AWS::DirectoryService::MicrosoftAD<a name="aws-resource-directoryservice-microsoftad"></a>
 
-The `AWS::DirectoryService::MicrosoftAD` resource creates a Microsoft Active Directory in AWS so that your directory users and groups can access the AWS Management Console and AWS applications using their existing credentials\. For more information, see [What Is AWS Directory Service?](http://docs.aws.amazon.com/directoryservice/latest/admin-guide/what_is.html) in the *AWS Directory Service Administration Guide*\.
+The `AWS::DirectoryService::MicrosoftAD` resource creates an Enterprise Edition Microsoft Active Directory in AWS so that your directory users and groups can access the AWS Management Console and AWS applications using their existing credentials\. Standard edition cannot be created through CloudFormation at this time.  For more information, see [What Is AWS Directory Service?](http://docs.aws.amazon.com/directoryservice/latest/admin-guide/what_is.html) in the *AWS Directory Service Administration Guide*\.
 
 
 + [Syntax](#aws-resource-directoryservice-microsoftad-syntax)


### PR DESCRIPTION
Change name of Ad to Enterprise Edition AD, and made note that a Standard Edition cannot be created through CF at this time.

*Issue #, if available:*

*Description of changes:*
Made comment about CF only being able to make an enterprise edition AD.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
