### PR TITLE
StreamEncryption is not required for Kinesis Stream

### DIFF
--- a/doc_source/aws-resource-kinesis-stream.md
+++ b/doc_source/aws-resource-kinesis-stream.md
@@ -66,7 +66,7 @@ The number of shards that the stream uses\. For greater provisioned throughput, 
 
 `StreamEncryption`  <a name="cfn-kinesis-stream-streamencryption"></a>
 Enables or updates server\-side encryption using an AWS KMS key for a specified stream\.  
-*Required: *Yes  
+*Required: *No  
 *Type:* [Kinesis StreamEncryption](aws-properties-kinesis-stream-streamencryption.md)  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
