### PR TITLE
Clarify ContainerDefinition Memory

### DIFF
--- a/doc_source/aws-properties-ecs-taskdefinition-containerdefinitions.md
+++ b/doc_source/aws-properties-ecs-taskdefinition-containerdefinitions.md
@@ -181,7 +181,7 @@ Configures a custom log driver for the container\. For more information, see the
 *Type*: [Amazon ECS TaskDefinition LogConfiguration](aws-properties-ecs-taskdefinition-containerdefinitions-logconfiguration.md)
 
 `Memory`  <a name="cfn-ecs-taskdefinition-containerdefinition-memory"></a>
-The number of MiB of memory to reserve for the container\. If your container attempts to exceed the allocated memory, the container is terminated\.  
+The maximum number of MiB of memory that the container is allowed to use\. If your container attempts to exceed the allocated memory, the container is terminated\.  
 *Required*: Conditional\. You must specify one or both of the `Memory` or `MemoryReservation` properties\. If you specify both, the value for the `Memory` property must be greater than the value of the `MemoryReservation` property\.  
 *Type*: Integer
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Make it clear that `Memory` is not a reservation, it's the hard maximum, and that it's memory that your container is allowed to use but isn't reserved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
