### PR TITLE
Fix CloudFront DistributionConfig YAML syntax lists

### DIFF
--- a/doc_source/aws-properties-cloudfront-distributionconfig.md
+++ b/doc_source/aws-properties-cloudfront-distributionconfig.md
@@ -32,10 +32,10 @@
 [Aliases](#cfn-cloudfront-distributionconfig-aliases):
   - String
 [CacheBehaviors](#cfn-cloudfront-distributionconfig-cachebehaviors):
-  CacheBehavior
+  - CacheBehavior
 [Comment](#cfn-cloudfront-distributionconfig-comment): String
 [CustomErrorResponses](#cfn-cloudfront-distributionconfig-customerrorresponses):
-  CustomErrorResponse
+  - CustomErrorResponse
 [DefaultCacheBehavior](#cfn-cloudfront-distributionconfig-defaultcachebehavior):
   DefaultCacheBehavior
 [DefaultRootObject](#cfn-cloudfront-distributionconfig-defaultrootobject): String
@@ -45,7 +45,7 @@
 [Logging](#cfn-cloudfront-distributionconfig-logging):
   Logging
 [Origins](#cfn-cloudfront-distributionconfig-origins):
-  Origin
+  - Origin
 [PriceClass](#cfn-cloudfront-distributionconfig-priceclass): String
 [Restrictions](#cfn-cloudfront-distributionconfig-restrictions):
   Restriction


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

On the [CloudFront DistributionConfig page](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig.html), the JSON syntax and properties descriptions for `Aliases`, `CacheBehaviors`, `CustomErrorResponses` and `Origins` all correctly show these properties as being "list" types, but only `Aliases` is correctly shown as a list in the YAML syntax section.

This patch changes `CacheBehaviors`, `CustomErrorResponses` and `Origins` to lists in the YAML syntax section as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
