### PR TITLE
YAML examples do not requires the CloudFormation type to be enclosed …

### DIFF
--- a/doc_source/aws-properties-as-group.md
+++ b/doc_source/aws-properties-as-group.md
@@ -47,7 +47,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-autoscaling-autoscalinggroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::AutoScaling::AutoScalingGroup"
+Type: AWS::AutoScaling::AutoScalingGroup
 Properties:
   [AutoScalingGroupName](#cfn-autoscaling-autoscalinggroup-autoscalinggroupname): String
   [AvailabilityZones](#cfn-as-group-availabilityzones):
@@ -251,7 +251,7 @@ To view more Auto Scaling examples, see [Auto Scaling Template Snippets](quickre
 
 ```
 WebServerGroup: 
-  Type: "AWS::AutoScaling::AutoScalingGroup"
+  Type: AWS::AutoScaling::AutoScalingGroup
   Properties: 
     AvailabilityZones: 
       Fn::GetAZs: ""
@@ -328,7 +328,7 @@ ASG1:
       MaxBatchSize: "1"
       PauseTime: "PT12M5S"
       WaitOnResourceSignals: "true"
-  Type: "AWS::AutoScaling::AutoScalingGroup"
+  Type: AWS::AutoScaling::AutoScalingGroup
   Properties: 
     AvailabilityZones: 
       Fn::GetAZs: 

--- a/doc_source/aws-properties-as-launchconfig.md
+++ b/doc_source/aws-properties-as-launchconfig.md
@@ -47,7 +47,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-autoscaling-launchconfig-syntax.yaml"></a>
 
 ```
-Type: "AWS::AutoScaling::LaunchConfiguration"
+Type: AWS::AutoScaling::LaunchConfiguration
 Properties:
   [AssociatePublicIpAddress](#cf-as-launchconfig-associatepubip): Boolean
   [BlockDeviceMappings](#cfn-as-launchconfig-blockdevicemappings):
@@ -240,7 +240,7 @@ This example shows a launch configuration that describes two Amazon Elastic Bloc
 
 ```
 LaunchConfig: 
-  Type: "AWS::AutoScaling::LaunchConfiguration"
+  Type: AWS::AutoScaling::LaunchConfiguration
   Properties: 
     KeyName: 
       Ref: "KeyName"
@@ -304,7 +304,7 @@ This example shows a launch configuration that features a spot price in the Auto
 
 ```
 LaunchConfig: 
-  Type: "AWS::AutoScaling::LaunchConfiguration"
+  Type: AWS::AutoScaling::LaunchConfiguration
   Properties: 
     KeyName: 
       Ref: "KeyName"
@@ -356,7 +356,7 @@ Only the `AWS::AutoScaling::LaunchConfiguration` specification is shown\. For th
 
 ```
 myLCOne: 
-  Type: "AWS::AutoScaling::LaunchConfiguration"
+  Type: AWS::AutoScaling::LaunchConfiguration
   Properties: 
     ImageId: 
       Fn::FindInMap: 
@@ -411,7 +411,7 @@ Use this AMI in your Auto Scaling launch configuration\. For example, an EBS\-op
 
 ```
 LaunchConfig: 
-  Type: "AWS::AutoScaling::LaunchConfiguration"
+  Type: AWS::AutoScaling::LaunchConfiguration
   Properties: 
     KeyName: 
       Ref: "KeyName"

--- a/doc_source/aws-properties-as-policy.md
+++ b/doc_source/aws-properties-as-policy.md
@@ -39,7 +39,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-autoscaling-scalingpolicy-syntax.yaml"></a>
 
 ```
-Type: "AWS::AutoScaling::ScalingPolicy"
+Type: AWS::AutoScaling::ScalingPolicy
 Properties:
   [AdjustmentType](#cfn-as-scalingpolicy-adjustmenttype): String
   [AutoScalingGroupName](#cfn-as-scalingpolicy-autoscalinggroupname): String
@@ -151,7 +151,7 @@ The following example is a simple scaling policy that increases the number insta
 
 ```
 SimpleScaling: 
-  Type: "AWS::AutoScaling::ScalingPolicy"
+  Type: AWS::AutoScaling::ScalingPolicy
   Properties: 
     AdjustmentType: "ChangeInCapacity"
     PolicyType: "SimpleScaling"
@@ -195,7 +195,7 @@ The following example is a step scaling policy that increases the number instanc
 
 ```
 StepScaling: 
-  Type: "AWS::AutoScaling::ScalingPolicy"
+  Type: AWS::AutoScaling::ScalingPolicy
   Properties: 
     AdjustmentType: "ChangeInCapacity"
     AutoScalingGroupName: 

--- a/doc_source/aws-properties-beanstalk-environment.md
+++ b/doc_source/aws-properties-beanstalk-environment.md
@@ -37,7 +37,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticbeanstalk-environment-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElasticBeanstalk::Environment"
+Type: AWS::ElasticBeanstalk::Environment
 Properties:
   [ApplicationName](#cfn-beanstalk-environment-applicationname): String
   [CNAMEPrefix](#cfn-beanstalk-environment-cnameprefix): String
@@ -171,7 +171,7 @@ For more information about using `Fn::GetAtt`, see [Fn::GetAtt](intrinsic-functi
 #### YAML<a name="aws-resource-elasticbeanstalk-environment-example1.yaml"></a>
 
 ```
-Type: "AWS::ElasticBeanstalk::Environment"
+Type: AWS::ElasticBeanstalk::Environment
 Properties: 
   ApplicationName: 
     Ref: sampleApplication
@@ -206,7 +206,7 @@ Properties:
 #### YAML<a name="aws-resource-elasticbeanstalk-environment-example2.yaml"></a>
 
 ```
-Type: "AWS::ElasticBeanstalk::Environment"
+Type: AWS::ElasticBeanstalk::Environment
 Properties: 
   ApplicationName: 
     Ref: sampleApplication

--- a/doc_source/aws-properties-beanstalk-version.md
+++ b/doc_source/aws-properties-beanstalk-version.md
@@ -88,7 +88,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 
 ```
 myAppVersion: 
-  Type: "AWS::ElasticBeanstalk::ApplicationVersion"
+  Type: AWS::ElasticBeanstalk::ApplicationVersion
   Properties: 
     ApplicationName: 
       Ref: "myApp"

--- a/doc_source/aws-properties-beanstalk.md
+++ b/doc_source/aws-properties-beanstalk.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticbeanstalk-application-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElasticBeanstalk::Application"
+Type: AWS::ElasticBeanstalk::Application
 Properties:
   [ApplicationName](#cfn-elasticbeanstalk-application-name): String
   [Description](#cfn-elasticbeanstalk-application-description): String
@@ -84,7 +84,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 ### YAML<a name="aws-resource-elasticbeanstalk-application-example.yaml"></a>
 
 ```
-Type: "AWS::ElasticBeanstalk::Application"
+Type: AWS::ElasticBeanstalk::Application
 Properties: 
   ApplicationName: "SampleAWSElasticBeanstalkApplication"
   Description: "AWS Elastic Beanstalk PHP Sample Application"

--- a/doc_source/aws-properties-cloudfront-distribution.md
+++ b/doc_source/aws-properties-cloudfront-distribution.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cloudfront-distribution-syntax.yaml"></a>
 
 ```
-Type: "AWS::CloudFront::Distribution"
+Type: AWS::CloudFront::Distribution
 Properties:
   [DistributionConfig](#cfn-cloudfront-distribution-distributionconfig): 
     [*DistributionConfig*](aws-properties-cloudfront-distributionconfig.md)

--- a/doc_source/aws-properties-cw-alarm.md
+++ b/doc_source/aws-properties-cw-alarm.md
@@ -45,7 +45,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cw-alarm-syntax.yaml"></a>
 
 ```
-Type: "AWS::CloudWatch::Alarm"
+Type: AWS::CloudWatch::Alarm
 Properties:
   [ActionsEnabled](#cfn-cloudwatch-alarms-actionsenabled): Boolean
   [AlarmActions](#cfn-cloudwatch-alarms-alarmactions):

--- a/doc_source/aws-properties-cw-dashboard.md
+++ b/doc_source/aws-properties-cw-dashboard.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cw-dashboard-syntax.yaml"></a>
 
 ```
-Type: "AWS::CloudWatch::Dashboard"
+Type: AWS::CloudWatch::Dashboard
 Properties:
       [DashboardName](#cfn-cloudwatch-dashboard-name): String
       [DashboardBody](#cfn-cloudwatch-dashboard-body): String

--- a/doc_source/aws-properties-ec2-ebs-volume.md
+++ b/doc_source/aws-properties-ec2-ebs-volume.md
@@ -57,7 +57,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-volume-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::Volume"
+Type: AWS::EC2::Volume
 Properties:
   [AutoEnableIO](#cfn-ec2-ebs-volume-autoenableio): Boolean
   [AvailabilityZone](#cfn-ec2-ebs-volume-availabilityzone): String

--- a/doc_source/aws-properties-ec2-eip-association.md
+++ b/doc_source/aws-properties-ec2-eip-association.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-eipassociation-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::EIPAssociation"
+Type: AWS::EC2::EIPAssociation
 Properties:
   [AllocationId](#cfn-ec2-eipassociation-allocationid): String
   [EIP](#cfn-ec2-eipassociation-eip): String

--- a/doc_source/aws-properties-ec2-eip.md
+++ b/doc_source/aws-properties-ec2-eip.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-eip-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::EIP"
+Type: AWS::EC2::EIP
 Properties:
   [InstanceId](#cfn-ec2-eip-instanceid): String
   [Domain](#cfn-ec2-eip-domain): String

--- a/doc_source/aws-properties-ec2-elb.md
+++ b/doc_source/aws-properties-ec2-elb.md
@@ -44,7 +44,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticloadbalancing-loadbalancer-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElasticLoadBalancing::LoadBalancer"
+Type: AWS::ElasticLoadBalancing::LoadBalancer
 Properties:
   [AccessLoggingPolicy](#cfn-ec2-elb-accessloggingpolicy):
     AccessLoggingPolicy

--- a/doc_source/aws-properties-ec2-instance.md
+++ b/doc_source/aws-properties-ec2-instance.md
@@ -59,7 +59,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-properties-ec2-instance-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::Instance"
+Type: AWS::EC2::Instance
 Properties: 
   [Affinity](#cfn-ec2-instance-affinity): String
   [AvailabilityZone](#cfn-ec2-instance-availabilityzone): String
@@ -410,7 +410,7 @@ For more information about using `Fn::GetAtt`, see [Fn::GetAtt](intrinsic-functi
   Description: "Ec2 block device mapping"
   Resources: 
     MyEC2Instance: 
-      Type: "AWS::EC2::Instance"
+      Type: AWS::EC2::Instance
       Properties: 
         ImageId: "ami-79fd7eee"
         KeyName: "testkey"
@@ -451,7 +451,7 @@ You can associate a public IP address with a network interface only if it has a 
 
 ```
   Ec2Instance: 
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Properties: 
       ImageId: 
         Fn::FindInMap: 

--- a/doc_source/aws-properties-ec2-security-group-ingress.md
+++ b/doc_source/aws-properties-ec2-security-group-ingress.md
@@ -38,7 +38,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-securitygroupingress-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::SecurityGroupIngress"
+Type: AWS::EC2::SecurityGroupIngress
 Properties: 
   [CidrIp](#cfn-ec2-security-group-ingress-cidrip): String
   [CidrIpv6](#cfn-ec2-security-group-ingress-cidripv6): String

--- a/doc_source/aws-properties-ec2-security-group-rule.md
+++ b/doc_source/aws-properties-ec2-security-group-rule.md
@@ -145,7 +145,7 @@ The end of port range for the TCP and UDP protocols, or an ICMP code\. An ICMP c
 
 ```
 InstanceSecurityGroup: 
-  Type: "AWS::EC2::SecurityGroup"
+  Type: AWS::EC2::SecurityGroup
   Properties: 
     GroupDescription: "Enable SSH access via port 22"
     SecurityGroupIngress: 
@@ -180,7 +180,7 @@ InstanceSecurityGroup:
 
 ```
 InstanceSecurityGroup: 
-  Type: "AWS::EC2::SecurityGroup"
+  Type: AWS::EC2::SecurityGroup
   Properties: 
     GroupDescription: "Enable HTTP access on the configured port"
     VpcId: 
@@ -246,7 +246,7 @@ This snippet grants SSH access with CidrIp, and HTTP access with `SourceSecurity
 
 ```
 ElasticLoadBalancer: 
-  Type: "AWS::ElasticLoadBalancing::LoadBalancer"
+  Type: AWS::ElasticLoadBalancing::LoadBalancer
   Properties: 
     AvailabilityZones: 
       Fn::GetAZs: ""
@@ -270,7 +270,7 @@ ElasticLoadBalancer:
       Interval: "30"
       Timeout: "5"
 InstanceSecurityGroup: 
-  Type: "AWS::EC2::SecurityGroup"
+  Type: AWS::EC2::SecurityGroup
   Properties: 
     GroupDescription: "Enable SSH access and HTTP from the load balancer only"
     SecurityGroupIngress: 

--- a/doc_source/aws-properties-ec2-security-group.md
+++ b/doc_source/aws-properties-ec2-security-group.md
@@ -37,7 +37,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-securitygroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::SecurityGroup"
+Type: AWS::EC2::SecurityGroup
 Properties: 
   [GroupName](#cfn-ec2-securitygroup-groupname): String
   [GroupDescription](#cfn-ec2-securitygroup-groupdescription): String

--- a/doc_source/aws-properties-elasticache-cache-cluster.md
+++ b/doc_source/aws-properties-elasticache-cache-cluster.md
@@ -48,7 +48,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticache-cachecluster-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElastiCache::CacheCluster"
+Type: AWS::ElastiCache::CacheCluster
 Properties:
   [AutoMinorVersionUpgrade](#cfn-elasticache-cachecluster-autominorversionupgrade): Boolean
   [AZMode](#cfn-elasticache-cachecluster-azmode): String
@@ -282,7 +282,7 @@ For the cache cluster, the `VpcSecurityGroupIds` property is used to associate t
 
 ```
 ElasticacheSecurityGroup:
-  Type: "AWS::EC2::SecurityGroup"
+  Type: AWS::EC2::SecurityGroup
   Properties:
     GroupDescription: "Elasticache Security Group"
     SecurityGroupIngress:
@@ -293,7 +293,7 @@ ElasticacheSecurityGroup:
         SourceSecurityGroupName:
           Ref: "InstanceSecurityGroup"
 ElasticacheCluster:
-  Type: "AWS::ElastiCache::CacheCluster"
+  Type: AWS::ElastiCache::CacheCluster
   Properties:
     AutoMinorVersionUpgrade: "true"
     Engine: "memcached"
@@ -329,7 +329,7 @@ The following example launches a cache cluster with three nodes, where two nodes
 
 ```
 myCacheCluster:
-  Type: "AWS::ElastiCache::CacheCluster"
+  Type: AWS::ElastiCache::CacheCluster
   Properties:
     AZMode: "cross-az"
     CacheNodeType: "cache.m3.medium"

--- a/doc_source/aws-properties-elasticache-parameter-group.md
+++ b/doc_source/aws-properties-elasticache-parameter-group.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticache-parametergroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElastiCache::ParameterGroup"
+Type: AWS::ElastiCache::ParameterGroup
 Properties: 
   CacheParameterGroupFamily: String
   Description: String
@@ -95,7 +95,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 
 ```
 MyParameterGroup: 
-  Type: "AWS::ElastiCache::ParameterGroup"
+  Type: AWS::ElastiCache::ParameterGroup
   Properties: 
     Description: "MyNewParameterGroup"
     CacheParameterGroupFamily: "memcached1.4"

--- a/doc_source/aws-properties-elasticache-security-group-ingress.md
+++ b/doc_source/aws-properties-elasticache-security-group-ingress.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticache-securitygroupingress-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElastiCache::SecurityGroupIngress"
+Type: AWS::ElastiCache::SecurityGroupIngress
 Properties:
   [CacheSecurityGroupName](#cfn-elasticache-securitygroupingress-cachesecuritygroupname): String
   [EC2SecurityGroupName](#cfn-elasticache-securitygroupingress-ec2securitygroupname): String

--- a/doc_source/aws-properties-elasticache-security-group.md
+++ b/doc_source/aws-properties-elasticache-security-group.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticache-securitygroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElastiCache::SecurityGroup"
+Type: AWS::ElastiCache::SecurityGroup
 Properties:
   [Description](#cfn-elasticache-securitygroup-description): String
 ```

--- a/doc_source/aws-properties-elasticache-subnetgroup.md
+++ b/doc_source/aws-properties-elasticache-subnetgroup.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticache-subnetgroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElastiCache::SubnetGroup"
+Type: AWS::ElastiCache::SubnetGroup
 Properties:
   [CacheSubnetGroupName](#cfn-elasticache-subnetgroup-cachesubnetgroupname): String
   [Description](#cfn-elasticache-subnetgroup-description): String
@@ -83,7 +83,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 
 ```
 SubnetGroup: 
-  Type: "AWS::ElastiCache::SubnetGroup"
+  Type: AWS::ElastiCache::SubnetGroup
   Properties: 
     Description: "Cache Subnet Group"
     SubnetIds: 

--- a/doc_source/aws-properties-iam-accesskey.md
+++ b/doc_source/aws-properties-iam-accesskey.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-iam-accesskey-syntax.yaml"></a>
 
 ```
-Type: "AWS::IAM::AccessKey"
+Type: AWS::IAM::AccessKey
 Properties: 
   [Serial](#cfn-iam-accesskey-serial): Integer
   [Status](#cfn-iam-accesskey-status): String

--- a/doc_source/aws-properties-iam-addusertogroup.md
+++ b/doc_source/aws-properties-iam-addusertogroup.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-iam-addusertogroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::IAM::UserToGroupAddition"
+Type: AWS::IAM::UserToGroupAddition
 Properties: 
   [GroupName](#cfn-iam-addusertogroup-groupname): String
   [Users](#cfn-iam-addusertogroup-users):

--- a/doc_source/aws-properties-iam-group.md
+++ b/doc_source/aws-properties-iam-group.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-iam-group-syntax.yaml"></a>
 
 ```
-Type: "AWS::IAM::Group"
+Type: AWS::IAM::Group
 Properties:
   [GroupName](#cfn-iam-group-groupname): String
   [ManagedPolicyArns](#cfn-iam-group-managepolicyarns): [ String, ... ]

--- a/doc_source/aws-properties-iam-user.md
+++ b/doc_source/aws-properties-iam-user.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-iam-user-syntax.yaml"></a>
 
 ```
-Type: "AWS::IAM::User"
+Type: AWS::IAM::User
 Properties: 
   [Groups](#cfn-iam-user-groups):
     - String

--- a/doc_source/aws-properties-name.md
+++ b/doc_source/aws-properties-name.md
@@ -42,7 +42,7 @@ If you want to use a custom name, specify a name property for that resource in y
 
 ```
 myDynamoDBTable: 
-  Type: "AWS::DynamoDB::Table"
+  Type: AWS::DynamoDB::Table
   Properties: 
     KeySchema: 
       HashKeyElement: 

--- a/doc_source/aws-properties-rds-database-instance.md
+++ b/doc_source/aws-properties-rds-database-instance.md
@@ -69,7 +69,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-rds-dbinstance-syntax.yaml"></a>
 
 ```
-Type: "AWS::RDS::DBInstance"
+Type: AWS::RDS::DBInstance
 Properties:
   [AllocatedStorage](#cfn-rds-dbinstance-allocatedstorage): String
   [AllowMajorVersionUpgrade](#cfn-rds-dbinstance-allowmajorversionupgrade): Boolean
@@ -523,7 +523,7 @@ This example shows how to set the MySQL version that has a `[DeletionPolicy Attr
 
 ```
 MyDB: 
-  Type: "AWS::RDS::DBInstance"
+  Type: AWS::RDS::DBInstance
   Properties: 
     DBName: 
       Ref: "DBName"
@@ -569,7 +569,7 @@ This example sets a provisioned IOPS value in the [Iops](#cfn-rds-dbinstance-iop
 
 ```
 MyDB: 
-  Type: "AWS::RDS::DBInstance"
+  Type: AWS::RDS::DBInstance
   Properties: 
     AllocatedStorage: "100"
     DBInstanceClass: "db.m1.small"

--- a/doc_source/aws-properties-rds-dbparametergroup.md
+++ b/doc_source/aws-properties-rds-dbparametergroup.md
@@ -34,7 +34,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-rds-dbparametergroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::RDS::DBParameterGroup"
+Type: AWS::RDS::DBParameterGroup
 Properties: 
   [Description](#cfn-rds-dbparametergroup-description): String
   [Family](#cfn-rds-dbparametergroup-family): String

--- a/doc_source/aws-properties-rds-security-group.md
+++ b/doc_source/aws-properties-rds-security-group.md
@@ -34,7 +34,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-rds-securitygroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::RDS::DBSecurityGroup"
+Type: AWS::RDS::DBSecurityGroup
 Properties:
   [EC2VpcId](#cfn-rds-dbsecuritygroup-ec2vpcid): String
   [DBSecurityGroupIngress](#cfn-rds-dbsecuritygroup-dbsecuritygroupingress):
@@ -99,7 +99,7 @@ This template snippet creates/updates a single VPC security group, referred to b
 
 ```
 DBSecurityGroup: 
-  Type: "AWS::RDS::DBSecurityGroup"
+  Type: AWS::RDS::DBSecurityGroup
   Properties: 
     EC2VpcId: 
       Ref: "VpcId"
@@ -153,7 +153,7 @@ This template snippet creates/updates multiple VPC security groups\.
 ```
 Resources: 
   DBinstance: 
-    Type: "AWS::RDS::DBInstance"
+    Type: AWS::RDS::DBInstance
     Properties: 
       DBSecurityGroups: 
         - 
@@ -165,7 +165,7 @@ Resources:
       MasterUserPassword: "YourPassword"
     DeletionPolicy: "Snapshot"
   DbSecurityByEC2SecurityGroup: 
-    Type: "AWS::RDS::DBSecurityGroup"
+    Type: AWS::RDS::DBSecurityGroup
     Properties: 
       GroupDescription: "Ingress for Amazon EC2 security group"
       DBSecurityGroupIngress: 

--- a/doc_source/aws-properties-route53-recordset.md
+++ b/doc_source/aws-properties-route53-recordset.md
@@ -41,7 +41,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-route53-recordset-syntax.yaml"></a>
 
 ```
-Type: "AWS::Route53::RecordSet"
+Type: AWS::Route53::RecordSet
 Properties: 
   [AliasTarget](#cfn-route53-recordset-aliastarget): 
     [*AliasTarget*](aws-properties-route53-aliastarget.md)

--- a/doc_source/aws-properties-route53-recordsetgroup.md
+++ b/doc_source/aws-properties-route53-recordsetgroup.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-route53-recordsetgroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::Route53::RecordSetGroup"
+Type: AWS::Route53::RecordSetGroup
 Properties: 
   [Comment](#cfn-route53-recordsetgroup-comment): String
   [HostedZoneId](#cfn-route53-recordsetgroup-hostedzoneid): String

--- a/doc_source/aws-properties-s3-bucket-notificationconfig-lambdaconfig.md
+++ b/doc_source/aws-properties-s3-bucket-notificationconfig-lambdaconfig.md
@@ -76,7 +76,7 @@ The `BucketName` is unique and the `Value` contains a file extension without a p
 
 ```
 EncryptionServiceBucket:
-  Type: "AWS::S3::Bucket"
+  Type: AWS::S3::Bucket
   Properties:
     BucketName: !Sub ${User}-encryption-service
     NotificationConfiguration:

--- a/doc_source/aws-properties-s3-bucket.md
+++ b/doc_source/aws-properties-s3-bucket.md
@@ -46,7 +46,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-s3-bucket-syntax.yaml"></a>
 
 ```
-Type: "AWS::S3::Bucket"
+Type: AWS::S3::Bucket
 Properties: 
   [AccessControl](#cfn-s3-bucket-accesscontrol): String
   [AccelerateConfiguration](#cfn-s3-bucket-accelerateconfiguration):

--- a/doc_source/aws-properties-s3-policy.md
+++ b/doc_source/aws-properties-s3-policy.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-s3-bucketpolicy-syntax.yaml"></a>
 
 ```
-Type: "AWS::S3::BucketPolicy"
+Type: AWS::S3::BucketPolicy
 Properties: 
   [Bucket](#cfn-s3-bucketpolicy-bucket): String
   [PolicyDocument](#cfn-s3-bucketpolicy-policydocument): JSON
@@ -85,7 +85,7 @@ The following sample is a bucket policy that is attached to the `myExampleBucket
 
 ```
 SampleBucketPolicy: 
-  Type: "AWS::S3::BucketPolicy"
+  Type: AWS::S3::BucketPolicy
   Properties: 
     Bucket: 
       Ref: "myExampleBucket"

--- a/doc_source/aws-properties-simpledb.md
+++ b/doc_source/aws-properties-simpledb.md
@@ -23,7 +23,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-sdb-domain-syntax.yaml"></a>
 
 ```
-Type: "AWS::SDB::Domain"
+Type: AWS::SDB::Domain
 Properties: 
   [Description](#cfn-sdb-domain-description): String
 ```

--- a/doc_source/aws-properties-sns-policy.md
+++ b/doc_source/aws-properties-sns-policy.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-sns-policy-syntax.yaml"></a>
 
 ```
-Type: "AWS::SNS::TopicPolicy"
+Type: AWS::SNS::TopicPolicy
 Properties:
   [PolicyDocument](#cfn-sns-topicpolicy-policydocument): PolicyDocument
   [Topics](#cfn-sns-topicpolicy-topics):

--- a/doc_source/aws-properties-sns-topic.md
+++ b/doc_source/aws-properties-sns-topic.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-sns-topic-syntax.yaml"></a>
 
 ```
-Type: "AWS::SNS::Topic"
+Type: AWS::SNS::Topic
 Properties: 
   [DisplayName](#cfn-sns-topic-displayname): String
   [Subscription](#cfn-sns-topic-subscription):
@@ -98,7 +98,7 @@ An example of an SNS topic subscribed to by two SQS queues:
 
 ```
 MySNSTopic: 
-  Type: "AWS::SNS::Topic"
+  Type: AWS::SNS::Topic
   Properties: 
     Subscription: 
       - 

--- a/doc_source/aws-properties-sqs-policy.md
+++ b/doc_source/aws-properties-sqs-policy.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-sqs-queuepolicy-syntax.yaml"></a>
 
 ```
-Type: "AWS::SQS::QueuePolicy"
+Type: AWS::SQS::QueuePolicy
 Properties: 
   [PolicyDocument](#cfn-sqs-queuepolicy-policydoc): JSON
   [Queues](#cfn-sqs-queuepolicy-queues):

--- a/doc_source/aws-properties-sqs-queues.md
+++ b/doc_source/aws-properties-sqs-queues.md
@@ -39,7 +39,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-sqs-queues-syntax.yaml"></a>
 
 ```
-Type: "AWS::SQS::Queue"
+Type: AWS::SQS::Queue
 Properties:
   [ContentBasedDeduplication](#cfn-sqs-queue-contentbaseddeduplication): Boolean
   [DelaySeconds](#aws-sqs-queue-delayseconds): Integer
@@ -236,11 +236,11 @@ Parameters:
     Type: "String"
 Resources: 
   MyQueue: 
-    Type: "AWS::SQS::Queue"
+    Type: AWS::SQS::Queue
     Properties: 
       QueueName: "SampleQueue"
   AlarmTopic: 
-    Type: "AWS::SNS::Topic"
+    Type: AWS::SNS::Topic
     Properties: 
       Subscription: 
         - 
@@ -248,7 +248,7 @@ Resources:
             Ref: "AlarmEmail"
           Protocol: "email"
   QueueDepthAlarm: 
-    Type: "AWS::CloudWatch::Alarm"
+    Type: AWS::CloudWatch::Alarm
     Properties: 
       AlarmDescription: "Alarm if queue depth grows beyond 10 messages"
       Namespace: "AWS/SQS"
@@ -342,7 +342,7 @@ The following sample creates a source queue and a dead letter queue\. Because th
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   MySourceQueue: 
-    Type: "AWS::SQS::Queue"
+    Type: AWS::SQS::Queue
     Properties: 
       RedrivePolicy: 
         deadLetterTargetArn: 
@@ -351,7 +351,7 @@ Resources:
             - "Arn"
         maxReceiveCount: 5
   MyDeadLetterQueue: 
-    Type: "AWS::SQS::Queue"
+    Type: AWS::SQS::Queue
 Outputs: 
   SourceQueueURL: 
     Description: "URL of the source queue"

--- a/doc_source/aws-properties-stack-parameters.md
+++ b/doc_source/aws-properties-stack-parameters.md
@@ -72,7 +72,7 @@ You could use the following template to embed a stack \(myStackWithParams\) usin
 1. AWSTemplateFormatVersion: "2010-09-09"
 2. Resources: 
 3.   myStackWithParams: 
-4.     Type: "AWS::CloudFormation::Stack"
+4.     Type: AWS::CloudFormation::Stack
 5.     Properties: 
 6.       TemplateURL: "https://s3.amazonaws.com/cloudformation-templates-us-east-1/EC2ChooseAMI.template"
 7.       Parameters: 

--- a/doc_source/aws-properties-stack.md
+++ b/doc_source/aws-properties-stack.md
@@ -40,7 +40,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cloudformation-stack-syntax.yaml"></a>
 
 ```
-Type: "AWS::CloudFormation::Stack"
+Type: AWS::CloudFormation::Stack
 Properties:
   [NotificationARNs](#cfn-cloudformation-stack-notificationarns):
     - String

--- a/doc_source/aws-properties-waitcondition.md
+++ b/doc_source/aws-properties-waitcondition.md
@@ -41,7 +41,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cloudformation-waitcondition-syntax.yaml"></a>
 
 ```
-Type: "AWS::CloudFormation::WaitCondition"
+Type: AWS::CloudFormation::WaitCondition
 Properties: 
   [Count](#cfn-waitcondition-count): Integer
   [Handle](#cfn-waitcondition-handle): String
@@ -129,7 +129,7 @@ For more information about using `Fn::GetAtt`, see [Fn::GetAtt](intrinsic-functi
 
 ```
 WebServerGroup: 
-  Type: "AWS::AutoScaling::AutoScalingGroup"
+  Type: AWS::AutoScaling::AutoScalingGroup
   Properties: 
     AvailabilityZones: 
       Fn::GetAZs: ""
@@ -143,9 +143,9 @@ WebServerGroup:
       - 
         Ref: "ElasticLoadBalancer"
 WaitHandle: 
-  Type: "AWS::CloudFormation::WaitConditionHandle"
+  Type: AWS::CloudFormation::WaitConditionHandle
 WaitCondition: 
-  Type: "AWS::CloudFormation::WaitCondition"
+  Type: AWS::CloudFormation::WaitCondition
   DependsOn: "WebServerGroup"
   Properties: 
     Handle: 

--- a/doc_source/aws-properties-waitconditionhandle.md
+++ b/doc_source/aws-properties-waitconditionhandle.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cloudformation-waitconditionhandle-syntax.yaml"></a>
 
 ```
-Type: "AWS::CloudFormation::WaitConditionHandle"
+Type: AWS::CloudFormation::WaitConditionHandle
 Properties:
 ```
 

--- a/doc_source/aws-resource-apigateway-account.md
+++ b/doc_source/aws-resource-apigateway-account.md
@@ -30,7 +30,7 @@ The syntax for declaring this resource:
 ### YAML<a name="aws-resource-apigateway-account-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::Account"
+Type: AWS::ApiGateway::Account
 Properties: 
   [CloudWatchRoleArn](#cfn-apigateway-account-cloudwatchrolearn): String
 ```
@@ -85,7 +85,7 @@ The following example creates an IAM role that API Gateway can assume to push lo
 
 ```
 CloudWatchRole: 
- Type: "AWS::IAM::Role"
+ Type: AWS::IAM::Role
  Properties: 
   AssumeRolePolicyDocument: 
    Version: "2012-10-17"
@@ -99,7 +99,7 @@ CloudWatchRole:
   ManagedPolicyArns: 
    - "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 Account: 
- Type: "AWS::ApiGateway::Account"
+ Type: AWS::ApiGateway::Account
  Properties: 
   CloudWatchRoleArn: 
    "Fn::GetAtt": 

--- a/doc_source/aws-resource-apigateway-apikey.md
+++ b/doc_source/aws-resource-apigateway-apikey.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-apikey-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::ApiKey"
+Type: AWS::ApiGateway::ApiKey
 Properties: 
   [CustomerId](#cfn-apigateway-apikey-customerid): String
   [Description](#cfn-apigateway-apikey-description): String
@@ -119,7 +119,7 @@ The following example creates an API key and associates it with the `Test` stage
 
 ```
 ApiKey: 
-  Type: "AWS::ApiGateway::ApiKey"
+  Type: AWS::ApiGateway::ApiKey
   DependsOn: 
     - "TestAPIDeployment"
     - "Test"

--- a/doc_source/aws-resource-apigateway-authorizer.md
+++ b/doc_source/aws-resource-apigateway-authorizer.md
@@ -35,7 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-authorizer-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::Authorizer"
+Type: AWS::ApiGateway::Authorizer
 Properties:
   [AuthType](#cfn-apigateway-authorizer-authtype): String
   [AuthorizerCredentials](#cfn-apigateway-authorizer-authorizercredentials): String
@@ -156,7 +156,7 @@ The following examples create a custom authorizer that is an AWS Lambda function
 
 ```
 Authorizer: 
-  Type: "AWS::ApiGateway::Authorizer"
+  Type: AWS::ApiGateway::Authorizer
   Properties: 
     AuthorizerCredentials: 
       Fn::GetAtt: 

--- a/doc_source/aws-resource-apigateway-basepathmapping.md
+++ b/doc_source/aws-resource-apigateway-basepathmapping.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-basepathmapping-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::BasePathMapping"
+Type: AWS::ApiGateway::BasePathMapping
 Properties:
   [BasePath](#cfn-apigateway-basepathmapping-basepath): String
   [DomainName](#cfn-apigateway-basepathmapping-domainname): String

--- a/doc_source/aws-resource-apigateway-clientcertificate.md
+++ b/doc_source/aws-resource-apigateway-clientcertificate.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-clientcertificate-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::ClientCertificate"
+Type: AWS::ApiGateway::ClientCertificate
 Properties:
   [Description](#cfn-apigateway-clientcertificate-description): String
 ```
@@ -66,7 +66,7 @@ The following example creates a client certificate that you can use with an API 
 
 ```
 TestClientCertificate: 
-  Type: "AWS::ApiGateway::ClientCertificate"
+  Type: AWS::ApiGateway::ClientCertificate
   Properties: 
     Description: "A test client certificate"
 ```

--- a/doc_source/aws-resource-apigateway-deployment.md
+++ b/doc_source/aws-resource-apigateway-deployment.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-deployment-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::Deployment"
+Type: AWS::ApiGateway::Deployment
 Properties:
   [Description](#cfn-apigateway-deployment-description): String
   [RestApiId](#cfn-apigateway-deployment-restapiid): String
@@ -96,7 +96,7 @@ The following example deploys the `MyApi` API to a stage named `DummyStage`\.
 
 ```
 Deployment: 
-  Type: "AWS::ApiGateway::Deployment"
+  Type: AWS::ApiGateway::Deployment
   Properties: 
     RestApiId: 
       Ref: "MyApi"
@@ -127,7 +127,7 @@ If you create a `AWS::ApiGateway::RestApi` resource and its methods \(using `AWS
 ```
 Deployment: 
   DependsOn: "MyMethod"
-  Type: "AWS::ApiGateway::Deployment"
+  Type: AWS::ApiGateway::Deployment
   Properties: 
     RestApiId: 
       Ref: "MyApi"

--- a/doc_source/aws-resource-apigateway-documentationpart.md
+++ b/doc_source/aws-resource-apigateway-documentationpart.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-documentationpart-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::DocumentationPart"
+Type: AWS::ApiGateway::DocumentationPart
 Properties:
   [Location](#cfn-apigateway-documentationpart-location): 
     [*Location*](aws-properties-apigateway-documentationpart-location.md)

--- a/doc_source/aws-resource-apigateway-documentationversion.md
+++ b/doc_source/aws-resource-apigateway-documentationversion.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-documentationversion-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::DocumentationVersion"
+Type: AWS::ApiGateway::DocumentationVersion
 Properties:
   [Description](#cfn-apigateway-documentationversion-description): String
   [DocumentationVersion](#cfn-apigateway-documentationversion-documentationversion): String

--- a/doc_source/aws-resource-apigateway-domainname.md
+++ b/doc_source/aws-resource-apigateway-domainname.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-domainname-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::DomainName"
+Type: AWS::ApiGateway::DomainName
 Properties: 
   [CertificateArn](#cfn-apigateway-domainname-certificatearn): String
   [DomainName](#cfn-apigateway-domainname-domainname): String

--- a/doc_source/aws-resource-apigateway-gatewayresponse.md
+++ b/doc_source/aws-resource-apigateway-gatewayresponse.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-gatewayresponse-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::GatewayResponse"
+Type: AWS::ApiGateway::GatewayResponse
 Properties:
   [ResponseParameters](#cfn-apigateway-gatewayresponse-responseparameters): 
     String: String

--- a/doc_source/aws-resource-apigateway-method.md
+++ b/doc_source/aws-resource-apigateway-method.md
@@ -38,7 +38,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-method-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::Method"
+Type: AWS::ApiGateway::Method
 Properties:
   [ApiKeyRequired](#cfn-apigateway-method-apikeyrequired): Boolean
   [AuthorizationType](#cfn-apigateway-method-authorizationtype): String
@@ -165,7 +165,7 @@ The following example creates a mock GET method for the `MyApi` API\.
 
 ```
 MockMethod: 
-  Type: "AWS::ApiGateway::Method"
+  Type: AWS::ApiGateway::Method
   Properties: 
     RestApiId: 
       Ref: "MyApi"

--- a/doc_source/aws-resource-apigateway-model.md
+++ b/doc_source/aws-resource-apigateway-model.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-model-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::Model"
+Type: AWS::ApiGateway::Model
 Properties:
   [ContentType](#cfn-apigateway-model-contenttype): String
   [Description](#cfn-apigateway-model-description): String
@@ -115,7 +115,7 @@ The following example creates a model that transforms input data into the descri
 
 ```
 PetsModelNoFlatten: 
-  Type: "AWS::ApiGateway::Model"
+  Type: AWS::ApiGateway::Model
   Properties: 
     RestApiId: 
       Ref: RestApi

--- a/doc_source/aws-resource-apigateway-requestvalidator.md
+++ b/doc_source/aws-resource-apigateway-requestvalidator.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-requestvalidator-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::RequestValidator"
+Type: AWS::ApiGateway::RequestValidator
 Properties:
   [Name](#cfn-apigateway-requestvalidator-name): String
   [RestApiId](#cfn-apigateway-requestvalidator-restapiid): String

--- a/doc_source/aws-resource-apigateway-resource.md
+++ b/doc_source/aws-resource-apigateway-resource.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-resource-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::Resource"
+Type: AWS::ApiGateway::Resource
 Properties:
   [ParentId](#cfn-apigateway-resource-parentid): String
   [PathPart](#cfn-apigateway-resource-pathpart): String
@@ -84,7 +84,7 @@ The following example creates a `stack` resource for the `MyApi` API\.
 
 ```
 Stack: 
-  Type: "AWS::ApiGateway::Resource"
+  Type: AWS::ApiGateway::Resource
   Properties: 
     RestApiId: 
       Ref: "MyApi"

--- a/doc_source/aws-resource-apigateway-restapi.md
+++ b/doc_source/aws-resource-apigateway-restapi.md
@@ -40,7 +40,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-restapi-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::RestApi"
+Type: AWS::ApiGateway::RestApi
 Properties:
   [ApiKeySourceType](#cfn-apigateway-restapi-apikeysourcetype): String
   [BinaryMediaTypes](#cfn-apigateway-restapi-binarymediatypes):
@@ -173,7 +173,7 @@ The following example creates an API Gateway `RestApi` resource based on an Open
 
 ```
 MyRestApi: 
-  Type: "AWS::ApiGateway::RestApi"
+  Type: AWS::ApiGateway::RestApi
   Properties:
     Body:
       OpenAPI specification    

--- a/doc_source/aws-resource-apigateway-stage.md
+++ b/doc_source/aws-resource-apigateway-stage.md
@@ -35,7 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-stage-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::Stage"
+Type: AWS::ApiGateway::Stage
 Properties:
   [CacheClusterEnabled](#cfn-apigateway-stage-cacheclusterenabled): Boolean
   [CacheClusterSize](#cfn-apigateway-stage-cacheclustersize): String

--- a/doc_source/aws-resource-apigateway-usageplan.md
+++ b/doc_source/aws-resource-apigateway-usageplan.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-usageplan-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::UsagePlan"
+Type: AWS::ApiGateway::UsagePlan
 Properties:
   [ApiStages](#cfn-apigateway-usageplan-apistages): 
   - [ApiStage](aws-properties-apigateway-usageplan-apistage.md)

--- a/doc_source/aws-resource-apigateway-usageplankey.md
+++ b/doc_source/aws-resource-apigateway-usageplankey.md
@@ -26,7 +26,7 @@ The `AWS::ApiGateway::UsagePlanKey` resource associates an Amazon API Gateway AP
 ### YAML<a name="aws-resource-apigateway-usageplankey-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::UsagePlanKey"
+Type: AWS::ApiGateway::UsagePlanKey
 Properties:
   [KeyId](#cfn-apigateway-keyid): String
   [KeyType](#cfn-apigateway-keytype): String
@@ -86,7 +86,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 
 ```
 usagePlanKey:
-  Type: "AWS::ApiGateway::UsagePlanKey"
+  Type: AWS::ApiGateway::UsagePlanKey
   Properties : 
     KeyId: !Ref 'myApiKey'
     KeyType: API_KEY

--- a/doc_source/aws-resource-apigateway-vpclink.md
+++ b/doc_source/aws-resource-apigateway-vpclink.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-apigateway-vpclink-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApiGateway::VpcLink"
+Type: AWS::ApiGateway::VpcLink
 Properties:
   [Description](#cfn-apigateway-vpclink-description): String
   [Name](#cfn-apigateway-vpclink-name): String

--- a/doc_source/aws-resource-applicationautoscaling-scalabletarget.md
+++ b/doc_source/aws-resource-applicationautoscaling-scalabletarget.md
@@ -44,7 +44,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-applicationautoscaling-scalabletarget-syntax.yaml"></a>
 
 ```
-Type: "AWS::ApplicationAutoScaling::ScalableTarget"
+Type: AWS::ApplicationAutoScaling::ScalableTarget
 Properties:
   [MaxCapacity](#cfn-applicationautoscaling-scalabletarget-maxcapacity): Integer
   [MinCapacity](#cfn-applicationautoscaling-scalabletarget-mincapacity): Integer
@@ -351,7 +351,7 @@ This example sets up Application Auto Scaling for an `AWS::DynamoDB::Table` reso
 ```
 Resources:
   DDBTable:
-    Type: "AWS::DynamoDB::Table"
+    Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
         -
@@ -386,7 +386,7 @@ Resources:
         ReadCapacityUnits: 5
         WriteCapacityUnits: 5
   WriteCapacityScalableTarget:
-    Type: "AWS::ApplicationAutoScaling::ScalableTarget"
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       MaxCapacity: 15
       MinCapacity: 5
@@ -398,7 +398,7 @@ Resources:
       ScalableDimension: dynamodb:table:WriteCapacityUnits
       ServiceNamespace: dynamodb
   ScalingRole:
-    Type: "AWS::IAM::Role"
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -429,7 +429,7 @@ Resources:
                   - "cloudwatch:DeleteAlarms"
                 Resource: "*"
   WriteScalingPolicy:
-    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: WriteAutoScalingPolicy
       PolicyType: TargetTrackingScaling

--- a/doc_source/aws-resource-applicationautoscaling-scalingpolicy.md
+++ b/doc_source/aws-resource-applicationautoscaling-scalingpolicy.md
@@ -305,7 +305,7 @@ This example sets up Application Auto Scaling for a `AWS::DynamoDB::Table` resou
 ```
 Resources:
   DDBTable:
-    Type: "AWS::DynamoDB::Table"
+    Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
         -
@@ -340,7 +340,7 @@ Resources:
         ReadCapacityUnits: 5
         WriteCapacityUnits: 5
   WriteCapacityScalableTarget:
-    Type: "AWS::ApplicationAutoScaling::ScalableTarget"
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       MaxCapacity: 15
       MinCapacity: 5
@@ -352,7 +352,7 @@ Resources:
       ScalableDimension: dynamodb:table:WriteCapacityUnits
       ServiceNamespace: dynamodb
   ScalingRole:
-    Type: "AWS::IAM::Role"
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -383,7 +383,7 @@ Resources:
                   - "cloudwatch:DeleteAlarms"
                 Resource: "*"
   WriteScalingPolicy:
-    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: WriteAutoScalingPolicy
       PolicyType: TargetTrackingScaling

--- a/doc_source/aws-resource-as-lifecyclehook.md
+++ b/doc_source/aws-resource-as-lifecyclehook.md
@@ -34,7 +34,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-autoscaling-lifecyclehook-syntax.yaml"></a>
 
 ```
-Type: "AWS::AutoScaling::LifecycleHook"
+Type: AWS::AutoScaling::LifecycleHook
 Properties:
   [AutoScalingGroupName](#cfn-as-lifecyclehook-autoscalinggroupname): String
   [DefaultResult](#cfn-as-lifecyclehook-defaultresult): String
@@ -132,7 +132,7 @@ In the following template snippet, the Auto Scaling pauses instances before comp
 
 ```
 myLifecycleHook: 
-  Type: "AWS::AutoScaling::LifecycleHook"
+  Type: AWS::AutoScaling::LifecycleHook
   Properties: 
     AutoScalingGroupName: 
       Ref: myAutoScalingGroup

--- a/doc_source/aws-resource-as-scheduledaction.md
+++ b/doc_source/aws-resource-as-scheduledaction.md
@@ -142,7 +142,7 @@ The following template snippet includes two scheduled actions that scale the num
 
 ```
 ScheduledActionUp: 
-  Type: "AWS::AutoScaling::ScheduledAction"
+  Type: AWS::AutoScaling::ScheduledAction
   Properties:
     AutoScalingGroupName: 
       Ref: "WebServerGroup"
@@ -150,7 +150,7 @@ ScheduledActionUp:
     MinSize: 5
     Recurrence: "0 7 * * *"
 ScheduledActionDown: 
-  Type: "AWS::AutoScaling::ScheduledAction"
+  Type: AWS::AutoScaling::ScheduledAction
   Properties:
     AutoScalingGroupName: 
       Ref: "WebServerGroup"

--- a/doc_source/aws-resource-athena-namedquery.md
+++ b/doc_source/aws-resource-athena-namedquery.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-athena-namedquery-syntax.yaml"></a>
 
 ```
-Type: "AWS::Athena::NamedQuery"
+Type: AWS::Athena::NamedQuery
 Properties:
   [Description](#cfn-athena-namedquery-description): String
   [QueryString](#cfn-athena-namedquery-querystring): String

--- a/doc_source/aws-resource-authentication.md
+++ b/doc_source/aws-resource-authentication.md
@@ -53,7 +53,7 @@ You should be aware of the following considerations when using the AWS::CloudFor
 ### YAML<a name="aws-resource-cloudformation-authentication-syntax.yaml"></a>
 
 ```
-Type: "AWS::CloudFormation::Authentication"
+Type: AWS::CloudFormation::Authentication
 String:
   [accessKeyId](#cfn-cloudformation-authentication-accesskeyid): String
   [buckets](#cfn-cloudformation-authentication-buckets):
@@ -169,7 +169,7 @@ This template snippet shows how to get a file from a private S3 bucket within an
 
 ```
 WebServer: 
-  Type: "AWS::EC2::Instance"
+  Type: AWS::EC2::Instance
   DependsOn: "BucketPolicy"
   Metadata: 
     AWS::CloudFormation::Init: 

--- a/doc_source/aws-resource-batch-computeenvironment.md
+++ b/doc_source/aws-resource-batch-computeenvironment.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-batch-computeenvironment-syntax.yaml"></a>
 
 ```
-Type: "AWS::Batch::ComputeEnvironment"
+Type: AWS::Batch::ComputeEnvironment
 Properties:
   [Type](#cfn-batch-computeenvironment-type): String
   [ServiceRole](#cfn-batch-computeenvironment-servicerole): String

--- a/doc_source/aws-resource-batch-jobdefinition.md
+++ b/doc_source/aws-resource-batch-jobdefinition.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-batch-jobdefinition-syntax.yaml"></a>
 
 ```
-Type: "AWS::Batch::JobDefinition"
+Type: AWS::Batch::JobDefinition
 Properties:
   [Type](#cfn-batch-jobdefinition-type): String
   [Parameters](#cfn-batch-jobdefinition-parameters): Json object

--- a/doc_source/aws-resource-batch-jobqueue.md
+++ b/doc_source/aws-resource-batch-jobqueue.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-batch-jobqueue-syntax.yaml"></a>
 
 ```
-Type: "AWS::Batch::JobQueue"
+Type: AWS::Batch::JobQueue
 Properties:
   [ComputeEnvironmentOrder](#cfn-batch-jobqueue-computeenvironmentorder): 
     - [*ComputeEnvironmentOrder*](aws-properties-batch-jobqueue-computeenvironmentorder.md) 

--- a/doc_source/aws-resource-beanstalk-configurationtemplate.md
+++ b/doc_source/aws-resource-beanstalk-configurationtemplate.md
@@ -33,7 +33,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticbeanstalk-configurationtemplate-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElasticBeanstalk::ConfigurationTemplate"
+Type: AWS::ElasticBeanstalk::ConfigurationTemplate
 Properties:
   [ApplicationName](#cfn-elasticbeanstalk-configurationtemplate-applicationname): String
   [Description](#cfn-elasticbeanstalk-configurationtemplate-description): String
@@ -134,7 +134,7 @@ This example of an ElasticBeanstalk `ConfigurationTemplate` is found in the AWS 
 
 ```
 myConfigTemplate: 
-  Type: "AWS::ElasticBeanstalk::ConfigurationTemplate"
+  Type: AWS::ElasticBeanstalk::ConfigurationTemplate
   Properties: 
     ApplicationName: 
       Ref: "myApp"

--- a/doc_source/aws-resource-certificatemanager-certificate.md
+++ b/doc_source/aws-resource-certificatemanager-certificate.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-certificatemanager-certificate-syntax.yaml"></a>
 
 ```
-Type: "AWS::CertificateManager::Certificate"
+Type: AWS::CertificateManager::Certificate
 Properties: 
   [DomainName](#cfn-certificatemanager-certificate-domainname): String
   [DomainValidationOptions](#cfn-certificatemanager-certificate-domainvalidationoptions):

--- a/doc_source/aws-resource-cloud9-environmentec2.md
+++ b/doc_source/aws-resource-cloud9-environmentec2.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cloud9-environmentec2-syntax.yaml"></a>
 
 ```
-Type: "AWS::Cloud9::EnvironmentEC2"
+Type: AWS::Cloud9::EnvironmentEC2
 Properties:
   [Repositories](#cfn-cloud9-environmentec2-repositories): 
     - [*Repository*](aws-properties-cloud9-environmentec2-repository.md)

--- a/doc_source/aws-resource-cloudfront-cloudfrontoriginaccessidentity.md
+++ b/doc_source/aws-resource-cloudfront-cloudfrontoriginaccessidentity.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cloudfront-cloudfrontoriginaccessidentity-syntax.yaml"></a>
 
 ```
-Type: "AWS::CloudFront::CloudFrontOriginAccessIdentity"
+Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
 Properties:
   [CloudFrontOriginAccessIdentityConfig](#cfn-cloudfront-cloudfrontoriginaccessidentity-cloudfrontoriginaccessidentityconfig): CloudFrontOriginAccessIdentityConfig
 ```

--- a/doc_source/aws-resource-cloudfront-streamingdistribution.md
+++ b/doc_source/aws-resource-cloudfront-streamingdistribution.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cloudfront-streamingdistribution-syntax.yaml"></a>
 
 ```
-Type: "AWS::CloudFront::StreamingDistribution"
+Type: AWS::CloudFront::StreamingDistribution
 Properties:
   [StreamingDistributionConfig](#cfn-cloudfront-streamingdistribution-streamingdistributionconfig): StreamingDistributionConfig
   [Tags](#cfn-cloudfront-streamingdistribution-tags): 

--- a/doc_source/aws-resource-cloudtrail-trail.md
+++ b/doc_source/aws-resource-cloudtrail-trail.md
@@ -38,7 +38,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cloudtrail-trail-syntax.yaml"></a>
 
 ```
-Type: "AWS::CloudTrail::Trail"
+Type: AWS::CloudTrail::Trail
 Properties:
   [CloudWatchLogsLogGroupArn](#cfn-cloudtrail-trail-cloudwatchlogsloggrouparn): String
   [CloudWatchLogsRoleArn](#cfn-cloudtrail-trail-cloudwatchlogsrolearn): String
@@ -263,10 +263,10 @@ For more information about the regions that CloudTrail supports, see [Supported 
   Resources: 
     S3Bucket: 
       DeletionPolicy: Retain
-      Type: "AWS::S3::Bucket"
+      Type: AWS::S3::Bucket
       Properties: {}
     BucketPolicy: 
-      Type: "AWS::S3::BucketPolicy"
+      Type: AWS::S3::BucketPolicy
       Properties: 
         Bucket: 
           Ref: S3Bucket
@@ -295,7 +295,7 @@ For more information about the regions that CloudTrail supports, see [Supported 
                 StringEquals:
                   s3:x-amz-acl: "bucket-owner-full-control"
     Topic: 
-      Type: "AWS::SNS::Topic"
+      Type: AWS::SNS::Topic
       Properties: 
         Subscription: 
           - 
@@ -303,7 +303,7 @@ For more information about the regions that CloudTrail supports, see [Supported 
               Ref: OperatorEmail
             Protocol: email
     TopicPolicy: 
-      Type: "AWS::SNS::TopicPolicy"
+      Type: AWS::SNS::TopicPolicy
       Properties: 
         Topics: 
           - Ref: "Topic"
@@ -321,7 +321,7 @@ For more information about the regions that CloudTrail supports, see [Supported 
       DependsOn: 
         - BucketPolicy
         - TopicPolicy
-      Type: "AWS::CloudTrail::Trail"
+      Type: AWS::CloudTrail::Trail
       Properties: 
         S3BucketName: 
           Ref: S3Bucket

--- a/doc_source/aws-resource-codebuild-project.md
+++ b/doc_source/aws-resource-codebuild-project.md
@@ -39,7 +39,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-codebuild-project-syntax.yaml"></a>
 
 ```
-Type: "AWS::CodeBuild::Project"
+Type: AWS::CodeBuild::Project
 Properties: 
   [Artifacts](#cfn-codebuild-project-artifacts):
     [*Artifacts*](aws-properties-codebuild-project-artifacts.md)

--- a/doc_source/aws-resource-codecommit-repository.md
+++ b/doc_source/aws-resource-codecommit-repository.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-codecommit-repository-syntax.yaml"></a>
 
 ```
-Type: "AWS::CodeCommit::Repository"
+Type: AWS::CodeCommit::Repository
 Properties: 
   [RepositoryDescription](#cfn-codecommit-repository-repositorydescription): String
   [RepositoryName](#cfn-codecommit-repository-repositoryname): String

--- a/doc_source/aws-resource-codedeploy-application.md
+++ b/doc_source/aws-resource-codedeploy-application.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-codedeploy-application-syntax.yaml"></a>
 
 ```
-Type: "AWS::CodeDeploy::Application"
+Type: AWS::CodeDeploy::Application
 Properties:
   [ApplicationName](#cfn-codedeploy-application-applicationname): String	    
   [ComputePlatform](#cfn-codedeploy-application-computeplatform): String

--- a/doc_source/aws-resource-codedeploy-deploymentconfig.md
+++ b/doc_source/aws-resource-codedeploy-deploymentconfig.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-codedeploy-deploymentconfig-syntax.yaml"></a>
 
 ```
-Type: "AWS::CodeDeploy::DeploymentConfig"
+Type: AWS::CodeDeploy::DeploymentConfig
 Properties:
   [DeploymentConfigName](#cfn-codedeploy-deploymentconfig-deploymentconfigname): String
   [MinimumHealthyHosts](#cfn-codedeploy-deploymentconfig-minimumhealthyhosts):
@@ -80,7 +80,7 @@ The following example requires at least 75% of the fleet to be healthy\. For exa
 
 ```
 TwentyFivePercentAtATime: 
-  Type: "AWS::CodeDeploy::DeploymentConfig"
+  Type: AWS::CodeDeploy::DeploymentConfig
   Properties: 
     MinimumHealthyHosts: 
       Type: "FLEET_PERCENT"

--- a/doc_source/aws-resource-codedeploy-deploymentgroup.md
+++ b/doc_source/aws-resource-codedeploy-deploymentgroup.md
@@ -38,7 +38,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-codedeploy-deploymentgroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::CodeDeploy::DeploymentGroup"
+Type: AWS::CodeDeploy::DeploymentGroup
 Properties:
   [AlarmConfiguration](#cfn-codedeploy-deploymentgroup-alarmconfiguration):
     [*AlarmConfiguration*](aws-properties-codedeploy-deploymentgroup-alarmconfiguration.md)
@@ -190,7 +190,7 @@ The following example creates a deployment group that is associated with Auto Sc
 
 ```
 DeploymentGroup: 
-  Type: "AWS::CodeDeploy::DeploymentGroup"
+  Type: AWS::CodeDeploy::DeploymentGroup
   Properties: 
     ApplicationName: 
       Ref: "ApplicationName"
@@ -249,7 +249,7 @@ The following example creates a deployment group that uses instance tags to asso
 
 ```
 DeploymentGroup: 
-  Type: "AWS::CodeDeploy::DeploymentGroup"
+  Type: AWS::CodeDeploy::DeploymentGroup
   Properties: 
     ApplicationName: 
       Ref: "Application"

--- a/doc_source/aws-resource-codepipeline-customactiontype.md
+++ b/doc_source/aws-resource-codepipeline-customactiontype.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-codepipeline-customactiontype-syntax.yaml"></a>
 
 ```
-Type: "AWS::CodePipeline::CustomActionType"
+Type: AWS::CodePipeline::CustomActionType
 Properties:
   [Category](#cfn-codepipeline-customactiontype-category): String,
   [ConfigurationProperties](#cfn-codepipeline-customactiontype-configurationproperties):
@@ -143,7 +143,7 @@ The following example is a custom build action that requires users to specify on
 
 ```
 MyCustomActionType: 
-  Type: "AWS::CodePipeline::CustomActionType"
+  Type: AWS::CodePipeline::CustomActionType
   Properties: 
     Category: Build
     Provider: "My-Build-Provider-Name"

--- a/doc_source/aws-resource-codepipeline-pipeline.md
+++ b/doc_source/aws-resource-codepipeline-pipeline.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-codepipeline-pipeline-syntax.yaml"></a>
 
 ```
-Type: "AWS::CodePipeline::Pipeline"
+Type: AWS::CodePipeline::Pipeline
 Properties:
   [ArtifactStore](#cfn-codepipeline-pipeline-artifactstore):
     ArtifactStore
@@ -193,7 +193,7 @@ The following example creates a pipeline with a source, beta, and release stage\
 
 ```
 AppPipeline: 
-  Type: "AWS::CodePipeline::Pipeline"
+  Type: AWS::CodePipeline::Pipeline
   Properties: 
     RoleArn: 
       Ref: CodePipelineServiceRole

--- a/doc_source/aws-resource-cognito-identitypool.md
+++ b/doc_source/aws-resource-cognito-identitypool.md
@@ -34,7 +34,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cognito-identitypool-syntax.yaml"></a>
 
 ```
-Type: "AWS::Cognito::IdentityPool"
+Type: AWS::Cognito::IdentityPool
 Properties:
   [IdentityPoolName](#cfn-cognito-identitypool-identitypoolname): String
   [AllowUnauthenticatedIdentities](#cfn-cognito-identitypool-allowunauthenticatedidentities): Boolean

--- a/doc_source/aws-resource-cognito-identitypoolroleattachment.md
+++ b/doc_source/aws-resource-cognito-identitypoolroleattachment.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cognito-identitypoolroleattachment-syntax.yaml"></a>
 
 ```
-Type: "AWS::Cognito::IdentityPoolRoleAttachment"
+Type: AWS::Cognito::IdentityPoolRoleAttachment
 Properties:
   [IdentityPoolId](#cfn-cognito-identitypoolroleattachment-identitypoolid): String
   [RoleMappings](#cfn-cognito-identitypoolroleattachment-rolemappings): 

--- a/doc_source/aws-resource-cognito-userpool.md
+++ b/doc_source/aws-resource-cognito-userpool.md
@@ -40,7 +40,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cognito-userpool-syntax.yaml"></a>
 
 ```
-Type: "AWS::Cognito::UserPool"
+Type: AWS::Cognito::UserPool
 Properties:
   [AdminCreateUserConfig](#cfn-cognito-userpool-admincreateuserconfig): 
     AdminCreateUserConfig

--- a/doc_source/aws-resource-cognito-userpoolclient.md
+++ b/doc_source/aws-resource-cognito-userpoolclient.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cognito-userpoolclient-syntax.yaml"></a>
 
 ```
-Type: "AWS::Cognito::UserPoolClient"
+Type: AWS::Cognito::UserPoolClient
 Properties:
     [ClientName](#cfn-cognito-userpoolclient-clientname): String,
     [ExplicitAuthFlows](#cfn-cognito-userpoolclient-explicitauthflows): 

--- a/doc_source/aws-resource-cognito-userpoolgroup.md
+++ b/doc_source/aws-resource-cognito-userpoolgroup.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cognito-userpoolgroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::Cognito::UserPoolGroup"
+Type: AWS::Cognito::UserPoolGroup
 Properties:
   [Description](#cfn-cognito-userpoolgroup-description): String
   [GroupName](#cfn-cognito-userpoolgroup-groupname): String

--- a/doc_source/aws-resource-cognito-userpooluser.md
+++ b/doc_source/aws-resource-cognito-userpooluser.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cognito-userpooluser-syntax.yaml"></a>
 
 ```
-Type: "AWS::Cognito::UserPoolUser"
+Type: AWS::Cognito::UserPoolUser
 Properties:
   [DesiredDeliveryMediums](#cfn-cognito-userpooluser-desireddeliverymediums): 
     - String

--- a/doc_source/aws-resource-cognito-userpoolusertogroupattachment.md
+++ b/doc_source/aws-resource-cognito-userpoolusertogroupattachment.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-cognito-userpoolusertogroupattachment-syntax.yaml"></a>
 
 ```
-Type: "AWS::Cognito::UserPoolUserToGroupAttachment"
+Type: AWS::Cognito::UserPoolUserToGroupAttachment
 Properties:
   [GroupName](#cfn-cognito-userpoolusertogroupattachment-groupname): String
   [Username](#cfn-cognito-userpoolusertogroupattachment-username): String

--- a/doc_source/aws-resource-config-configrule.md
+++ b/doc_source/aws-resource-config-configrule.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-config-configrule-syntax.yaml"></a>
 
 ```
-Type: "AWS::Config::ConfigRule"
+Type: AWS::Config::ConfigRule
 Properties:
   [ConfigRuleName](#cfn-config-configrule-configrulename): String
   [Description](#cfn-config-configrule-description): String
@@ -134,7 +134,7 @@ The following example uses an AWS managed rule that checks whether EC2 volumes r
 
 ```
 ConfigRuleForVolumeTags: 
-  Type: "AWS::Config::ConfigRule"
+  Type: AWS::Config::ConfigRule
   Properties: 
     InputParameters: 
       tag1Key: CostCenter
@@ -235,7 +235,7 @@ The following example creates a custom configuration rule that uses a Lambda fun
 
 ```
 ConfigPermissionToCallLambda: 
-  Type: "AWS::Lambda::Permission"
+  Type: AWS::Lambda::Permission
   Properties: 
     FunctionName: 
       Fn::GetAtt: 
@@ -244,7 +244,7 @@ ConfigPermissionToCallLambda:
     Action: "lambda:InvokeFunction"
     Principal: "config.amazonaws.com"
 VolumeAutoEnableIOComplianceCheck: 
-  Type: "AWS::Lambda::Function"
+  Type: AWS::Lambda::Function
   Properties: 
     Code: 
       ZipFile: 
@@ -289,7 +289,7 @@ VolumeAutoEnableIOComplianceCheck:
         - LambdaExecutionRole
         - Arn
 ConfigRuleForVolumeAutoEnableIO: 
-  Type: "AWS::Config::ConfigRule"
+  Type: AWS::Config::ConfigRule
   Properties: 
     ConfigRuleName: ConfigRuleForVolumeAutoEnableIO
     Scope: 

--- a/doc_source/aws-resource-config-configurationrecorder.md
+++ b/doc_source/aws-resource-config-configurationrecorder.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-config-configurationrecorder-syntax.yaml"></a>
 
 ```
-Type: "AWS::Config::ConfigurationRecorder"
+Type: AWS::Config::ConfigurationRecorder
 Properties:
   [Name](#cfn-config-configurationrecorder-name): String
   [RecordingGroup](#cfn-config-configurationrecorder-recordinggroup):
@@ -89,7 +89,7 @@ The following example creates a configuration recorder for EC2 volumes\.
 
 ```
 ConfigRecorder: 
-  Type: "AWS::Config::ConfigurationRecorder"
+  Type: AWS::Config::ConfigurationRecorder
   Properties: 
     Name: default
     RecordingGroup: 

--- a/doc_source/aws-resource-config-deliverychannel.md
+++ b/doc_source/aws-resource-config-deliverychannel.md
@@ -45,7 +45,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-config-deliverychannel-syntax.yaml"></a>
 
 ```
-Type: "AWS::Config::DeliveryChannel"
+Type: AWS::Config::DeliveryChannel
 Properties:
   [ConfigSnapshotDeliveryProperties](#cfn-config-deliverychannel-configsnapshotdeliveryproperties):
     Config snapshot delivery properties
@@ -118,7 +118,7 @@ The following example creates a delivery channel that sends notifications to the
 
 ```
 DeliveryChannel: 
-  Type: "AWS::Config::DeliveryChannel"
+  Type: AWS::Config::DeliveryChannel
   Properties: 
     ConfigSnapshotDeliveryProperties: 
       DeliveryFrequency: "Six_Hours"

--- a/doc_source/aws-resource-datapipeline-pipeline.md
+++ b/doc_source/aws-resource-datapipeline-pipeline.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-datapipeline-pipeline-syntax.yaml"></a>
 
 ```
-Type: "AWS::DataPipeline::Pipeline"
+Type: AWS::DataPipeline::Pipeline
 Properties:
   [Activate](#cfn-datapipeline-pipeline-activate): Boolean
   [Description](#cfn-datapipeline-pipeline-description): String
@@ -337,7 +337,7 @@ The following data pipeline backs up data from an Amazon DynamoDB \(DynamoDB\) t
 
 ```
 DynamoDBInputS3OutputHive: 
-  Type: "AWS::DataPipeline::Pipeline"
+  Type: AWS::DataPipeline::Pipeline
   Properties: 
     Name: DynamoDBInputS3OutputHive
     Description: "Pipeline to backup DynamoDB data to S3"

--- a/doc_source/aws-resource-dax-cluster.md
+++ b/doc_source/aws-resource-dax-cluster.md
@@ -31,7 +31,7 @@ For information about creating a DAX cluster, see [Creating a DAX Cluster](http:
 ### YAML<a name="aws-resource-dax-cluster-syntax.yaml"></a>
 
 ```
-Type: "AWS::DAX::Cluster"
+Type: AWS::DAX::Cluster
 Properties:
       [AvailabilityZones](#cfn-dax-cluster-availability-zones): [ String, ... ]
       [ClusterName](#cfn-dax-cluster-cluster-name): String

--- a/doc_source/aws-resource-dax-parametergroup.md
+++ b/doc_source/aws-resource-dax-parametergroup.md
@@ -22,7 +22,7 @@ For more information, see [http://docs.aws.amazon.com/amazondynamodb/latest/APIR
 ### YAML<a name="aws-resource-dax-parametergroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::DAX::ParameterGroup"
+Type: AWS::DAX::ParameterGroup
 Properties:
       [ParameterGroupName](#cfn-dax-parametergroup-name): String
       [Description](#cfn-dax-parametergroup-description): String

--- a/doc_source/aws-resource-dax-subnetgroup.md
+++ b/doc_source/aws-resource-dax-subnetgroup.md
@@ -22,7 +22,7 @@ For more information, see [http://docs.aws.amazon.com/amazondynamodb/latest/APIR
 ### YAML<a name="aws-resource-dax-subnetgroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::DAX::SubnetGroup"
+Type: AWS::DAX::SubnetGroup
 Properties:
       [SubnetGroupName](#cfn-dax-subnetgroup-name): String
       [Description](#cfn-dax-subnetgroup-description): String

--- a/doc_source/aws-resource-directoryservice-microsoftad.md
+++ b/doc_source/aws-resource-directoryservice-microsoftad.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-directoryservice-microsoftad-syntax.yaml"></a>
 
 ```
-Type: "AWS::DirectoryService::MicrosoftAD"
+Type: AWS::DirectoryService::MicrosoftAD
 Properties:
   [CreateAlias](#cfn-directoryservice-microsoftad-createalias): Boolean
   [EnableSso](#cfn-directoryservice-microsoftad-enablesso): Boolean
@@ -131,7 +131,7 @@ The following example creates a Microsoft Active Directory in AWS, where the dir
 
 ```
 myDirectory: 
-  Type: "AWS::DirectoryService::MicrosoftAD"
+  Type: AWS::DirectoryService::MicrosoftAD
   Properties: 
     Name: "corp.example.com"
     Password: 

--- a/doc_source/aws-resource-directoryservice-simplead.md
+++ b/doc_source/aws-resource-directoryservice-simplead.md
@@ -33,7 +33,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-directoryservice-simplead-syntax.yaml"></a>
 
 ```
-Type: "AWS::DirectoryService::SimpleAD"
+Type: AWS::DirectoryService::SimpleAD
 Properties:
   [CreateAlias](#cfn-directoryservice-simplead-createalias): Boolean
   [Description](#cfn-directoryservice-simplead-description): String
@@ -147,7 +147,7 @@ The following example creates a Simple AD directory, where the directory DNS nam
 
 ```
 myDirectory: 
-  Type: "AWS::DirectoryService::SimpleAD"
+  Type: AWS::DirectoryService::SimpleAD
   Properties: 
     Name: "corp.example.com"
     Password: 

--- a/doc_source/aws-resource-dms-certificate.md
+++ b/doc_source/aws-resource-dms-certificate.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-dms-certificate-syntax.yaml"></a>
 
 ```
-Type: "AWS::DMS::Certificate"
+Type: AWS::DMS::Certificate
 Properties:
   [CertificateIdentifier](#cfn-dms-certificate-certificateidentifier): String
   [CertificatePem](#cfn-dms-certificate-certificatepem): String

--- a/doc_source/aws-resource-dms-endpoint.md
+++ b/doc_source/aws-resource-dms-endpoint.md
@@ -42,7 +42,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-dms-endpoint-syntax.yaml"></a>
 
 ```
-Type: "AWS::DMS::Endpoint"
+Type: AWS::DMS::Endpoint
 Properties:
   [CertificateArn](#cfn-dms-endpoint-certificatearn): String
   [DatabaseName](#cfn-dms-endpoint-databasename): String
@@ -206,7 +206,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: "Endpoint test"
 Resources:
   BasicEndpoint:
-    Type: "AWS::DMS::Endpoint"
+    Type: AWS::DMS::Endpoint
     Properties:
       EngineName: "mysql"
       EndpointType: "target"

--- a/doc_source/aws-resource-dms-eventsubscription.md
+++ b/doc_source/aws-resource-dms-eventsubscription.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-dms-eventsubscription-syntax.yaml"></a>
 
 ```
-Type: "AWS::DMS::EventSubscription"
+Type: AWS::DMS::EventSubscription
 Properties: 
   [Enabled](#cfn-dms-eventsubscription-enabled): Boolean
   [EventCategories](#cfn-dms-eventsubscription-eventcategories): 

--- a/doc_source/aws-resource-dms-replicationinstance.md
+++ b/doc_source/aws-resource-dms-replicationinstance.md
@@ -39,7 +39,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-dms-replicationinstance-syntax.yaml"></a>
 
 ```
-Type: "AWS::DMS::ReplicationInstance"
+Type: AWS::DMS::ReplicationInstance
 Properties:
   [AllocatedStorage](#cfn-dms-replicationinstance-allocatedstorage): Integer
   [AutoMinorVersionUpgrade](#cfn-dms-replicationinstance-autominorversionupgrade): Boolean

--- a/doc_source/aws-resource-dms-replicationsubnet-group.md
+++ b/doc_source/aws-resource-dms-replicationsubnet-group.md
@@ -33,7 +33,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-dms-replicationsubnetgroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::DMS::ReplicationSubnetGroup"
+Type: AWS::DMS::ReplicationSubnetGroup
 Properties: 
   [ReplicationSubnetGroupIdentifier](#cfn-dms-replicationsubnetgroup-replicationsubnetgroupidentifier): String
   [ReplicationSubnetGroupDescription](#cfn-dms-replicationsubnetgroup-replicationsubnetgroupdescription): String
@@ -104,7 +104,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 AWSTemplateFormatVersion: 2010-09-09
 Resources: 
   myReplicationSubnetGroup: 
-    Type: "AWS::DMS::ReplicationSubnetGroup"
+    Type: AWS::DMS::ReplicationSubnetGroup
     Properties: 
       ReplicationSubnetGroupIdentifier: "identifier"
       ReplicationSubnetGroupDescription: "description"

--- a/doc_source/aws-resource-dms-replicationtask.md
+++ b/doc_source/aws-resource-dms-replicationtask.md
@@ -35,7 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-dms-replicationtask-syntax.yaml"></a>
 
 ```
-Type: "AWS::DMS::ReplicationTask"
+Type: AWS::DMS::ReplicationTask
 Properties:
   [CdcStartTime](#cfn-dms-replicationtask-cdcstarttime): Timestamp
   [MigrationType](#cfn-dms-replicationtask-migrationtype): String
@@ -142,7 +142,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 AWSTemplateFormatVersion: 2010-09-09
 Resources:
   myReplicationTask:
-    Type: "AWS::DMS::ReplicationTask"
+    Type: AWS::DMS::ReplicationTask
     Properties:
       SourceEndpointArn: !Ref SourceEndpoint
       TargetEndpointArn: !Ref TargetEndpoint

--- a/doc_source/aws-resource-dynamodb-table.md
+++ b/doc_source/aws-resource-dynamodb-table.md
@@ -51,7 +51,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-dynamodb-table-syntax.yaml"></a>
 
 ```
-Type: "AWS::DynamoDB::Table"
+Type: AWS::DynamoDB::Table
 Properties:
   [AttributeDefinitions](#cfn-dynamodb-table-attributedef):
     - AttributeDefinition
@@ -296,7 +296,7 @@ For querying the sales of an album, the local secondary index uses the same hash
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   myDynamoDBTable: 
-    Type: "AWS::DynamoDB::Table"
+    Type: AWS::DynamoDB::Table
     Properties: 
       AttributeDefinitions: 
         - 
@@ -445,7 +445,7 @@ The following sample assumes that the `myFirstDDBTable` table is declared in the
 
 ```
 mySecondDDBTable: 
-  Type: "AWS::DynamoDB::Table"
+  Type: AWS::DynamoDB::Table
   DependsOn: "myFirstDDBTable"
   Properties: 
     AttributeDefinitions: 
@@ -640,7 +640,7 @@ This example sets up Application Auto Scaling for a `AWS::DynamoDB::Table` resou
 ```
 Resources:
   DDBTable:
-    Type: "AWS::DynamoDB::Table"
+    Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
         -
@@ -675,7 +675,7 @@ Resources:
         ReadCapacityUnits: 5
         WriteCapacityUnits: 5
   WriteCapacityScalableTarget:
-    Type: "AWS::ApplicationAutoScaling::ScalableTarget"
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       MaxCapacity: 15
       MinCapacity: 5
@@ -687,7 +687,7 @@ Resources:
       ScalableDimension: dynamodb:table:WriteCapacityUnits
       ServiceNamespace: dynamodb
   ScalingRole:
-    Type: "AWS::IAM::Role"
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -718,7 +718,7 @@ Resources:
                   - "cloudwatch:DeleteAlarms"
                 Resource: "*"
   WriteScalingPolicy:
-    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: WriteAutoScalingPolicy
       PolicyType: TargetTrackingScaling

--- a/doc_source/aws-resource-ec2-customer-gateway.md
+++ b/doc_source/aws-resource-ec2-customer-gateway.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-customergateway-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::CustomerGateway"
+Type: AWS::EC2::CustomerGateway
 Properties:
   [BgpAsn](#cfn-ec2-customergateway-bgpasn): Number
   [IpAddress](#cfn-ec2-customergateway-ipaddress): String
@@ -104,7 +104,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   myCustomerGateway: 
-    Type: "AWS::EC2::CustomerGateway"
+    Type: AWS::EC2::CustomerGateway
     Properties: 
       Type: ipsec.1
       BgpAsn: 64000

--- a/doc_source/aws-resource-ec2-dhcp-options.md
+++ b/doc_source/aws-resource-ec2-dhcp-options.md
@@ -35,7 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-dhcpoptions-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::DHCPOptions"
+Type: AWS::EC2::DHCPOptions
 Properties:
   [DomainName](#cfn-ec2-dhcpoptions-domainname): String
   [DomainNameServers](#cfn-ec2-dhcpoptions-domainnameservers):
@@ -155,7 +155,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   myDhcpOptions: 
-    Type: "AWS::EC2::DHCPOptions"
+    Type: AWS::EC2::DHCPOptions
     Properties: 
       DomainName: example.com
       DomainNameServers: 

--- a/doc_source/aws-resource-ec2-egressonlyinternetgateway.md
+++ b/doc_source/aws-resource-ec2-egressonlyinternetgateway.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-egressonlyinternetgateway-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::EgressOnlyInternetGateway"
+Type: AWS::EC2::EgressOnlyInternetGateway
 Properties: 
   [VpcId](#cfn-ec2-egressonlyinternetgateway-vpcid): String
 ```
@@ -74,7 +74,7 @@ The following example creates an egress\-only Internet gateway for the specified
 AWSTemplateFormatVersion: 2010-09-09
 Resources:
   myEgressOnlyInternetGateway:
-    Type: "AWS::EC2::EgressOnlyInternetGateway"
+    Type: AWS::EC2::EgressOnlyInternetGateway
     Properties:
       VpcId: vpc-1a2b3c4d
 ```

--- a/doc_source/aws-resource-ec2-flowlog.md
+++ b/doc_source/aws-resource-ec2-flowlog.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-flowlog-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::FlowLog"
+Type: AWS::EC2::FlowLog
 Properties:
   [DeliverLogsPermissionArn](#cfn-ec2-flowlog-deliverlogspermissionarn) : String
   [LogGroupName](#cfn-ec2-flowlog-loggroupname) : String

--- a/doc_source/aws-resource-ec2-host.md
+++ b/doc_source/aws-resource-ec2-host.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-host-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::Host"
+Type: AWS::EC2::Host
 Properties: 
   [AutoPlacement](#cfn-ec2-host-autoplacement): String
   [AvailabilityZone](#cfn-ec2-host-availabilityzone): String

--- a/doc_source/aws-resource-ec2-internetgateway.md
+++ b/doc_source/aws-resource-ec2-internetgateway.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-internetgateway-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::InternetGateway"
+Type: AWS::EC2::InternetGateway
 Properties: 
   [Tags](#cfn-ec2-internetgateway-tags):
     - Resource Tag
@@ -73,7 +73,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   myInternetGateway:
-    Type: "AWS::EC2::InternetGateway"
+    Type: AWS::EC2::InternetGateway
     Properties:
       Tags:
       - Key: foo

--- a/doc_source/aws-resource-ec2-natgateway.md
+++ b/doc_source/aws-resource-ec2-natgateway.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-natgateway-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::NatGateway"
+Type: AWS::EC2::NatGateway
 Properties: 
   [AllocationId](#cfn-ec2-natgateway-allocationid): String
   [SubnetId](#cfn-ec2-natgateway-subnetid): String

--- a/doc_source/aws-resource-ec2-network-acl-entry.md
+++ b/doc_source/aws-resource-ec2-network-acl-entry.md
@@ -35,7 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-networkaclentry-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::NetworkAclEntry"
+Type: AWS::EC2::NetworkAclEntry
 Properties: 
   [CidrBlock](#cfn-ec2-networkaclentry-cidrblock): String
   [Egress](#cfn-ec2-networkaclentry-egress): Boolean

--- a/doc_source/aws-resource-ec2-network-acl.md
+++ b/doc_source/aws-resource-ec2-network-acl.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-networkacl-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::NetworkAcl"
+Type: AWS::EC2::NetworkAcl
 Properties:
   [Tags](#cfn-ec2-networkacl-tags):
     - Resource Tag

--- a/doc_source/aws-resource-ec2-network-interface-attachment.md
+++ b/doc_source/aws-resource-ec2-network-interface-attachment.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-networkinterfaceattachment-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::NetworkInterfaceAttachment"
+Type: AWS::EC2::NetworkInterfaceAttachment
 Properties: 
   [DeleteOnTermination](#cfn-ec2-network-interface-attachment-deleteonterm): Boolean
   [DeviceIndex](#cfn-ec2-network-interface-attachment-deviceindex): String

--- a/doc_source/aws-resource-ec2-network-interface.md
+++ b/doc_source/aws-resource-ec2-network-interface.md
@@ -36,7 +36,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-networkinterface-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::NetworkInterface"
+Type: AWS::EC2::NetworkInterface
 Properties: 
   [Description](#cfn-awsec2networkinterface-description): String
   [GroupSet](#cfn-awsec2networkinterface-groupset):

--- a/doc_source/aws-resource-ec2-networkinterfacepermission.md
+++ b/doc_source/aws-resource-ec2-networkinterfacepermission.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-networkinterfacepermission-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::NetworkInterfacePermission"
+Type: AWS::EC2::NetworkInterfacePermission
 Properties:
   [AwsAccountId](#cfn-ec2-networkinterfacepermission-awsaccountid): String
   [NetworkInterfaceId](#cfn-ec2-networkinterfacepermission-networkinterfaceid): String

--- a/doc_source/aws-resource-ec2-placementgroup.md
+++ b/doc_source/aws-resource-ec2-placementgroup.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-placementgroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::PlacementGroup"
+Type: AWS::EC2::PlacementGroup
 Properties: 
   [Strategy](#cfn-ec2-placementgroup-strategy): String
 ```

--- a/doc_source/aws-resource-ec2-route-table.md
+++ b/doc_source/aws-resource-ec2-route-table.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-routetable-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::RouteTable"
+Type: AWS::EC2::RouteTable
 Properties: 
   [VpcId](#cfn-ec2-routetable-vpcid): String
   [Tags](#cfn-ec2-routetable-tags):

--- a/doc_source/aws-resource-ec2-route.md
+++ b/doc_source/aws-resource-ec2-route.md
@@ -35,7 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-route-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::Route"
+Type: AWS::EC2::Route
 Properties: 
   [DestinationCidrBlock](#cfn-ec2-route-destinationcidrblock): String
   [DestinationIpv6CidrBlock](#cfn-ec2-route-destinationipv6cidrblock): String

--- a/doc_source/aws-resource-ec2-security-group-egress.md
+++ b/doc_source/aws-resource-ec2-security-group-egress.md
@@ -37,7 +37,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-securitygroupegress-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::SecurityGroupEgress"
+Type: AWS::EC2::SecurityGroupEgress
 Properties:
   [CidrIp](#cfn-ec2-securitygroupegress-cidrip): String
   [CidrIpv6](#cfn-ec2-securitygroupegress-cidripv6): String

--- a/doc_source/aws-resource-ec2-spotfleet.md
+++ b/doc_source/aws-resource-ec2-spotfleet.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-spotfleet-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::SpotFleet"
+Type: AWS::EC2::SpotFleet
 Properties: 
   [SpotFleetRequestConfigData](#cfn-ec2-spotfleet-spotfleetrequestconfigdata):
     SpotFleetRequestConfigData

--- a/doc_source/aws-resource-ec2-subnet-network-acl-assoc.md
+++ b/doc_source/aws-resource-ec2-subnet-network-acl-assoc.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-subnetnetworkaclassociation-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::SubnetNetworkAclAssociation"
+Type: AWS::EC2::SubnetNetworkAclAssociation
 Properties:
   [SubnetId](#cfn-ec2-subnetnetworkaclassociation-associationid): String
   [NetworkAclId](#cfn-ec2-subnetnetworkaclassociation-networkaclid): String

--- a/doc_source/aws-resource-ec2-subnet-route-table-assoc.md
+++ b/doc_source/aws-resource-ec2-subnet-route-table-assoc.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-subnetroutetableassociation-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::SubnetRouteTableAssociation"
+Type: AWS::EC2::SubnetRouteTableAssociation
 Properties: 
   [RouteTableId](#cfn-ec2-subnetroutetableassociation-routetableid): String
   [SubnetId](#cfn-ec2-subnetroutetableassociation-subnetid): String

--- a/doc_source/aws-resource-ec2-subnet.md
+++ b/doc_source/aws-resource-ec2-subnet.md
@@ -33,7 +33,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-subnet-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::Subnet"
+Type: AWS::EC2::Subnet
 Properties:
   [AssignIpv6AddressOnCreation](#cfn-ec2-subnet-assignipv6addressoncreation): Boolean
   [AvailabilityZone](#cfn-ec2-subnet-availabilityzone): String

--- a/doc_source/aws-resource-ec2-subnetcidrblock.md
+++ b/doc_source/aws-resource-ec2-subnetcidrblock.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-subnetcidrblock-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::SubnetCidrBlock"
+Type: AWS::EC2::SubnetCidrBlock
 Properties: 
   [Ipv6CidrBlock](#cfn-ec2-subnetcidrblock-ipv6cidrblock): String
   [SubnetId](#cfn-ec2-subnetcidrblock-subnetid): String
@@ -68,7 +68,7 @@ The following example associates an IPv6 CIDR block \(with a prefix length of /6
 
 ```
 Ipv6TestSubnetCidrBlock:
-  Type: "AWS::EC2::SubnetCidrBlock"
+  Type: AWS::EC2::SubnetCidrBlock
   Properties:
     Ipv6CidrBlock: !Ref Ipv6SubnetCidrBlock
     SubnetId: !Ref Ipv6TestSubnet

--- a/doc_source/aws-resource-ec2-vpc-dhcp-options-assoc.md
+++ b/doc_source/aws-resource-ec2-vpc-dhcp-options-assoc.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-vpcdhcpoptionsassociation-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::VPCDHCPOptionsAssociation"
+Type: AWS::EC2::VPCDHCPOptionsAssociation
 Properties: 
   [DhcpOptionsId](#cfn-ec2-vpcdhcpoptionsassociation-dhcpoptionsid): String
   [VpcId](#cfn-ec2-vpcdhcpoptionsassociation-vpcid): String

--- a/doc_source/aws-resource-ec2-vpc-gateway-attachment.md
+++ b/doc_source/aws-resource-ec2-vpc-gateway-attachment.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-vpcgatewayattachment-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::VPCGatewayAttachment"
+Type: AWS::EC2::VPCGatewayAttachment
 Properties: 
   [InternetGatewayId](#cfn-ec2-vpcgatewayattachment-internetgatewayid): String
   [VpcId](#cfn-ec2-vpcgatewayattachment-vpcid): String

--- a/doc_source/aws-resource-ec2-vpc.md
+++ b/doc_source/aws-resource-ec2-vpc.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-vpc-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::VPC"
+Type: AWS::EC2::VPC
 Properties: 
   [CidrBlock](#cfn-aws-ec2-vpc-cidrblock): String
   [EnableDnsSupport](#cfn-aws-ec2-vpc-EnableDnsSupport): Boolean

--- a/doc_source/aws-resource-ec2-vpccidrblock.md
+++ b/doc_source/aws-resource-ec2-vpccidrblock.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-vpccidrblock-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::VPCCidrBlock"
+Type: AWS::EC2::VPCCidrBlock
 Properties: 
   [AmazonProvidedIpv6CidrBlock](#cfn-ec2-vpccidrblock-amazonprovidedipv6cidrblock): Boolean
   [CidrBlock](#cfn-ec2-vpccidrblock-cidrblock): String
@@ -78,7 +78,7 @@ The following snippet associates an Amazon\-provided IPv6 CIDR block \(with a pr
 
 ```
 Ipv6VPCCidrBlock:
-  Type: "AWS::EC2::VPCCidrBlock"
+  Type: AWS::EC2::VPCCidrBlock
   Properties:
     AmazonProvidedIpv6CidrBlock: true
     VpcId: !Ref TestVPCIpv6
@@ -167,16 +167,16 @@ The following example associates an IPv4 CIDR block and an Amazon\-provided IPv6
 ```
 Resources:
   VPC:
-    Type: "AWS::EC2::VPC"
+    Type: AWS::EC2::VPC
     Properties:
       CidrBlock: 10.0.0.0/24
   VpcCidrBlock:
-    Type: "AWS::EC2::VPCCidrBlock"
+    Type: AWS::EC2::VPCCidrBlock
     Properties:
       VpcId: !Ref VPC
       CidrBlock: 192.0.0.0/24
   VpcCidrBlockIpv6:
-    Type: "AWS::EC2::VPCCidrBlock"
+    Type: AWS::EC2::VPCCidrBlock
     Properties:
       VpcId: !Ref VPC
       AmazonProvidedIpv6CidrBlock: true

--- a/doc_source/aws-resource-ec2-vpcendpoint.md
+++ b/doc_source/aws-resource-ec2-vpcendpoint.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-vpcendpoint-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::VPCEndpoint"
+Type: AWS::EC2::VPCEndpoint
 Properties: 
   [PolicyDocument](#cfn-ec2-vpcendpoint-policydocument): JSON object
   [RouteTableIds](#cfn-ec2-vpcendpoint-routetableids):

--- a/doc_source/aws-resource-ec2-vpcpeeringconnection.md
+++ b/doc_source/aws-resource-ec2-vpcpeeringconnection.md
@@ -33,7 +33,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-vpcpeeringconnection-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::VPCPeeringConnection"
+Type: AWS::EC2::VPCPeeringConnection
 Properties: 
   [PeerVpcId](#cfn-ec2-vpcpeeringconnection-peervpcid): String
   [Tags](#cfn-ec2-vpcpeeringconnection-tags):

--- a/doc_source/aws-resource-ec2-vpn-connection-route.md
+++ b/doc_source/aws-resource-ec2-vpn-connection-route.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-vpnconnectionroute-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::VPNConnectionRoute"
+Type: AWS::EC2::VPNConnectionRoute
 Properties: 
   [DestinationCidrBlock](#cfn-ec2-vpnconnectionroute-cidrblock): String
   [VpnConnectionId](#cfn-ec2-vpnconnectionroute-connectionid): String
@@ -74,7 +74,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 
 ```
 MyConnectionRoute0: 
-  Type: "AWS::EC2::VPNConnectionRoute"
+  Type: AWS::EC2::VPNConnectionRoute
   Properties: 
     DestinationCidrBlock: 10.0.0.0/16
     VpnConnectionId: 

--- a/doc_source/aws-resource-ec2-vpn-connection.md
+++ b/doc_source/aws-resource-ec2-vpn-connection.md
@@ -34,7 +34,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-vpnconnection-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::VPNConnection"
+Type: AWS::EC2::VPNConnection
 Properties: 
   [Type](#cfn-ec2-vpnconnection-type): String
   [CustomerGatewayId](#cfn-ec2-vpnconnection-customergatewayid):
@@ -126,7 +126,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
   myVPNConnection: 
-    Type: "AWS::EC2::VPNConnection"
+    Type: AWS::EC2::VPNConnection
     Properties: 
       Type: ipsec.1
       StaticRoutesOnly: true

--- a/doc_source/aws-resource-ec2-vpn-gateway.md
+++ b/doc_source/aws-resource-ec2-vpn-gateway.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-vpcgateway-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::VPNGateway"
+Type: AWS::EC2::VPNGateway
 Properties: 
   [AmazonSideAsn](#cfn-ec2-vpngateway-amazonsideasn): Long
   [Type](#cfn-ec2-vpngateway-type): String
@@ -94,7 +94,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   myVPNGateway: 
-    Type: "AWS::EC2::VPNGateway"
+    Type: AWS::EC2::VPNGateway
     Properties: 
       Type: ipsec.1
       Tags: 

--- a/doc_source/aws-resource-ec2-vpn-gatewayrouteprop.md
+++ b/doc_source/aws-resource-ec2-vpn-gatewayrouteprop.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ec2-vpngatewayroutepropagation-syntax.yaml"></a>
 
 ```
-Type: "AWS::EC2::VPNGatewayRoutePropagation"
+Type: AWS::EC2::VPNGatewayRoutePropagation
 Properties: 
   [RouteTableIds](#cfn-ec2-vpngatewayrouteprop-routetableids):
     - String
@@ -82,7 +82,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 
 ```
 myVPNGatewayRouteProp: 
-  Type: "AWS::EC2::VPNGatewayRoutePropagation"
+  Type: AWS::EC2::VPNGatewayRoutePropagation
   Properties:
     RouteTableIds: 
       - !Ref PrivateRouteTable

--- a/doc_source/aws-resource-ecr-repository.md
+++ b/doc_source/aws-resource-ecr-repository.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ecr-repository-syntax.yaml"></a>
 
 ```
-Type: "AWS::ECR::Repository"
+Type: AWS::ECR::Repository
 Properties: 
   [LifecyclePolicy](#cfn-ecr-repository-lifecyclepolicy):
     [*LifecyclePolicy*](aws-properties-ecr-repository-lifecyclepolicy.md)
@@ -110,7 +110,7 @@ The following example creates a repository named `test-repository`\. Its policy 
 
 ```
 MyRepository: 
-  Type: "AWS::ECR::Repository"
+  Type: AWS::ECR::Repository
   Properties: 
     RepositoryName: "test-repository"
     RepositoryPolicyText: 

--- a/doc_source/aws-resource-ecs-cluster.md
+++ b/doc_source/aws-resource-ecs-cluster.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ecs-cluster-syntax.yaml"></a>
 
 ```
-Type: "AWS::ECS::Cluster"
+Type: AWS::ECS::Cluster
 Properties:
   [ClusterName](#cfn-ecs-cluster-clustername): String
 ```
@@ -79,5 +79,5 @@ The following sample declares an Amazon ECS cluster:
 
 ```
 MyCluster:
-  Type: "AWS::ECS::Cluster"
+  Type: AWS::ECS::Cluster
 ```

--- a/doc_source/aws-resource-ecs-service.md
+++ b/doc_source/aws-resource-ecs-service.md
@@ -39,7 +39,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ecs-service-syntax.yaml"></a>
 
 ```
-Type: "AWS::ECS::Service"
+Type: AWS::ECS::Service
 Properties: 
   [Cluster](#cfn-ecs-service-cluster): String
   [DeploymentConfiguration](#cfn-ecs-service-deploymentconfiguration):
@@ -193,7 +193,7 @@ The following examples define an Amazon ECS service that uses a cluster and task
 
 ```
 WebApp: 
-  Type: "AWS::ECS::Service"
+  Type: AWS::ECS::Service
   Properties: 
     Cluster: 
       Ref: "cluster"

--- a/doc_source/aws-resource-ecs-taskdefinition.md
+++ b/doc_source/aws-resource-ecs-taskdefinition.md
@@ -36,7 +36,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ecs-taskdefinition-syntax.yaml"></a>
 
 ```
-Type: "AWS::ECS::TaskDefinition"
+Type: AWS::ECS::TaskDefinition
 Properties: 
   [Volumes](#cfn-ecs-taskdefinition-volumes):
     - Volume Definition
@@ -225,7 +225,7 @@ The following example defines an Amazon ECS task definition, which includes two 
 
 ```
 taskdefinition: 
-  Type: "AWS::ECS::TaskDefinition"
+  Type: AWS::ECS::TaskDefinition
   Properties: 
     ContainerDefinitions: 
       - 
@@ -347,7 +347,7 @@ The following example defines an Amazon ECS task definition that specifies `EC2`
 AWSTemplateFormatVersion: 2010-09-09
 Resources:
   taskdefinition: 
-    Type: "AWS::ECS::TaskDefinition"
+    Type: AWS::ECS::TaskDefinition
     Properties: 
       RequiresCompatibilities:
         - "EC2"

--- a/doc_source/aws-resource-efs-filesystem.md
+++ b/doc_source/aws-resource-efs-filesystem.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-efs-filesystem-syntax.yaml"></a>
 
 ```
-Type: "AWS::EFS::FileSystem"
+Type: AWS::EFS::FileSystem
 Properties: 
   [Encrypted](#cfn-efs-filesystem-encrypted): Boolean
   [FileSystemTags](#cfn-efs-filesystem-filesystemtags):

--- a/doc_source/aws-resource-efs-mounttarget.md
+++ b/doc_source/aws-resource-efs-mounttarget.md
@@ -35,7 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-efs-mounttarget-syntax.yaml"></a>
 
 ```
-Type: "AWS::EFS::MountTarget"
+Type: AWS::EFS::MountTarget
 Properties:
   [FileSystemId](#cfn-efs-mounttarget-filesystemid): String
   [IpAddress](#cfn-efs-mounttarget-ipaddress): String
@@ -103,7 +103,7 @@ The following example declares a mount target that is associated with a file sys
 
 ```
 MountTarget: 
-  Type: "AWS::EFS::MountTarget"
+  Type: AWS::EFS::MountTarget
   Properties: 
     FileSystemId: 
       Ref: "FileSystem"

--- a/doc_source/aws-resource-elasticache-replicationgroup.md
+++ b/doc_source/aws-resource-elasticache-replicationgroup.md
@@ -55,7 +55,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticache-replicationgroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElastiCache::ReplicationGroup"
+Type: AWS::ElastiCache::ReplicationGroup
 Properties: 
   [AtRestEncryptionEnabled](#cfn-elasticache-replicationgroup-atrestencryptionenabled): Boolean
   [AuthToken](#cfn-elasticache-replicationgroup-authtoken): String
@@ -449,7 +449,7 @@ The following example declares a replication group with two nodes and automatic 
 
 ```
 myReplicationGroup: 
-  Type: "AWS::ElastiCache::ReplicationGroup"
+  Type: AWS::ElastiCache::ReplicationGroup
   Properties: 
     ReplicationGroupDescription: "my description"
     NumCacheClusters: "2"

--- a/doc_source/aws-resource-elasticloadbalancingv2-listener.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-listener.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticloadbalancingv2-listener-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElasticLoadBalancingV2::Listener"
+Type: AWS::ElasticLoadBalancingV2::Listener
 Properties: 
   [Certificates](#cfn-elasticloadbalancingv2-listener-certificates):
     - [Certificate](aws-properties-elasticloadbalancingv2-listener-certificates.md)

--- a/doc_source/aws-resource-elasticloadbalancingv2-listenercertificate.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-listenercertificate.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticloadbalancingv2-listenercertificate-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElasticLoadBalancingV2::ListenerCertificate"
+Type: AWS::ElasticLoadBalancingV2::ListenerCertificate
 Properties:
   [Certificates](#cfn-elasticloadbalancingv2-listenercertificate-certificates): 
     - [*Certificate*](aws-properties-elasticloadbalancingv2-listenercertificate-certificate.md)

--- a/doc_source/aws-resource-elasticloadbalancingv2-listenerrule.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-listenerrule.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticloadbalancingv2-listenerrule-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElasticLoadBalancingV2::ListenerRule"
+Type: AWS::ElasticLoadBalancingV2::ListenerRule
 Properties:
   [Actions](#cfn-elasticloadbalancingv2-listenerrule-actions):
     - [Actions](aws-properties-elasticloadbalancingv2-listenerrule-actions.md)

--- a/doc_source/aws-resource-elasticloadbalancingv2-loadbalancer.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-loadbalancer.md
@@ -37,7 +37,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticloadbalancingv2-loadbalancer-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+Type: AWS::ElasticLoadBalancingV2::LoadBalancer
 Properties:
   [LoadBalancerAttributes](#cfn-elasticloadbalancingv2-loadbalancer-loadbalancerattributes):
     - [LoadBalancerAttributes](aws-properties-elasticloadbalancingv2-loadbalancer-loadbalancerattributes.md)

--- a/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
@@ -41,7 +41,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticloadbalancingv2-targetgroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+Type: AWS::ElasticLoadBalancingV2::TargetGroup
 Properties:
   [HealthCheckIntervalSeconds](#cfn-elasticloadbalancingv2-targetgroup-healthcheckintervalseconds): Integer
   [HealthCheckPath](#cfn-elasticloadbalancingv2-targetgroup-healthcheckpath): String

--- a/doc_source/aws-resource-elasticmapreduce-instancefleetconfig.md
+++ b/doc_source/aws-resource-elasticmapreduce-instancefleetconfig.md
@@ -33,7 +33,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticmapreduce-instancefleetconfig-syntax.yaml"></a>
 
 ```
-Type: "AWS::EMR::InstanceFleetConfig"
+Type: AWS::EMR::InstanceFleetConfig
 Properties: 
   [ClusterId](#cfn-elasticmapreduce-instancefleetconfig-clusterid): String
   [InstanceFleetType](#cfn-elasticmapreduce-instancefleetconfig-instancefleettype): String

--- a/doc_source/aws-resource-elasticsearch-domain.md
+++ b/doc_source/aws-resource-elasticsearch-domain.md
@@ -34,7 +34,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-elasticsearch-domain-syntax.yaml"></a>
 
 ```
-Type: "AWS::Elasticsearch::Domain"
+Type: AWS::Elasticsearch::Domain
 Properties: 
   [AccessPolicies](#cfn-elasticsearch-domain-accesspolicies): JSON object
   [AdvancedOptions](#cfn-elasticsearch-domain-advancedoptions):
@@ -192,7 +192,7 @@ The following examples create an Amazon ES domain that contains two data nodes a
 
 ```
 ElasticsearchDomain: 
-  Type: "AWS::Elasticsearch::Domain"
+  Type: AWS::Elasticsearch::Domain
   Properties:
     DomainName: "test"
     ElasticsearchClusterConfig: 

--- a/doc_source/aws-resource-emr-cluster.md
+++ b/doc_source/aws-resource-emr-cluster.md
@@ -42,7 +42,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-emr-cluster-syntax.yaml"></a>
 
 ```
-Type: "AWS::EMR::Cluster"
+Type: AWS::EMR::Cluster
 Properties: 
   [AdditionalInfo](#cfn-emr-cluster-additionalinfo): JSON object
   [Applications](#cfn-emr-cluster-applications):
@@ -241,7 +241,7 @@ The following example creates an Amazon EMR cluster with one master node and two
 
 ```
 TestCluster: 
-  Type: "AWS::EMR::Cluster"
+  Type: AWS::EMR::Cluster
   Properties: 
     Instances: 
       MasterInstanceGroup: 
@@ -315,7 +315,7 @@ The following example creates an Amazon EMR cluster with a bootstrap action\.
 
 ```
 TestCluster: 
-  Type: "AWS::EMR::Cluster"
+  Type: AWS::EMR::Cluster
   Properties: 
     BootstrapActions: 
       - 

--- a/doc_source/aws-resource-emr-instancegroupconfig.md
+++ b/doc_source/aws-resource-emr-instancegroupconfig.md
@@ -38,7 +38,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-emr-instancegroupconfig-syntax.yaml"></a>
 
 ```
-Type: "AWS::EMR::InstanceGroupConfig"
+Type: AWS::EMR::InstanceGroupConfig
 Properties: 
   [AutoScalingPolicy](#cfn-elasticmapreduce-instancegroupconfig-autoscalingpolicy):
     AutoScalingPolicy
@@ -155,7 +155,7 @@ The following example adds a task instance group to the `TestCluster` cluster\. 
 
 ```
 TestInstanceGroupConfig: 
-  Type: "AWS::EMR::InstanceGroupConfig"
+  Type: AWS::EMR::InstanceGroupConfig
   Properties: 
     InstanceCount: 2
     InstanceType: "m3.xlarge"

--- a/doc_source/aws-resource-emr-securityconfiguration.md
+++ b/doc_source/aws-resource-emr-securityconfiguration.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-emr-securityconfiguration-syntax.yaml"></a>
 
 ```
-Type: "AWS::EMR::SecurityConfiguration"
+Type: AWS::EMR::SecurityConfiguration
 Properties: 
   [Name](#cfn-emr-securityconfiguration-name): String
   [SecurityConfiguration](#cfn-emr-securityconfiguration-securityconfiguration): String

--- a/doc_source/aws-resource-emr-step.md
+++ b/doc_source/aws-resource-emr-step.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-emr-step-syntax.yaml"></a>
 
 ```
-Type: "AWS::EMR::Step"
+Type: AWS::EMR::Step
 Properties: 
   [ActionOnFailure](#cfn-emr-step-actiononfailure): String
   [HadoopJarStep](#cfn-emr-step-hadoopjarstep):
@@ -111,7 +111,7 @@ The following example creates a step that submits work to the `TestCluster` clus
 
 ```
 TestStep: 
-  Type: "AWS::EMR::Step"
+  Type: AWS::EMR::Step
   Properties: 
     ActionOnFailure: "CONTINUE"
     HadoopJarStep: 

--- a/doc_source/aws-resource-events-rule.md
+++ b/doc_source/aws-resource-events-rule.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-events-rule-syntax.yaml"></a>
 
 ```
-Type: "AWS::Events::Rule"
+Type: AWS::Events::Rule
 Properties: 
   [Description](#cfn-events-rule-description): String
   [EventPattern](#cfn-events-rule-eventpattern): JSON object
@@ -135,7 +135,7 @@ The following example creates a rule that invokes the specified Lambda function 
 
 ```
 ScheduledRule: 
-  Type: "AWS::Events::Rule"
+  Type: AWS::Events::Rule
   Properties: 
     Description: "ScheduledRule"
     ScheduleExpression: "rate(10 minutes)"
@@ -148,7 +148,7 @@ ScheduledRule:
             - "Arn"
         Id: "TargetFunctionV1"
 PermissionForEventsToInvokeLambda: 
-  Type: "AWS::Lambda::Permission"
+  Type: AWS::Lambda::Permission
   Properties: 
     FunctionName: 
       Ref: "LambdaFunction"
@@ -206,7 +206,7 @@ The following example creates a rule that invokes the specified Lambda function 
 
 ```
 EventRule: 
-  Type: "AWS::Events::Rule"
+  Type: AWS::Events::Rule
   Properties: 
     Description: "EventRule"
     EventPattern: 
@@ -226,7 +226,7 @@ EventRule:
             - "Arn"
         Id: "TargetFunctionV1"
 PermissionForEventsToInvokeLambda: 
-  Type: "AWS::Lambda::Permission"
+  Type: AWS::Lambda::Permission
   Properties: 
     FunctionName: 
       Ref: "LambdaFunction"
@@ -272,7 +272,7 @@ The following example creates a rule that notifies an Amazon Simple Notification
 
 ```
 OpsEventRule: 
-  Type: "AWS::Events::Rule"
+  Type: AWS::Events::Rule
   Properties: 
     Description: "EventRule"
     EventPattern: 

--- a/doc_source/aws-resource-gamelift-alias.md
+++ b/doc_source/aws-resource-gamelift-alias.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-gamelift-alias-syntax.yaml"></a>
 
 ```
-Type: "AWS::GameLift::Alias"
+Type: AWS::GameLift::Alias
 Properties: 
   [Name](#cfn-gamelift-alias-name): String
   [Description](#cfn-gamelift-alias-description): String
@@ -88,7 +88,7 @@ The following example creates a terminal alias named `TerminalAlias` with a gene
 
 ```
 AliasResource: 
-  Type: "AWS::GameLift::Alias"
+  Type: AWS::GameLift::Alias
   Properties: 
     Name: "TerminalAlias"
     Description: "A terminal alias"

--- a/doc_source/aws-resource-gamelift-build.md
+++ b/doc_source/aws-resource-gamelift-build.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-gamelift-build-syntax.yaml"></a>
 
 ```
-Type: "AWS::GameLift::Build"
+Type: AWS::GameLift::Build
 Properties: 
   [Name](#cfn-gamelift-build-name): String
   [StorageLocation](#cfn-gamelift-build-storagelocation):
@@ -120,7 +120,7 @@ The following example creates a GameLift build named `MyGameServerBuild`\. The b
 
 ```
 BuildResource: 
-  Type: "AWS::GameLift::Build"
+  Type: AWS::GameLift::Build
   Properties: 
     Name: "MyGameServerBuild"
     Version: "v15"
@@ -132,7 +132,7 @@ BuildResource:
           - "IAMRole"
           - "Arn"
 IAMRole: 
-  Type: "AWS::IAM::Role"
+  Type: AWS::IAM::Role
   Properties: 
     AssumeRolePolicyDocument: 
       Version: "2012-10-17"

--- a/doc_source/aws-resource-gamelift-fleet.md
+++ b/doc_source/aws-resource-gamelift-fleet.md
@@ -36,7 +36,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-gamelift-fleet-syntax.yaml"></a>
 
 ```
-Type: "AWS::GameLift::Fleet"
+Type: AWS::GameLift::Fleet
 Properties: 
   [BuildId](#cfn-gamelift-fleet-buildid): String
   [Description](#cfn-gamelift-fleet-description): String
@@ -171,7 +171,7 @@ The following example creates a GameLift fleet named `MyGameFleet` with two inbo
 
 ```
 FleetResource: 
-  Type: "AWS::GameLift::Fleet"
+  Type: AWS::GameLift::Fleet
   Properties: 
     Name: "MyGameFleet"
     Description: "A fleet for my game"

--- a/doc_source/aws-resource-glue-classifier.md
+++ b/doc_source/aws-resource-glue-classifier.md
@@ -25,7 +25,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-glue-classifier-syntax.yaml"></a>
 
 ```
-Type: "AWS::Glue::Classifier"
+Type: AWS::Glue::Classifier
 Properties:
   [GrokClassifier](#cfn-glue-classifier-grokclassifier): 
     [*GrokClassifier*](aws-properties-glue-classifier-grokclassifier.md)

--- a/doc_source/aws-resource-glue-connection.md
+++ b/doc_source/aws-resource-glue-connection.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-glue-connection-syntax.yaml"></a>
 
 ```
-Type: "AWS::Glue::Connection"
+Type: AWS::Glue::Connection
 Properties:
   [ConnectionInput](#cfn-glue-connection-connectioninput): 
     [*ConnectionInput*](aws-properties-glue-connection-connectioninput.md)

--- a/doc_source/aws-resource-glue-crawler.md
+++ b/doc_source/aws-resource-glue-crawler.md
@@ -34,7 +34,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-glue-crawler-syntax.yaml"></a>
 
 ```
-Type: "AWS::Glue::Crawler"
+Type: AWS::Glue::Crawler
 Properties:
   [Role](#cfn-glue-crawler-role): String
   [Classifiers](#cfn-glue-crawler-classifiers): 

--- a/doc_source/aws-resource-glue-database.md
+++ b/doc_source/aws-resource-glue-database.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-glue-database-syntax.yaml"></a>
 
 ```
-Type: "AWS::Glue::Database"
+Type: AWS::Glue::Database
 Properties:
   [DatabaseInput](#cfn-glue-database-databaseinput): 
     [*DatabaseInput*](aws-properties-glue-database-databaseinput.md)

--- a/doc_source/aws-resource-glue-devendpoint.md
+++ b/doc_source/aws-resource-glue-devendpoint.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-glue-devendpoint-syntax.yaml"></a>
 
 ```
-Type: "AWS::Glue::DevEndpoint"
+Type: AWS::Glue::DevEndpoint
 Properties:
   [EndpointName](#cfn-glue-devendpoint-endpointname): String
   [ExtraJarsS3Path](#cfn-glue-devendpoint-extrajarss3path): String

--- a/doc_source/aws-resource-glue-job.md
+++ b/doc_source/aws-resource-glue-job.md
@@ -35,7 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-glue-job-syntax.yaml"></a>
 
 ```
-Type: "AWS::Glue::Job"
+Type: AWS::Glue::Job
 Properties:
   [Role](#cfn-glue-job-role): String
   [DefaultArguments](#cfn-glue-job-defaultarguments): JSON object

--- a/doc_source/aws-resource-glue-partition.md
+++ b/doc_source/aws-resource-glue-partition.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-glue-partition-syntax.yaml"></a>
 
 ```
-Type: "AWS::Glue::Partition"
+Type: AWS::Glue::Partition
 Properties:
   [TableName](#cfn-glue-partition-tablename): String
   [DatabaseName](#cfn-glue-partition-databasename): String

--- a/doc_source/aws-resource-glue-table.md
+++ b/doc_source/aws-resource-glue-table.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-glue-table-syntax.yaml"></a>
 
 ```
-Type: "AWS::Glue::Table"
+Type: AWS::Glue::Table
 Properties:
   [TableInput](#cfn-glue-table-tableinput): 
     [*TableInput*](aws-properties-glue-table-tableinput.md)

--- a/doc_source/aws-resource-glue-trigger.md
+++ b/doc_source/aws-resource-glue-trigger.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-glue-trigger-syntax.yaml"></a>
 
 ```
-Type: "AWS::Glue::Trigger"
+Type: AWS::Glue::Trigger
 Properties:
   [Type](#cfn-glue-trigger-type): String
   [Description](#cfn-glue-trigger-description): String

--- a/doc_source/aws-resource-guardduty-detector.md
+++ b/doc_source/aws-resource-guardduty-detector.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-guardduty-detector-syntax.yaml"></a>
 
 ```
-Type: "AWS::GuardDuty::Detector"
+Type: AWS::GuardDuty::Detector
 Properties:
   [Enable](#cfn-guardduty-detector-enable): Boolean
 ```
@@ -68,7 +68,7 @@ The following example shows how to declare an `AWS::GuardDuty::Detector` resourc
 
 ```
 mydetector:
-  Type: "AWS::GuardDuty::Detector"
+  Type: AWS::GuardDuty::Detector
   Properties:
     Enable: true
 ```

--- a/doc_source/aws-resource-guardduty-ipset.md
+++ b/doc_source/aws-resource-guardduty-ipset.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-guardduty-ipset-syntax.yaml"></a>
 
 ```
-Type: "AWS::GuardDuty::IPSet"
+Type: AWS::GuardDuty::IPSet
 Properties:
   [Activate](#cfn-guardduty-ipset-activate): Boolean
   [DetectorId](#cfn-guardduty-ipset-detectorid): String
@@ -104,7 +104,7 @@ The following example shows how to declare an AWS::GuardDuty::IPSet resource to 
 
 ```
 myipset:
-  Type: "AWS::GuardDuty::IPSet"
+  Type: AWS::GuardDuty::IPSet
   Properties:
     Activate: true
     DetectorId: "12abc34d567e8f4912ab3d45e67891f2"

--- a/doc_source/aws-resource-guardduty-master.md
+++ b/doc_source/aws-resource-guardduty-master.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-guardduty-master-syntax.yaml"></a>
 
 ```
-Type: "AWS::GuardDuty::Master"
+Type: AWS::GuardDuty::Master
 Properties:
   [DetectorId](#cfn-guardduty-master-detectorid): String
   [MasterId](#cfn-guardduty-master-masterid): String
@@ -86,7 +86,7 @@ The following example shows how to declare an `AWS::GuardDuty::Master` resource 
 
 ```
 GDmaster:
-  Type: "AWS::GuardDuty::Master"
+  Type: AWS::GuardDuty::Master
   Properties:
     DetectorId: "a12abc34d567e8fa901bc2d34e56789f0"
     MasterId: "012345678901"

--- a/doc_source/aws-resource-guardduty-member.md
+++ b/doc_source/aws-resource-guardduty-member.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-guardduty-member-syntax.yaml"></a>
 
 ```
-Type: "AWS::GuardDuty::Member"
+Type: AWS::GuardDuty::Member
 Properties:
   [Status](#cfn-guardduty-member-status): String
   [MemberId](#cfn-guardduty-member-memberid): String
@@ -104,7 +104,7 @@ The following example shows how to declare an AWS::GuardDuty::Member resource to
 
 ```
 GDmaster:
-  Type: "AWS::GuardDuty::Member"
+  Type: AWS::GuardDuty::Member
   Properties:
     Status: "Invited"    
     MemberId: "012345678901"

--- a/doc_source/aws-resource-guardduty-threatintelset.md
+++ b/doc_source/aws-resource-guardduty-threatintelset.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-guardduty-threatintelset-syntax.yaml"></a>
 
 ```
-Type: "AWS::GuardDuty::ThreatIntelSet"
+Type: AWS::GuardDuty::ThreatIntelSet
 Properties:
   [Activate](#cfn-guardduty-threatintelset-activate): Boolean
   [DetectorId](#cfn-guardduty-threatintelset-detectorid): String
@@ -104,7 +104,7 @@ The following example shows how to declare an AWS::GuardDuty::ThreatIntelSet res
 
 ```
 mythreatintelset:
-  Type: "AWS::GuardDuty::ThreatIntelSet"
+  Type: AWS::GuardDuty::ThreatIntelSet
   Properties:
     Activate: true
     DetectorId: "12abc34d567e8f4912ab3d45e67891f2"

--- a/doc_source/aws-resource-iam-instanceprofile.md
+++ b/doc_source/aws-resource-iam-instanceprofile.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-iam-instanceprofile-syntax.yaml"></a>
 
 ```
-Type: "AWS::IAM::InstanceProfile"
+Type: AWS::IAM::InstanceProfile
 Properties: 
   [Path](#cfn-iam-instanceprofile-path): String
   [Roles](#cfn-iam-instanceprofile-roles):

--- a/doc_source/aws-resource-iam-managedpolicy.md
+++ b/doc_source/aws-resource-iam-managedpolicy.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-iam-managedpolicy-syntax.yaml"></a>
 
 ```
-Type: "AWS::IAM::ManagedPolicy"
+Type: AWS::IAM::ManagedPolicy
 Properties: 
   [Description](#cfn-iam-managedpolicy-description): String
   [Groups](#cfn-iam-managedpolicy-groups):
@@ -148,7 +148,7 @@ The following example creates a managed policy and associates it with the `TestD
 
 ```
 CreateTestDBPolicy: 
-  Type: "AWS::IAM::ManagedPolicy"
+  Type: AWS::IAM::ManagedPolicy
   Properties: 
     Description: "Policy for creating a test database"
     Path: "/"

--- a/doc_source/aws-resource-iam-policy.md
+++ b/doc_source/aws-resource-iam-policy.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-iam-policy-syntax.yaml"></a>
 
 ```
-Type: "AWS::IAM::Policy"
+Type: AWS::IAM::Policy
 Properties: 
   [Groups](#cfn-iam-policy-groups):
     - String
@@ -115,7 +115,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 #### YAML<a name="aws-resource-iam-policy-example1.yaml"></a>
 
 ```
-Type: "AWS::IAM::Policy"
+Type: AWS::IAM::Policy
 Properties: 
   PolicyName: "CFNUsers"
   PolicyDocument: 
@@ -156,7 +156,7 @@ Properties:
 #### YAML<a name="aws-resource-iam-policy-example2.yaml"></a>
 
 ```
-Type: "AWS::IAM::Policy"
+Type: AWS::IAM::Policy
 Properties: 
   PolicyName: "root"
   PolicyDocument: 

--- a/doc_source/aws-resource-iam-role.md
+++ b/doc_source/aws-resource-iam-role.md
@@ -33,7 +33,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-iam-role-syntax.yaml"></a>
 
 ```
-Type: "AWS::IAM::Role"
+Type: AWS::IAM::Role
 Properties: 
   [AssumeRolePolicyDocument](#cfn-iam-role-assumerolepolicydocument):
     JSON object
@@ -173,7 +173,7 @@ This example shows an embedded Policy in the IAM::Role\. The policy is specified
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   RootRole: 
-    Type: "AWS::IAM::Role"
+    Type: AWS::IAM::Role
     Properties: 
       AssumeRolePolicyDocument: 
         Version: "2012-10-17"
@@ -197,7 +197,7 @@ Resources:
                 Action: "*"
                 Resource: "*"
   RootInstanceProfile: 
-    Type: "AWS::IAM::InstanceProfile"
+    Type: AWS::IAM::InstanceProfile
     Properties: 
       Path: "/"
       Roles: 
@@ -267,7 +267,7 @@ In this example, the Policy and InstanceProfile resources are specified external
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   RootRole: 
-    Type: "AWS::IAM::Role"
+    Type: AWS::IAM::Role
     Properties: 
       AssumeRolePolicyDocument: 
         Version: "2012-10-17"
@@ -281,7 +281,7 @@ Resources:
               - "sts:AssumeRole"
       Path: "/"
   RolePolicies: 
-    Type: "AWS::IAM::Policy"
+    Type: AWS::IAM::Policy
     Properties: 
       PolicyName: "root"
       PolicyDocument: 
@@ -295,7 +295,7 @@ Resources:
         - 
           Ref: "RootRole"
   RootInstanceProfile: 
-    Type: "AWS::IAM::InstanceProfile"
+    Type: AWS::IAM::InstanceProfile
     Properties: 
       Path: "/"
       Roles: 

--- a/doc_source/aws-resource-init.md
+++ b/doc_source/aws-resource-init.md
@@ -62,7 +62,7 @@ The cfn\-init helper script processes these configuration sections in the follow
 ```
 Resources: 
   MyInstance: 
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Metadata: 
       AWS::CloudFormation::Init: 
         config: 

--- a/doc_source/aws-resource-inspector-assessmenttarget.md
+++ b/doc_source/aws-resource-inspector-assessmenttarget.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-inspector-assessmenttarget-syntax.yaml"></a>
 
 ```
-Type: "AWS::Inspector::AssessmentTarget"
+Type: AWS::Inspector::AssessmentTarget
 Properties:
   [AssessmentTargetName](#cfn-inspector-assessmenttarget-assessmenttargetname): String
   [ResourceGroupArn](#cfn-inspector-assessmenttarget-resourcegrouparn): String
@@ -80,7 +80,7 @@ The following example shows how to declare an AWS::Inspector::AssessmentTarget r
 
 ```
 myassessmenttarget: 
-  Type: "AWS::Inspector::AssessmentTarget"
+  Type: AWS::Inspector::AssessmentTarget
   Properties: 
     AssessmentTargetName : "MyAssessmentTarget"
     ResourceGroupArn : "arn:aws:inspector:us-west-2:123456789012:resourcegroup/0-AB6DMKnv"

--- a/doc_source/aws-resource-inspector-assessmenttemplate.md
+++ b/doc_source/aws-resource-inspector-assessmenttemplate.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-inspector-assessmenttemplate-syntax.yaml"></a>
 
 ```
-Type: "AWS::Inspector::AssessmentTemplate"
+Type: AWS::Inspector::AssessmentTemplate
 Properties:
   [AssessmentTargetArn](#cfn-inspector-assessmenttemplate-assessmenttargetarn): String
   [DurationInSeconds](#cfn-inspector-assessmenttemplate-durationinseconds): Integer
@@ -124,5 +124,5 @@ myassessmenttemplate:
       - 
         Key: Example
         Value: example
-  Type: "AWS::Inspector::AssessmentTemplate"
+  Type: AWS::Inspector::AssessmentTemplate
 ```

--- a/doc_source/aws-resource-inspector-resourcegroup.md
+++ b/doc_source/aws-resource-inspector-resourcegroup.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-inspector-resourcegroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::Inspector::ResourceGroup"
+Type: AWS::Inspector::ResourceGroup
 Properties:
   [ResourceGroupTags](#cfn-inspector-resourcegroup-resourcegrouptags): 
     - Resource Tag
@@ -77,7 +77,7 @@ The following example shows how to declare an AWS::Inspector::ResourceGroup reso
 
 ```
 myresourcegroup: 
-  Type: "AWS::Inspector::ResourceGroup"
+  Type: AWS::Inspector::ResourceGroup
   Properties: 
     ResourceGroupTags : 
 	  -

--- a/doc_source/aws-resource-iot-certificate.md
+++ b/doc_source/aws-resource-iot-certificate.md
@@ -21,7 +21,7 @@ For information about working with X\.509 certificates, see [Authentication in A
 ### YAML<a name="aws-resource-iot-certificate-syntax.yaml"></a>
 
 ```
-Type: "AWS::IoT::Certificate"
+Type: AWS::IoT::Certificate
   Properties:
     [CertificateSigningRequest](#cfn-iot-certificate-certificatesigningrequest): String
     [Status](#cfn-iot-certificate-status): String
@@ -116,7 +116,7 @@ The following example declares an X\.509 certificate and its status\.
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   MyCertificate: 
-    Type: "AWS::IoT::Certificate"
+    Type: AWS::IoT::Certificate
     Properties: 
       CertificateSigningRequest: 
         Ref: "CSRParameter"

--- a/doc_source/aws-resource-iot-policy.md
+++ b/doc_source/aws-resource-iot-policy.md
@@ -21,7 +21,7 @@ For information about working with AWS IoT policies, see [Authorization](http://
 ### YAML<a name="aws-resource-iot-policy-syntax.yaml"></a>
 
 ```
-Type: "AWS::IoT::Policy"
+Type: AWS::IoT::Policy
 Properties:
   [PolicyDocument](#cfn-iot-policy-policydocument): JSON object
   [PolicyName](#cfn-iot-policy-policyname): String
@@ -107,7 +107,7 @@ The following example declares an AWS IoT policy\.
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   MyPolicy: 
-    Type: "AWS::IoT::Policy"
+    Type: AWS::IoT::Policy
     Properties: 
       PolicyName: 
         Ref: "NameParameter"

--- a/doc_source/aws-resource-iot-policyprincipalattachment.md
+++ b/doc_source/aws-resource-iot-policyprincipalattachment.md
@@ -21,7 +21,7 @@ For information about working with AWS IoT policies and principals, see [Authori
 ### YAML<a name="aws-resource-iot-policyprincipalattachment-syntax.yaml"></a>
 
 ```
-Type: "AWS::IoT::PolicyPrincipalAttachment"
+Type: AWS::IoT::PolicyPrincipalAttachment
   Properties:
     [PolicyName](#cfn-iot-policyprincipalattachment-policyname): String
     [Principal](#cfn-iot-policyprincipalattachment-principal): String
@@ -75,7 +75,7 @@ The following example attaches a policy to a principal\.
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   MyPolicyPrincipalAttachment: 
-    Type: "AWS::IoT::PolicyPrincipalAttachment"
+    Type: AWS::IoT::PolicyPrincipalAttachment
     Properties: 
       PolicyName: 
         Ref: "NameParameter"

--- a/doc_source/aws-resource-iot-thing.md
+++ b/doc_source/aws-resource-iot-thing.md
@@ -21,7 +21,7 @@ For information about working with things, see [How AWS IoT Works](http://docs.a
 ### YAML<a name="aws-resource-iot-thing-syntax.yaml"></a>
 
 ```
-Type: "AWS::IoT::Thing"
+Type: AWS::IoT::Thing
 Properties:
   [AttributePayload](#cfn-iot-thing-attributepayload):
     [*AttributePayload*](aws-properties-iot-thing-attributepayload.md)
@@ -118,7 +118,7 @@ The following example declares a thing and the values of its attributes\.
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   MyThing: 
-    Type: "AWS::IoT::Thing"
+    Type: AWS::IoT::Thing
     Properties: 
       ThingName: 
         Ref: "NameParameter"

--- a/doc_source/aws-resource-iot-thingprincipalattachment.md
+++ b/doc_source/aws-resource-iot-thingprincipalattachment.md
@@ -23,7 +23,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-iot-thingprincipalattachment-syntax.yaml"></a>
 
 ```
-Type: "AWS::IoT::ThingPrincipalAttachment"
+Type: AWS::IoT::ThingPrincipalAttachment
 Properties:
   [Principal](#cfn-iot-thingprincipalattachment-principal): String
   [ThingName](#cfn-iot-thingprincipalattachment-thingname): String
@@ -77,7 +77,7 @@ The following example attaches a principal to a thing\.
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   MyThingPrincipalAttachment: 
-    Type: "AWS::IoT::ThingPrincipalAttachment"
+    Type: AWS::IoT::ThingPrincipalAttachment
     Properties: 
       ThingName: 
         Ref: "NameParameter"

--- a/doc_source/aws-resource-iot-topicrule.md
+++ b/doc_source/aws-resource-iot-topicrule.md
@@ -21,7 +21,7 @@ For information about working with AWS IoT rules, see [Rules for AWS IoT](http:/
 ### YAML<a name="aws-resource-iot-topicrule-syntax.yaml"></a>
 
 ```
-Type: "AWS::IoT::TopicRule"
+Type: AWS::IoT::TopicRule
 Properties:
   [RuleName](#cfn-iot-topicrule-rulename): String
   [TopicRulePayload](#cfn-iot-topicrule-topicrulepayload): TopicRulePayLoad
@@ -139,7 +139,7 @@ The following example declares an AWS IoT rule\.
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   MyTopicRule: 
-    Type: "AWS::IoT::TopicRule"
+    Type: AWS::IoT::TopicRule
     Properties: 
       RuleName: 
         Ref: "NameParameter"
@@ -158,10 +158,10 @@ Resources:
                   - "Arn"
               Key: "MyKey.txt"
   MyBucket: 
-    Type: "AWS::S3::Bucket"
+    Type: AWS::S3::Bucket
     Properties:
   MyRole: 
-    Type: "AWS::IAM::Role"
+    Type: AWS::IAM::Role
     Properties: 
       AssumeRolePolicyDocument: 
         Version: "2012-10-17"

--- a/doc_source/aws-resource-kinesis-stream.md
+++ b/doc_source/aws-resource-kinesis-stream.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-kinesis-stream-syntax.yaml"></a>
 
 ```
-Type: "AWS::Kinesis::Stream"
+Type: AWS::Kinesis::Stream
 Properties: 
   [Name](#cfn-kinesis-stream-name): String
   [RetentionPeriodHours](#cfn-kinesis-stream-retentionperiodhours): Integer

--- a/doc_source/aws-resource-kinesisanalytics-application.md
+++ b/doc_source/aws-resource-kinesisanalytics-application.md
@@ -23,7 +23,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-kinesisanalytics-application-syntax.yaml"></a>
 
 ```
-Type: "AWS::KinesisAnalytics::Application"
+Type: AWS::KinesisAnalytics::Application
 Properties:
   [ApplicationName](#cfn-kinesisanalytics-application-applicationname): String
   [ApplicationDescription](#cfn-kinesisanalytics-application-applicationdescription): String
@@ -71,7 +71,7 @@ The following example demonstrates how to create and configure a Kinesis Data An
 Description: "Sample KinesisAnalytics via CloudFormation"
 Resources:
   BasicApplication:
-    Type: "AWS::KinesisAnalytics::Application"
+    Type: AWS::KinesisAnalytics::Application
     Properties:
       ApplicationName: "sampleApplication"
       ApplicationDescription: "SampleApp"
@@ -92,11 +92,11 @@ Resources:
             ResourceARN: !GetAtt InputKinesisStream.Arn
             RoleARN: !GetAtt KinesisAnalyticsRole.Arn
   InputKinesisStream:
-    Type: "AWS::Kinesis::Stream"
+    Type: AWS::Kinesis::Stream
     Properties:
       ShardCount: 1
   KinesisAnalyticsRole:
-    Type: "AWS::IAM::Role"
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -115,7 +115,7 @@ Resources:
                 Action: "*"
                 Resource: "*"
   BasicApplicationOutputs:
-    Type: "AWS::KinesisAnalytics::ApplicationOutput"
+    Type: AWS::KinesisAnalytics::ApplicationOutput
     DependsOn: BasicApplication
     Properties:
       ApplicationName: !Ref BasicApplication
@@ -127,11 +127,11 @@ Resources:
           ResourceARN: !GetAtt OutputKinesisStream.Arn
           RoleARN: !GetAtt KinesisAnalyticsRole.Arn
   OutputKinesisStream:
-    Type: "AWS::Kinesis::Stream"
+    Type: AWS::Kinesis::Stream
     Properties:
       ShardCount: 1
   ApplicationReferenceDataSource:
-    Type: "AWS::KinesisAnalytics::ApplicationReferenceDataSource"
+    Type: AWS::KinesisAnalytics::ApplicationReferenceDataSource
     DependsOn: BasicApplicationOutputs
     Properties:
       ApplicationName: !Ref BasicApplication

--- a/doc_source/aws-resource-kinesisanalytics-applicationoutput.md
+++ b/doc_source/aws-resource-kinesisanalytics-applicationoutput.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-kinesisanalytics-applicationoutput-syntax.yaml"></a>
 
 ```
-Type: "AWS::KinesisAnalytics::ApplicationOutput"
+Type: AWS::KinesisAnalytics::ApplicationOutput
 Properties:
   [ApplicationName](#cfn-kinesisanalytics-applicationoutput-applicationname): String
   [Output](#cfn-kinesisanalytics-applicationoutput-output): 
@@ -56,7 +56,7 @@ The following example adds an `ApplicationOutput` resource to an Amazon Kinesis 
 #### YAML<a name="aws-resource-kinesisanalytics-applicationoutput-example1.yaml"></a>
 
 ```
-Type: "AWS::KinesisAnalytics::ApplicationOutput"
+Type: AWS::KinesisAnalytics::ApplicationOutput
     Properties:
       ApplicationName: !Ref BasicApplication
       Output:

--- a/doc_source/aws-resource-kinesisanalytics-applicationreferencedatasource.md
+++ b/doc_source/aws-resource-kinesisanalytics-applicationreferencedatasource.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-kinesisanalytics-applicationreferencedatasource-syntax.yaml"></a>
 
 ```
-Type: "AWS::KinesisAnalytics::ApplicationReferenceDataSource"
+Type: AWS::KinesisAnalytics::ApplicationReferenceDataSource
 Properties:
   [ApplicationName](#cfn-kinesisanalytics-applicationreferencedatasource-applicationname): String
   [ReferenceDataSource](#cfn-kinesisanalytics-applicationreferencedatasource-referencedatasource): 
@@ -57,7 +57,7 @@ The following example creates an `ApplicationReferenceDataSource` resource:
 
 ```
 ApplicationReferenceDataSource:
-    Type: "AWS::KinesisAnalytics::ApplicationReferenceDataSource"
+    Type: AWS::KinesisAnalytics::ApplicationReferenceDataSource
     Properties:
       ApplicationName: !Ref BasicApplication
       ReferenceDataSource:

--- a/doc_source/aws-resource-kinesisfirehose-deliverystream.md
+++ b/doc_source/aws-resource-kinesisfirehose-deliverystream.md
@@ -33,7 +33,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-kinesisfirehose-deliverystream-syntax.yaml"></a>
 
 ```
-Type: "AWS::KinesisFirehose::DeliveryStream"
+Type: AWS::KinesisFirehose::DeliveryStream
 Properties: 
   [DeliveryStreamName](#cfn-kinesisfirehose-deliverystream-deliverystreamname): String
   [DeliveryStreamType](#cfn-kinesisfirehose-deliverystream-deliverystreamtype): String
@@ -169,7 +169,7 @@ The following example creates a Kinesis Firehose delivery stream that delivers d
 
 ```
 ElasticSearchDeliveryStream: 
-  Type: "AWS::KinesisFirehose::DeliveryStream"
+  Type: AWS::KinesisFirehose::DeliveryStream
   Properties: 
     ElasticsearchDestinationConfiguration: 
       BufferingHints: 

--- a/doc_source/aws-resource-kms-alias.md
+++ b/doc_source/aws-resource-kms-alias.md
@@ -27,7 +27,7 @@ The `AWS::KMS::Alias` resource creates a display name for a customer master key 
 ### YAML<a name="aws-resource-kms-alias-syntax.yaml"></a>
 
 ```
-Type: "AWS::KMS::Alias"
+Type: AWS::KMS::Alias
 Properties:
   [AliasName](#cfn-kms-alias-aliasname): String
   [TargetKeyId](#cfn-kms-alias-targetkeyid): String

--- a/doc_source/aws-resource-kms-key.md
+++ b/doc_source/aws-resource-kms-key.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-kms-key-syntax.yaml"></a>
 
 ```
-Type: "AWS::KMS::Key"
+Type: AWS::KMS::Key
 Properties: 
   [Description](#cfn-kms-key-description): String
   [Enabled](#cfn-kms-key-enabled): Boolean
@@ -149,7 +149,7 @@ The following example creates a custom CMK, which permits the IAM user `Alice` t
 
 ```
 myKey: 
-  Type: "AWS::KMS::Key"
+  Type: AWS::KMS::Key
   Properties: 
     Description: "A sample key"
     KeyPolicy: 

--- a/doc_source/aws-resource-lambda-alias.md
+++ b/doc_source/aws-resource-lambda-alias.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-lambda-alias-syntax.yaml"></a>
 
 ```
-Type: "AWS::Lambda::Alias"
+Type: AWS::Lambda::Alias
 Properties:     
   [Description](#cfn-lambda-alias-description): String         
   [FunctionName](#cfn-lambda-alias-functionname): String
@@ -103,7 +103,7 @@ The following example creates an alias named `TestingForMyApp`\. The alias point
 
 ```
 AliasForMyApp: 
-  Type: "AWS::Lambda::Alias"
+  Type: AWS::Lambda::Alias
   Properties: 
     FunctionName: 
       Ref: "MyFunction"

--- a/doc_source/aws-resource-lambda-eventsourcemapping.md
+++ b/doc_source/aws-resource-lambda-eventsourcemapping.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-lambda-eventsourcemapping-syntax.yaml"></a>
 
 ```
-Type: "AWS::Lambda::EventSourceMapping"
+Type: AWS::Lambda::EventSourceMapping
 Properties: 
   [BatchSize](#cfn-lambda-eventsourcemapping-batchsize): Integer
   [Enabled](#cfn-lambda-eventsourcemapping-enabled): Boolean
@@ -100,7 +100,7 @@ The following example associates an Kinesis stream with a Lambda function\.
 
 ```
 EventSourceMapping: 
-  Type: "AWS::Lambda::EventSourceMapping"
+  Type: AWS::Lambda::EventSourceMapping
   Properties: 
     EventSourceArn: 
       Fn::Join: 

--- a/doc_source/aws-resource-lambda-function.md
+++ b/doc_source/aws-resource-lambda-function.md
@@ -41,7 +41,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-lambda-function-syntax.yaml"></a>
 
 ```
-Type: "AWS::Lambda::Function"
+Type: AWS::Lambda::Function
 Properties: 
   [Code](#cfn-lambda-function-code):
     Code
@@ -215,7 +215,7 @@ The following example uses a packaged file in an S3 bucket to create a Lambda fu
 
 ```
 AMIIDLookup: 
-  Type: "AWS::Lambda::Function"
+  Type: AWS::Lambda::Function
   Properties: 
     Handler: "index.handler"
     Role: 

--- a/doc_source/aws-resource-lambda-permission.md
+++ b/doc_source/aws-resource-lambda-permission.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-lambda-permission-syntax.yaml"></a>
 
 ```
-Type: "AWS::Lambda::Permission"
+Type: AWS::Lambda::Permission
 Properties: 
   [Action](#cfn-lambda-permission-action): String
   [EventSourceToken](#cfn-lambda-permission-eventsourcetoken): String

--- a/doc_source/aws-resource-lambda-version.md
+++ b/doc_source/aws-resource-lambda-version.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-lambda-version-syntax.yaml"></a>
 
 ```
-Type: "AWS::Lambda::Version"
+Type: AWS::Lambda::Version
 Properties:     
   [CodeSha256](#cfn-lambda-version-codesha256) : String
   [Description](#cfn-lambda-version-description) : String         
@@ -92,7 +92,7 @@ The following example publishes a new version of the `MyFunction` Lambda functio
 
 ```
 TestingNewFeature: 
-  Type: "AWS::Lambda::Version"
+  Type: AWS::Lambda::Version
   Properties: 
     FunctionName: 
       Ref: "MyFunction"

--- a/doc_source/aws-resource-logs-destination.md
+++ b/doc_source/aws-resource-logs-destination.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-logs-destination-syntax.yaml"></a>
 
 ```
-Type: "AWS::Logs::Destination"
+Type: AWS::Logs::Destination
 Properties: 
   [DestinationName](#cfn-logs-destination-destinationname): String
   [DestinationPolicy](#cfn-logs-destination-destinationpolicy): String
@@ -103,7 +103,7 @@ In the following example, the target stream \(`TestStream`\) can receive log eve
 
 ```
 DestinationWithName: 
-  Type: "AWS::Logs::Destination"
+  Type: AWS::Logs::Destination
   Properties: 
     DestinationName: "TestDestination"
     RoleArn: "arn:aws:iam::123456789012:role/LogKinesisRole"

--- a/doc_source/aws-resource-logs-loggroup.md
+++ b/doc_source/aws-resource-logs-loggroup.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-logs-loggroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::Logs::LogGroup"
+Type: AWS::Logs::LogGroup
 Properties: 
   [LogGroupName](#cfn-cwl-loggroup-loggroupname): String
   [RetentionInDays](#cfn-cwl-loggroup-retentionindays): Integer
@@ -87,7 +87,7 @@ The following example creates a CloudWatch Logs log group that retains events fo
 
 ```
 myLogGroup: 
-  Type: "AWS::Logs::LogGroup"
+  Type: AWS::Logs::LogGroup
   Properties: 
     RetentionInDays: 7
 ```

--- a/doc_source/aws-resource-logs-logstream.md
+++ b/doc_source/aws-resource-logs-logstream.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-logs-logstream-syntax.yaml"></a>
 
 ```
-Type: "AWS::Logs::LogStream"
+Type: AWS::Logs::LogStream
 Properties: 
   [LogGroupName](#cfn-logs-logstream-loggroupname): String
   [LogStreamName](#cfn-logs-logstream-logstreamname): String
@@ -77,7 +77,7 @@ The following example creates a CloudWatch Logs log stream named `MyAppLogStream
 
 ```
 LogStream: 
-  Type: "AWS::Logs::LogStream"
+  Type: AWS::Logs::LogStream
   Properties: 
     LogGroupName: "exampleLogGroup"
     LogStreamName: "MyAppLogStream"

--- a/doc_source/aws-resource-logs-metricfilter.md
+++ b/doc_source/aws-resource-logs-metricfilter.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-logs-metricfilter-syntax.yaml"></a>
 
 ```
-Type: "AWS::Logs::MetricFilter"
+Type: AWS::Logs::MetricFilter
 Properties: 
   [FilterPattern](#cfn-cwl-metricfilter-filterpattern): String
   [LogGroupName](#cfn-cwl-metricfilter-loggroupname): String
@@ -89,7 +89,7 @@ The following example sends a value of `1` to the `404Count` metric whenever the
 
 ```
 404MetricFilter: 
-  Type: "AWS::Logs::MetricFilter"
+  Type: AWS::Logs::MetricFilter
   Properties: 
     LogGroupName: 
       Ref: "myLogGroup"

--- a/doc_source/aws-resource-logs-subscriptionfilter.md
+++ b/doc_source/aws-resource-logs-subscriptionfilter.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-logs-subscriptionfilter-syntax.yaml"></a>
 
 ```
-Type: "AWS::Logs::SubscriptionFilter"
+Type: AWS::Logs::SubscriptionFilter
 Properties: 
   [DestinationArn](#cfn-cwl-subscriptionfilter-destinationarn): String
   [FilterPattern](#cfn-cwl-subscriptionfilter-filterpattern): String
@@ -93,7 +93,7 @@ The following example sends log events that are associated with the `Root` user 
 
 ```
 SubscriptionFilter: 
-  Type: "AWS::Logs::SubscriptionFilter"
+  Type: AWS::Logs::SubscriptionFilter
   Properties: 
     RoleArn: 
       Fn::GetAtt: 

--- a/doc_source/aws-resource-opsworks-app.md
+++ b/doc_source/aws-resource-opsworks-app.md
@@ -38,7 +38,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-opsworks-app-syntax.yaml"></a>
 
 ```
-Type: "AWS::OpsWorks::App"
+Type: AWS::OpsWorks::App
 Properties: 
   [AppSource](#cfn-opsworks-app-appsource):
     Source
@@ -174,7 +174,7 @@ The following snippet creates an AWS OpsWorks app that uses a PHP application in
 
 ```
 myApp: 
-  Type: "AWS::OpsWorks::App"
+  Type: AWS::OpsWorks::App
   Properties: 
     StackId: 
       Ref: "myStack"

--- a/doc_source/aws-resource-opsworks-elbattachment.md
+++ b/doc_source/aws-resource-opsworks-elbattachment.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-opsworks-elbattachment-syntax.yaml"></a>
 
 ```
-Type: "AWS::OpsWorks::ElasticLoadBalancerAttachment"
+Type: AWS::OpsWorks::ElasticLoadBalancerAttachment
 Properties: 
   [ElasticLoadBalancerName](#cfn-opsworks-elbattachment-elbname): String
   [LayerId](#cfn-opsworks-elbattachment-layerid): String
@@ -67,7 +67,7 @@ The following snippet specifies a load balancer attachment to an AWS OpsWorks la
 
 ```
 ELBAttachment: 
-  Type: "AWS::OpsWorks::ElasticLoadBalancerAttachment"
+  Type: AWS::OpsWorks::ElasticLoadBalancerAttachment
   Properties: 
     ElasticLoadBalancerName: 
       Ref: "ELB"

--- a/doc_source/aws-resource-opsworks-instance.md
+++ b/doc_source/aws-resource-opsworks-instance.md
@@ -47,7 +47,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-opsworks-instance-syntax.yaml"></a>
 
 ```
-Type: "AWS::OpsWorks::Instance"
+Type: AWS::OpsWorks::Instance
 Properties:
   [AgentVersion](#cfn-opsworks-instance-agentversion): String
   [AmiId](#cfn-opsworks-instance-amiid): String
@@ -281,7 +281,7 @@ The following example creates two AWS OpsWorks instances that are associated wit
 
 ```
 myInstance1: 
-  Type: "AWS::OpsWorks::Instance"
+  Type: AWS::OpsWorks::Instance
   Properties: 
     StackId: 
       Ref: "myStack"
@@ -290,7 +290,7 @@ myInstance1:
         Ref: "myLayer"
     InstanceType: "m1.small"
 myInstance2: 
-  Type: "AWS::OpsWorks::Instance"
+  Type: AWS::OpsWorks::Instance
   Properties: 
     StackId: 
       Ref: "myStack"
@@ -327,7 +327,7 @@ In the following example, the `DBInstance` instance is online for four hours fro
 
 ```
 DBInstance: 
-  Type: "AWS::OpsWorks::Instance"
+  Type: AWS::OpsWorks::Instance
   Properties: 
     AutoScalingType: "timer"
     StackId: 

--- a/doc_source/aws-resource-opsworks-layer.md
+++ b/doc_source/aws-resource-opsworks-layer.md
@@ -44,7 +44,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-opsworks-layer-syntax.yaml"></a>
 
 ```
-Type: "AWS::OpsWorks::Layer"
+Type: AWS::OpsWorks::Layer
 Properties:
   [Attributes](#cfn-opsworks-layer-attributes):
     String:String
@@ -229,7 +229,7 @@ The following snippet creates an AWS OpsWorks PHP layer that is associated with 
 
 ```
 myLayer: 
-  Type: "AWS::OpsWorks::Layer"
+  Type: AWS::OpsWorks::Layer
   DependsOn: "myApp"
   Properties: 
     StackId: 
@@ -287,7 +287,7 @@ The following snippet creates a load\-based automatic scaling AWS OpsWorks PHP l
 
 ```
 myLayer: 
-  Type: "AWS::OpsWorks::Layer"
+  Type: AWS::OpsWorks::Layer
   DependsOn: "myApp"
   Properties: 
     StackId: 

--- a/doc_source/aws-resource-opsworks-stack.md
+++ b/doc_source/aws-resource-opsworks-stack.md
@@ -51,7 +51,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-opsworks-stack-syntax.yaml"></a>
 
 ```
-Type: "AWS::OpsWorks::Stack"
+Type: AWS::OpsWorks::Stack
 Properties: 
   [AgentVersion](#cfn-opsworks-stack-agentversion): String
   [Attributes](#cfn-opsworks-stack-attributes):
@@ -281,7 +281,7 @@ The following snippet creates an AWS OpsWorks stack that uses the default servic
 
 ```
 myStack: 
-  Type: "AWS::OpsWorks::Stack"
+  Type: AWS::OpsWorks::Stack
   Properties: 
     Name: 
       Ref: "OpsWorksStackName"

--- a/doc_source/aws-resource-opsworks-userprofile.md
+++ b/doc_source/aws-resource-opsworks-userprofile.md
@@ -27,7 +27,7 @@ The `AWS::OpsWorks::UserProfile` resource configures SSH access for users who re
 ### YAML<a name="aws-resource-opsworks-userprofile-syntax.yaml"></a>
 
 ```
-Type: "AWS::OpsWorks::UserProfile"
+Type: AWS::OpsWorks::UserProfile
 Properties:
   [AllowSelfManagement](#cfn-opsworks-userprofile-allowselfmanagement): Boolean
   [IamUserArn](#cfn-opsworks-userprofile-iamuserarn): String

--- a/doc_source/aws-resource-opsworks-volume.md
+++ b/doc_source/aws-resource-opsworks-volume.md
@@ -27,7 +27,7 @@ The `AWS::OpsWorks::Volume` resource registers an Amazon Elastic Block Store \(A
 ### YAML<a name="aws-resource-opsworks-volume-syntax.yaml"></a>
 
 ```
-Type: "AWS::OpsWorks::Volume"
+Type: AWS::OpsWorks::Volume
 Properties:
   [Ec2VolumeId](#cfn-opsworks-volume-ec2volumeid): String
   [MountPoint](#cfn-opsworks-volume-mountpoint): String

--- a/doc_source/aws-resource-rds-dbcluster.md
+++ b/doc_source/aws-resource-rds-dbcluster.md
@@ -50,7 +50,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-rds-dbcluster-syntax.yaml"></a>
 
 ```
-Type: "AWS::RDS::DBCluster"
+Type: AWS::RDS::DBCluster
 Properties:
   [AvailabilityZones](#cfn-rds-dbcluster-availabilityzones):
     - String

--- a/doc_source/aws-resource-rds-dbclusterparametergroup.md
+++ b/doc_source/aws-resource-rds-dbclusterparametergroup.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-rds-dbclusterparametergroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::RDS::DBClusterParameterGroup"
+Type: AWS::RDS::DBClusterParameterGroup
 Properties: 
   [Description](#cfn-rds-dbclusterparametergroup-description): String
   [Family](#cfn-rds-dbclusterparametergroup-family): String
@@ -107,7 +107,7 @@ The following snippet creates a parameter group that sets the character set data
 
 ```
 RDSDBClusterParameterGroup: 
-  Type: "AWS::RDS::DBClusterParameterGroup"
+  Type: AWS::RDS::DBClusterParameterGroup
   Properties: 
     Parameters: 
       character_set_database: "utf32"

--- a/doc_source/aws-resource-rds-dbsubnet-group.md
+++ b/doc_source/aws-resource-rds-dbsubnet-group.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-rds-dbsubnetgroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::RDS::DBSubnetGroup"
+Type: AWS::RDS::DBSubnetGroup
 Properties: 
   [DBSubnetGroupDescription](#cfn-rds-dbsubnetgroup-dbsubnetgroupdescription): String
   [DBSubnetGroupName](#cfn-rds-dbsubnetgroup-dbsubnetgroupname): String
@@ -101,7 +101,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 AWSTemplateFormatVersion: "2010-09-09"
 Resources: 
   myDBSubnetGroup: 
-    Type: "AWS::RDS::DBSubnetGroup"
+    Type: AWS::RDS::DBSubnetGroup
     Properties: 
       DBSubnetGroupDescription: "description"
       SubnetIds: 

--- a/doc_source/aws-resource-rds-eventsubscription.md
+++ b/doc_source/aws-resource-rds-eventsubscription.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-rds-eventsubscription-syntax.yaml"></a>
 
 ```
-Type: "AWS::RDS::EventSubscription"
+Type: AWS::RDS::EventSubscription
 Properties: 
   [Enabled](#cfn-rds-eventsubscription-enabled): Boolean
   [EventCategories](#cfn-rds-eventsubscription-eventcategories):
@@ -109,7 +109,7 @@ The following snippet creates an event subscription for an existing database ins
 
 ```
 myEventSubscription: 
-  Type: "AWS::RDS::EventSubscription"
+  Type: AWS::RDS::EventSubscription
   Properties: 
     EventCategories: 
       - "configuration change"

--- a/doc_source/aws-resource-rds-optiongroup.md
+++ b/doc_source/aws-resource-rds-optiongroup.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-rds-optiongroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::RDS::OptionGroup"
+Type: AWS::RDS::OptionGroup
 Properties: 
   [EngineName](#cfn-rds-optiongroup-enginename): String
   [MajorEngineVersion](#cfn-rds-optiongroup-majorengineversion): String
@@ -120,7 +120,7 @@ The following snippet creates an option group with two option configurations \(`
 
 ```
 OracleOptionGroup: 
-  Type: "AWS::RDS::OptionGroup"
+  Type: AWS::RDS::OptionGroup
   Properties: 
     EngineName: "oracle-ee"
     MajorEngineVersion: "12.1"

--- a/doc_source/aws-resource-rds-security-group-ingress.md
+++ b/doc_source/aws-resource-rds-security-group-ingress.md
@@ -33,7 +33,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-rds-dbsecuritygroupingress-syntax.yaml"></a>
 
 ```
-Type: "AWS::RDS::DBSecurityGroupIngress"
+Type: AWS::RDS::DBSecurityGroupIngress
 Properties:  
   [CIDRIP](#cfn-rds-securitygroup-ingress-cidrip): String
   [DBSecurityGroupName](#cfn-rds-securitygroup-ingress-dbsecuritygroupname): String

--- a/doc_source/aws-resource-redshift-cluster.md
+++ b/doc_source/aws-resource-redshift-cluster.md
@@ -55,7 +55,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-redshift-cluster-syntax.yaml"></a>
 
 ```
-Type: "AWS::Redshift::Cluster"
+Type: AWS::Redshift::Cluster
 Properties: 
   [AllowVersionUpgrade](#cfn-redshift-cluster-allowversionupgrade): Boolean
   [AutomatedSnapshotRetentionPeriod](#cfn-redshift-cluster-automatedsnapshotretentionperiod): Integer
@@ -327,7 +327,7 @@ The following example describes a single\-node Amazon Redshift cluster\. The mas
 
 ```
 myCluster: 
-  Type: "AWS::Redshift::Cluster"
+  Type: AWS::Redshift::Cluster
   Properties:
     DBName: "mydb"
     MasterUsername: "master"

--- a/doc_source/aws-resource-redshift-clusterparametergroup.md
+++ b/doc_source/aws-resource-redshift-clusterparametergroup.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-redshift-clusterparametergroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::Redshift::ClusterParameterGroup"
+Type: AWS::Redshift::ClusterParameterGroup
 Properties: 
   [Description](#cfn-redshift-clusterparametergroup-description): String
   [ParameterGroupFamily](#cfn-redshift-clusterparametergroup-parametergroupfamily): String
@@ -105,7 +105,7 @@ The following example describes a parameter group with one parameter that is spe
 
 ```
 myClusterParameterGroup: 
-  Type: "AWS::Redshift::ClusterParameterGroup"
+  Type: AWS::Redshift::ClusterParameterGroup
   Properties: 
     Description: "My parameter group"
     ParameterGroupFamily: "redshift-1.0"
@@ -145,7 +145,7 @@ The following example modifies the workload management configuration using the `
 
 ```
 RedshiftClusterParameterGroup: 
-  Type: "AWS::Redshift::ClusterParameterGroup"
+  Type: AWS::Redshift::ClusterParameterGroup
   Properties: 
     Description: "Cluster parameter group"
     ParameterGroupFamily: "redshift-1.0"

--- a/doc_source/aws-resource-redshift-clustersecuritygroup.md
+++ b/doc_source/aws-resource-redshift-clustersecuritygroup.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-redshift-clustersecuritygroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::Redshift::ClusterSecurityGroup"
+Type: AWS::Redshift::ClusterSecurityGroup
 Properties: 
   [Description](#cfn-redshift-clustersecuritygroup-description): String
   [Tags](#cfn-redshift-clustersecuritygroup-tags):
@@ -88,7 +88,7 @@ The following example creates an Amazon Redshift cluster security group that you
 
 ```
 myClusterSecurityGroup: 
-  Type: "AWS::Redshift::ClusterSecurityGroup"
+  Type: AWS::Redshift::ClusterSecurityGroup
   Properties: 
     Description: "Security group to determine where connections to the Amazon Redshift cluster can come from"
     Tags:

--- a/doc_source/aws-resource-redshift-clustersecuritygroupingress.md
+++ b/doc_source/aws-resource-redshift-clustersecuritygroupingress.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-redshift-clustersecuritygroupingress-syntax.yaml"></a>
 
 ```
-Type: "AWS::Redshift::ClusterSecurityGroupIngress"
+Type: AWS::Redshift::ClusterSecurityGroupIngress
 Properties: 
   [ClusterSecurityGroupName](#cfn-redshift-clustersecuritygroupingress-clustersecuritygroupname): String
   [CIDRIP](#cfn-redshift-clustersecuritygroupingress-cidrip): String
@@ -83,7 +83,7 @@ The following snippet describes a ingress rules for an Amazon Redshift cluster s
 
 ```
 myClusterSecurityGroupIngressIP: 
-  Type: "AWS::Redshift::ClusterSecurityGroupIngress"
+  Type: AWS::Redshift::ClusterSecurityGroupIngress
   Properties: 
     ClusterSecurityGroupName: 
       Ref: "myClusterSecurityGroup"

--- a/doc_source/aws-resource-redshift-clustersubnetgroup.md
+++ b/doc_source/aws-resource-redshift-clustersubnetgroup.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-redshift-clustersubnetgroup-syntax.yaml"></a>
 
 ```
-Type: "AWS::Redshift::ClusterSubnetGroup"
+Type: AWS::Redshift::ClusterSubnetGroup
 Properties: 
   [Description](#cfn-redshift-clustersubnetgroup-description): String
   [SubnetIds](#cfn-redshift-clustersubnetgroup-subnetids):

--- a/doc_source/aws-resource-route53-healthcheck.md
+++ b/doc_source/aws-resource-route53-healthcheck.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-route53-healthcheck-syntax.yaml"></a>
 
 ```
-Type: "AWS::Route53::HealthCheck"
+Type: AWS::Route53::HealthCheck
 Properties: 
   [HealthCheckConfig](#cfn-route53-healthcheck-healthcheckconfig):
     HealthCheckConfig
@@ -92,7 +92,7 @@ The following example creates an Amazon Route 53 health check that sends reques
 
 ```
 myHealthCheck: 
-  Type: "AWS::Route53::HealthCheck"
+  Type: AWS::Route53::HealthCheck
   Properties: 
     HealthCheckConfig: 
       IPAddress: "000.000.000.000"

--- a/doc_source/aws-resource-route53-hostedzone.md
+++ b/doc_source/aws-resource-route53-hostedzone.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-route53-hostedzone-syntax.yaml"></a>
 
 ```
-Type: "AWS::Route53::HostedZone"
+Type: AWS::Route53::HostedZone
 Properties: 
   [HostedZoneConfig](#cfn-route53-hostedzone-hostedzoneconfig):
     HostedZoneConfig
@@ -136,7 +136,7 @@ The following template snippet creates a private hosted zone for the `example.co
 
 ```
 DNS: 
-  Type: "AWS::Route53::HostedZone"
+  Type: AWS::Route53::HostedZone
   Properties: 
     HostedZoneConfig: 
       Comment: "My hosted zone for example.com"

--- a/doc_source/aws-resource-servicediscovery-instance.md
+++ b/doc_source/aws-resource-servicediscovery-instance.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-servicediscovery-instance-syntax.yaml"></a>
 
 ```
-Type: "AWS::ServiceDiscovery::Instance"
+Type: AWS::ServiceDiscovery::Instance
 Properties:
   [InstanceAttributes](#cfn-servicediscovery-instance-instanceattributes): JSON object
   [InstanceId](#cfn-servicediscovery-instance-instanceid): String

--- a/doc_source/aws-resource-servicediscovery-privatednsnamespace.md
+++ b/doc_source/aws-resource-servicediscovery-privatednsnamespace.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-servicediscovery-privatednsnamespace-syntax.yaml"></a>
 
 ```
-Type: "AWS::ServiceDiscovery::PrivateDnsNamespace"
+Type: AWS::ServiceDiscovery::PrivateDnsNamespace
 Properties:
   [Description](#cfn-servicediscovery-privatednsnamespace-description): String
   [Vpc](#cfn-servicediscovery-privatednsnamespace-vpc): String

--- a/doc_source/aws-resource-servicediscovery-publicdnsnamespace.md
+++ b/doc_source/aws-resource-servicediscovery-publicdnsnamespace.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-servicediscovery-publicdnsnamespace-syntax.yaml"></a>
 
 ```
-Type: "AWS::ServiceDiscovery::PublicDnsNamespace"
+Type: AWS::ServiceDiscovery::PublicDnsNamespace
 Properties:
   [Description](#cfn-servicediscovery-publicdnsnamespace-description): String
   [Name](#cfn-servicediscovery-publicdnsnamespace-name): String

--- a/doc_source/aws-resource-servicediscovery-service.md
+++ b/doc_source/aws-resource-servicediscovery-service.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-servicediscovery-service-syntax.yaml"></a>
 
 ```
-Type: "AWS::ServiceDiscovery::Service"
+Type: AWS::ServiceDiscovery::Service
 Properties:
   [Description](#cfn-servicediscovery-service-description): String
   [DnsConfig](#cfn-servicediscovery-service-dnsconfig): 

--- a/doc_source/aws-resource-ses-configurationset.md
+++ b/doc_source/aws-resource-ses-configurationset.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ses-configurationset-syntax.yaml"></a>
 
 ```
-Type: "AWS::SES::ConfigurationSet"
+Type: AWS::SES::ConfigurationSet
 Properties:
   [Name](#cfn-ses-configurationset-name): String
 ```
@@ -83,7 +83,7 @@ Parameters:
     Type: String
 Resources:
   ConfigSet:
-    Type: "AWS::SES::ConfigurationSet"
+    Type: AWS::SES::ConfigurationSet
     Properties:
       Name: !Ref ConfigSetName
 ```

--- a/doc_source/aws-resource-ses-configurationseteventdestination.md
+++ b/doc_source/aws-resource-ses-configurationseteventdestination.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ses-configurationseteventdestination-syntax.yaml"></a>
 
 ```
-Type: "AWS::SES::ConfigurationSetEventDestination"
+Type: AWS::SES::ConfigurationSetEventDestination
 Properties:
   [ConfigurationSetName](#cfn-ses-configurationseteventdestination-configurationsetname): String
   [EventDestination](#cfn-ses-configurationseteventdestination-eventdestination): [*EventDestination*](aws-properties-ses-configurationseteventdestination-eventdestination.md)

--- a/doc_source/aws-resource-ses-receiptfilter.md
+++ b/doc_source/aws-resource-ses-receiptfilter.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ses-receiptfilter-syntax.yaml"></a>
 
 ```
-Type: "AWS::SES::ReceiptFilter"
+Type: AWS::SES::ReceiptFilter
 Properties:
   [Filter](#cfn-ses-receiptfilter-filter): [*Filter*](aws-properties-ses-receiptfilter-filter.md)
 ```

--- a/doc_source/aws-resource-ses-receiptrule.md
+++ b/doc_source/aws-resource-ses-receiptrule.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ses-receiptrule-syntax.yaml"></a>
 
 ```
-Type: "AWS::SES::ReceiptRule"
+Type: AWS::SES::ReceiptRule
 Properties:
   [After](#cfn-ses-receiptrule-after): String
   [Rule](#cfn-ses-receiptrule-rule): [*Rule*](aws-properties-ses-receiptrule-rule.md)
@@ -157,7 +157,7 @@ Parameters:
 
 Resources:
   ReceiptRule1:
-    Type: "AWS::SES::ReceiptRule"
+    Type: AWS::SES::ReceiptRule
     Properties:
       RuleSetName: !Ref RuleSetName
       Rule:
@@ -171,7 +171,7 @@ Resources:
               HeaderValue: !Ref HeaderValue
 
   ReceiptRule2:
-    Type: "AWS::SES::ReceiptRule"
+    Type: AWS::SES::ReceiptRule
     Properties:
       RuleSetName: !Ref RuleSetName
       After: !Ref ReceiptRule1

--- a/doc_source/aws-resource-ses-receiptruleset.md
+++ b/doc_source/aws-resource-ses-receiptruleset.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ses-receiptruleset-syntax.yaml"></a>
 
 ```
-Type: "AWS::SES::ReceiptRuleSet"
+Type: AWS::SES::ReceiptRuleSet
 Properties:
   [RuleSetName](#cfn-ses-receiptruleset-rulesetname): String
 ```

--- a/doc_source/aws-resource-ses-template.md
+++ b/doc_source/aws-resource-ses-template.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ses-template-syntax.yaml"></a>
 
 ```
-Type: "AWS::SES::Template"
+Type: AWS::SES::Template
 Properties:
   [Template](#cfn-ses-template-template): [*Template*](aws-properties-ses-template-template.md)
 ```

--- a/doc_source/aws-resource-sns-subscription.md
+++ b/doc_source/aws-resource-sns-subscription.md
@@ -25,7 +25,7 @@ The `AWS::SNS::Subscription` resource subscribes an endpoint to an Amazon Simple
 ### YAML<a name="aws-resource-sns-subscription-syntax.yaml"></a>
 
 ```
-Type: "AWS::SNS::Subscription"
+Type: AWS::SNS::Subscription
 Properties:
   [Endpoint](#cfn-sns-endpoint): String
   [Protocol](#cfn-sns-protocol): String

--- a/doc_source/aws-resource-ssm-association.md
+++ b/doc_source/aws-resource-ssm-association.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ssm-association-syntax.yaml"></a>
 
 ```
-Type: "AWS::SSM::Association"
+Type: AWS::SSM::Association
 Properties: 
   [AssociationName](#cfn-ssm-association-associationname): String
   [DocumentVersion](#cfn-ssm-association-documentationversion): String

--- a/doc_source/aws-resource-ssm-document.md
+++ b/doc_source/aws-resource-ssm-document.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ssm-document-syntax.yaml"></a>
 
 ```
-Type: "AWS::SSM::Document"
+Type: AWS::SSM::Document
 Properties: 
   [Content](#cfn-ssm-document-content): JSON object
   [DocumentType](#cfn-ssm-document-documenttype): String
@@ -115,7 +115,7 @@ The following SSM document joins instances to a directory in AWS Directory Servi
 
 ```
 document: 
-  Type: "AWS::SSM::Document"
+  Type: AWS::SSM::Document
   Properties: 
     Content: 
       schemaVersion: "1.2"
@@ -175,7 +175,7 @@ The following example shows how to associate the SSM document with an instance\.
 
 ```
 myEC2: 
-  Type: "AWS::EC2::Instance"
+  Type: AWS::EC2::Instance
   Properties: 
     ImageId: 
       Ref: "myImageId"

--- a/doc_source/aws-resource-ssm-maintenancewindow.md
+++ b/doc_source/aws-resource-ssm-maintenancewindow.md
@@ -25,7 +25,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ssm-maintenancewindow-syntax.yaml"></a>
 
 ```
-Type: "AWS::SSM::MaintenanceWindow"
+Type: AWS::SSM::MaintenanceWindow
 Properties:
   [Description](#cfn-ssm-maintenancewindow-description): String
   [AllowUnassociatedTargets](#cfn-ssm-maintenancewindow-allowunassociatedtargets): Boolean

--- a/doc_source/aws-resource-ssm-maintenancewindowtarget.md
+++ b/doc_source/aws-resource-ssm-maintenancewindowtarget.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ssm-maintenancewindowtarget-syntax.yaml"></a>
 
 ```
-Type: "AWS::SSM::MaintenanceWindowTarget"
+Type: AWS::SSM::MaintenanceWindowTarget
 Properties:
   [OwnerInformation](#cfn-ssm-maintenancewindowtarget-ownerinformation): String
   [Description](#cfn-ssm-maintenancewindowtarget-description): String

--- a/doc_source/aws-resource-ssm-maintenancewindowtask.md
+++ b/doc_source/aws-resource-ssm-maintenancewindowtask.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ssm-maintenancewindowtask-syntax.yaml"></a>
 
 ```
-Type: "AWS::SSM::MaintenanceWindowTask"
+Type: AWS::SSM::MaintenanceWindowTask
 Properties:
   [MaxErrors](#cfn-ssm-maintenancewindowtask-maxerrors): String
   [Description](#cfn-ssm-maintenancewindowtask-description): String

--- a/doc_source/aws-resource-ssm-parameter.md
+++ b/doc_source/aws-resource-ssm-parameter.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ssm-parameter-syntax.yaml"></a>
 
 ```
-Type: "AWS::SSM::Parameter"
+Type: AWS::SSM::Parameter
 Properties: 
   [Name](#cfn-ssm-parameter-name): String
   [Description](#cfn-ssm-parameter-description): String
@@ -124,7 +124,7 @@ The following example snippet creates an SSM parameter in the Parameter Store\.
 Description: "Create SSM Parameter"
 Resources:
   BasicParameter:
-    Type: "AWS::SSM::Parameter"
+    Type: AWS::SSM::Parameter
     Properties:
       Name: "command"
       Type: "String"
@@ -163,7 +163,7 @@ The following example creates an SSM parameter with a `StringList` type\.
 Description: "Create SSM Parameter"
 Resources:
   BasicParameter:
-    Type: "AWS::SSM::Parameter"
+    Type: AWS::SSM::Parameter
     Properties:
       Name: "commands"
       Type: "StringList"

--- a/doc_source/aws-resource-ssm-patchbaseline.md
+++ b/doc_source/aws-resource-ssm-patchbaseline.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-ssm-patchbaseline-syntax.yaml"></a>
 
 ```
-Type: "AWS::SSM::PatchBaseline"
+Type: AWS::SSM::PatchBaseline
 Properties:
   [OperatingSystem](#cfn-ssm-patchbaseline-operatingsystem): String
   [ApprovedPatches](#cfn-ssm-patchbaseline-approvedpatches): 

--- a/doc_source/aws-resource-stepfunctions-activity.md
+++ b/doc_source/aws-resource-stepfunctions-activity.md
@@ -20,7 +20,7 @@ For information about creating an activity and creating a state machine with an 
 ### YAML<a name="aws-resource-stepfunctions-activity-syntax.yaml"></a>
 
 ```
-Type: "AWS::StepFunctions::Activity"
+Type: AWS::StepFunctions::Activity
 Properties:
   [Name](#cfn-stepfunctions-activity-name): String
 ```
@@ -97,7 +97,7 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: "A sample template for a Step Functions activity"
 Resources: 
   MyActivity:
-    Type: "AWS::StepFunctions::Activity"
+    Type: AWS::StepFunctions::Activity
     Properties: 
       Name: myActivity
 ```

--- a/doc_source/aws-resource-stepfunctions-statemachine.md
+++ b/doc_source/aws-resource-stepfunctions-statemachine.md
@@ -22,7 +22,7 @@ For information about creating state machines, see [Tutorial: A Lambda State Mac
 ### YAML<a name="aws-resource-stepfunctions-statemachine-syntax-yaml"></a>
 
 ```
-Type: "AWS::StepFunctions::StateMachine"
+Type: AWS::StepFunctions::StateMachine
 Properties:
   [StateMachineName](#cfn-stepfunctions-statemachine-definitionname): String
   [DefinitionString](#cfn-stepfunctions-statemachine-definitionstring): String

--- a/doc_source/aws-resource-waf-bytematchset.md
+++ b/doc_source/aws-resource-waf-bytematchset.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-waf-bytematchset-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAF::ByteMatchSet"
+Type: AWS::WAF::ByteMatchSet
 Properties: 
   [ByteMatchTuples](#cfn-waf-bytematchset-bytematchtuples):
     - Byte match tuple
@@ -97,7 +97,7 @@ The following example defines a set of HTTP referers to match\.
 
 ```
 BadReferers: 
-  Type: "AWS::WAF::ByteMatchSet"
+  Type: AWS::WAF::ByteMatchSet
   Properties: 
     Name: "ByteMatch for matching bad HTTP referers"
     ByteMatchTuples: 
@@ -144,7 +144,7 @@ The following example associates the `BadReferers` byte match set with a web acc
 
 ```
 BadReferersRule: 
-  Type: "AWS::WAF::Rule"
+  Type: AWS::WAF::Rule
   Properties: 
     Name: "BadReferersRule"
     MetricName: "BadReferersRule"
@@ -188,7 +188,7 @@ The following example associates the `BadReferersRule` rule with a web ACL\. The
 
 ```
 MyWebACL: 
-  Type: "AWS::WAF::WebACL"
+  Type: AWS::WAF::WebACL
   Properties: 
     Name: "WebACL to block blacklisted IP addresses"
     DefaultAction: 

--- a/doc_source/aws-resource-waf-ipset.md
+++ b/doc_source/aws-resource-waf-ipset.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-waf-ipset-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAF::IPSet"
+Type: AWS::WAF::IPSet
 Properties: 
   [IPSetDescriptors](#cfn-waf-ipset-ipsetdescriptors):
     - IPSet descriptor
@@ -91,7 +91,7 @@ The following example defines a set of IP addresses for a web access control lis
 
 ```
 MyIPSetBlacklist: 
-  Type: "AWS::WAF::IPSet"
+  Type: AWS::WAF::IPSet
   Properties: 
     Name: "IPSet for blacklisted IP adresses"
     IPSetDescriptors: 
@@ -130,7 +130,7 @@ The following example associates the `MyIPSetBlacklist` IP Set with a web ACL ru
 
 ```
 MyIPSetRule: 
-  Type: "AWS::WAF::Rule"
+  Type: AWS::WAF::Rule
   Properties: 
     Name: "MyIPSetRule"
     MetricName: "MyIPSetRule"
@@ -174,7 +174,7 @@ The following example associates the `MyIPSetRule` rule with a web ACL\. The web
 
 ```
 MyWebACL: 
-  Type: "AWS::WAF::WebACL"
+  Type: AWS::WAF::WebACL
   Properties: 
     Name: "WebACL to block blacklisted IP addresses"
     DefaultAction: 

--- a/doc_source/aws-resource-waf-rule.md
+++ b/doc_source/aws-resource-waf-rule.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-waf-rule-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAF::Rule"
+Type: AWS::WAF::Rule
 Properties: 
   [MetricName](#cfn-waf-rule-metricname): String
   [Name](#cfn-waf-rule-name): String
@@ -95,7 +95,7 @@ The following example associates the `MyIPSetBlacklist` `IPSet` object with a we
 
 ```
 MyIPSetRule: 
-  Type: "AWS::WAF::Rule"
+  Type: AWS::WAF::Rule
   Properties: 
     Name: "MyIPSetRule"
     MetricName: "MyIPSetRule"

--- a/doc_source/aws-resource-waf-sizeconstraintset.md
+++ b/doc_source/aws-resource-waf-sizeconstraintset.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-waf-sizeconstraintset-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAF::SizeConstraintSet"
+Type: AWS::WAF::SizeConstraintSet
 Properties: 
   [Name](#cfn-waf-sizeconstraintset-name): String
   [SizeConstraints](#cfn-waf-sizeconstraintset-sizeconstraints):
@@ -89,7 +89,7 @@ The following example checks that the body of an HTTP request equals `4096` byte
 
 ```
   MySizeConstraint: 
-    Type: "AWS::WAF::SizeConstraintSet"
+    Type: AWS::WAF::SizeConstraintSet
     Properties: 
       Name: "SizeConstraints"
       SizeConstraints: 
@@ -128,7 +128,7 @@ The following example associates the `MySizeConstraint` object with a web ACL ru
 
 ```
 SizeConstraintRule: 
-  Type: "AWS::WAF::Rule"
+  Type: AWS::WAF::Rule
   Properties: 
     Name: "SizeConstraintRule"
     MetricName: "SizeConstraintRule"
@@ -172,7 +172,7 @@ The following example associates the `SizeConstraintRule` rule with a web ACL\. 
 
 ```
 MyWebACL: 
-  Type: "AWS::WAF::WebACL"
+  Type: AWS::WAF::WebACL
   Properties: 
     Name: "Web ACL to allow requests with a specific size"
     DefaultAction: 

--- a/doc_source/aws-resource-waf-sqlinjectionmatchset.md
+++ b/doc_source/aws-resource-waf-sqlinjectionmatchset.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-waf-sqlinjectionmatchset-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAF::SqlInjectionMatchSet"
+Type: AWS::WAF::SqlInjectionMatchSet
 Properties: 
   [Name](#cfn-waf-sqlinjectionmatchset-name): String
   [SqlInjectionMatchTuples](#cfn-waf-sqlinjectionmatchset-sqlinjectionmatchtuples):
@@ -85,7 +85,7 @@ The following example looks for snippets of SQL code in the query string of an H
 
 ```
 SqlInjDetection: 
-  Type: "AWS::WAF::SqlInjectionMatchSet"
+  Type: AWS::WAF::SqlInjectionMatchSet
   Properties: 
     Name: "Find SQL injections in the query string"
     SqlInjectionMatchTuples: 
@@ -122,7 +122,7 @@ The following example associates the `SqlInjDetection` match set with a web acce
 
 ```
 SqlInjRule: 
-  Type: "AWS::WAF::Rule"
+  Type: AWS::WAF::Rule
   Properties: 
     Name: "SqlInjRule"
     MetricName: "SqlInjRule"
@@ -166,7 +166,7 @@ The following example associates the `SqlInjRule` rule with a web ACL\. The web 
 
 ```
 MyWebACL: 
-  Type: "AWS::WAF::WebACL"
+  Type: AWS::WAF::WebACL
   Properties: 
     Name: "Web ACL to block SQL injection in the query string"
     DefaultAction: 

--- a/doc_source/aws-resource-waf-webacl.md
+++ b/doc_source/aws-resource-waf-webacl.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-waf-webacl-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAF::WebACL"
+Type: AWS::WAF::WebACL
 Properties: 
   [DefaultAction](#cfn-waf-webacl-defaultaction):
     Action
@@ -122,7 +122,7 @@ The following example defines a web ACL that allows, by default, any web request
 
 ```
 MyWebACL: 
-  Type: "AWS::WAF::WebACL"
+  Type: AWS::WAF::WebACL
   Properties: 
     Name: "WebACL to with three rules"
     DefaultAction: 
@@ -209,7 +209,7 @@ The follow example associates the `MyWebACL` web ACL with a CloudFront distribut
 
 ```
 myDistribution: 
-  Type: "AWS::CloudFront::Distribution"
+  Type: AWS::CloudFront::Distribution
   Properties: 
     DistributionConfig: 
       WebACLId: 

--- a/doc_source/aws-resource-waf-xssmatchset.md
+++ b/doc_source/aws-resource-waf-xssmatchset.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-waf-xssmatchset-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAF::XssMatchSet"
+Type: AWS::WAF::XssMatchSet
 Properties: 
   [Name](#cfn-waf-xssmatchset-name): String
   [XssMatchTuples](#cfn-waf-xssmatchset-xssmatchtuples):
@@ -91,7 +91,7 @@ The following example looks for cross\-site scripting in the URI or query string
 
 ```
 DetectXSS: 
-  Type: "AWS::WAF::XssMatchSet"
+  Type: AWS::WAF::XssMatchSet
   Properties: 
     Name: "XssMatchSet"
     XssMatchTuples: 
@@ -132,7 +132,7 @@ The following example associates the `DetectXSS` match set with a web access con
 
 ```
 XSSRule: 
-  Type: "AWS::WAF::Rule"
+  Type: AWS::WAF::Rule
   Properties: 
     Name: "XSSRule"
     MetricName: "XSSRule"
@@ -176,7 +176,7 @@ The following example associates the `XSSRule` rule with a web ACL\. The web ACL
 
 ```
 MyWebACL: 
-  Type: "AWS::WAF::WebACL"
+  Type: AWS::WAF::WebACL
   Properties: 
     Name: "Web ACL to block cross-site scripting"
     DefaultAction: 

--- a/doc_source/aws-resource-wafregional-bytematchset.md
+++ b/doc_source/aws-resource-wafregional-bytematchset.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-wafregional-bytematchset-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAFRegional::ByteMatchSet"
+Type: AWS::WAFRegional::ByteMatchSet
 Properties: 
   [ByteMatchTuples](#cfn-wafregional-bytematchset-bytematchtuples):
     - Byte match tuple
@@ -97,7 +97,7 @@ The following example defines a set of HTTP referers to match\.
 
 ```
 BadReferers: 
-  Type: "AWS::WAFRegional::ByteMatchSet"
+  Type: AWS::WAFRegional::ByteMatchSet
   Properties: 
     Name: "ByteMatch for matching bad HTTP referers"
     ByteMatchTuples: 
@@ -144,7 +144,7 @@ The following example associates the `BadReferers` byte match set with a web acc
 
 ```
 BadReferersRule: 
-  Type: "AWS::WAFRegional::Rule"
+  Type: AWS::WAFRegional::Rule
   Properties: 
     Name: "BadReferersRule"
     MetricName: "BadReferersRule"
@@ -188,7 +188,7 @@ The following example associates the `BadReferersRule` rule with a web ACL\. The
 
 ```
 MyWebACL: 
-  Type: "AWS::WAFRegional::WebACL"
+  Type: AWS::WAFRegional::WebACL
   Properties: 
     Name: "WebACL to block blacklisted IP addresses"
     DefaultAction: 

--- a/doc_source/aws-resource-wafregional-ipset.md
+++ b/doc_source/aws-resource-wafregional-ipset.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-wafregional-ipset-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAFRegional::IPSet"
+Type: AWS::WAFRegional::IPSet
 Properties: 
   [IPSetDescriptors](#cfn-wafregional-ipset-ipsetdescriptors):
     - IPSet descriptor
@@ -91,7 +91,7 @@ The following example defines a set of IP addresses for a web access control lis
 
 ```
 MyIPSetBlacklist: 
-  Type: "AWS::WAFRegional::IPSet"
+  Type: AWS::WAFRegional::IPSet
   Properties: 
     Name: "IPSet for blacklisted IP addresses"
     IPSetDescriptors: 
@@ -130,7 +130,7 @@ The following example associates the `MyIPSetBlacklist` IP Set with a web ACL ru
 
 ```
 MyIPSetRule: 
-  Type: "AWS::WAFRegional::Rule"
+  Type: AWS::WAFRegional::Rule
   Properties: 
     Name: "MyIPSetRule"
     MetricName: "MyIPSetRule"
@@ -174,7 +174,7 @@ The following example associates the `MyIPSetRule` rule with a web ACL\. The web
 
 ```
 MyWebACL: 
-  Type: "AWS::WAFRegional::WebACL"
+  Type: AWS::WAFRegional::WebACL
   Properties: 
     Name: "WebACL to block blacklisted IP addresses"
     DefaultAction: 

--- a/doc_source/aws-resource-wafregional-rule.md
+++ b/doc_source/aws-resource-wafregional-rule.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-wafregional-rule-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAFRegional::Rule"
+Type: AWS::WAFRegional::Rule
 Properties: 
   [MetricName](#cfn-wafregional-rule-metricname): String
   [Name](#cfn-wafregional-rule-name): String
@@ -95,7 +95,7 @@ The following example associates the `MyIPSetBlacklist` `IPSet` object with a we
 
 ```
 MyIPSetRule: 
-  Type: "AWS::WAFRegional::Rule"
+  Type: AWS::WAFRegional::Rule
   Properties: 
     Name: "MyIPSetRule"
     MetricName: "MyIPSetRule"

--- a/doc_source/aws-resource-wafregional-sizeconstraintset.md
+++ b/doc_source/aws-resource-wafregional-sizeconstraintset.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-wafregional-sizeconstraintset-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAFRegional::SizeConstraintSet"
+Type: AWS::WAFRegional::SizeConstraintSet
 Properties: 
   [Name](#cfn-wafregional-sizeconstraintset-name): String
   [SizeConstraints](#cfn-wafregional-sizeconstraintset-sizeconstraints):
@@ -89,7 +89,7 @@ The following example checks that the body of an HTTP request equals `4096` byte
 
 ```
   MySizeConstraint: 
-    Type: "AWS::WAFRegional::SizeConstraintSet"
+    Type: AWS::WAFRegional::SizeConstraintSet
     Properties: 
       Name: "SizeConstraints"
       SizeConstraints: 
@@ -128,7 +128,7 @@ The following example associates the `MySizeConstraint` object with a web ACL ru
 
 ```
 SizeConstraintRule: 
-  Type: "AWS::WAFRegional::Rule"
+  Type: AWS::WAFRegional::Rule
   Properties: 
     Name: "SizeConstraintRule"
     MetricName: "SizeConstraintRule"
@@ -172,7 +172,7 @@ The following example associates the `SizeConstraintRule` rule with a web ACL\. 
 
 ```
 MyWebACL: 
-  Type: "AWS::WAFRegional::WebACL"
+  Type: AWS::WAFRegional::WebACL
   Properties: 
     Name: "Web ACL to allow requests with a specific size"
     DefaultAction: 

--- a/doc_source/aws-resource-wafregional-sqlinjectionmatchset.md
+++ b/doc_source/aws-resource-wafregional-sqlinjectionmatchset.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-wafregional-sqlinjectionmatchset-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAFRegional::SqlInjectionMatchSet"
+Type: AWS::WAFRegional::SqlInjectionMatchSet
 Properties: 
   [Name](#cfn-wafregional-sqlinjectionmatchset-name): String
   [SqlInjectionMatchTuples](#cfn-wafregional-sqlinjectionmatchset-sqlinjectionmatchtuples):
@@ -85,7 +85,7 @@ The following example looks for snippets of SQL code in the query string of an H
 
 ```
 SqlInjDetection: 
-  Type: "AWS::WAFRegional::SqlInjectionMatchSet"
+  Type: AWS::WAFRegional::SqlInjectionMatchSet
   Properties: 
     Name: "Find SQL injections in the query string"
     SqlInjectionMatchTuples: 
@@ -122,7 +122,7 @@ The following example associates the `SqlInjDetection` match set with a web acce
 
 ```
 SqlInjRule: 
-  Type: "AWS::WAFRegional::Rule"
+  Type: AWS::WAFRegional::Rule
   Properties: 
     Name: "SqlInjRule"
     MetricName: "SqlInjRule"
@@ -166,7 +166,7 @@ The following example associates the `SqlInjRule` rule with a web ACL\. The web 
 
 ```
 MyWebACL: 
-  Type: "AWS::WAFRegional::WebACL"
+  Type: AWS::WAFRegional::WebACL
   Properties: 
     Name: "Web ACL to block SQL injection in the query string"
     DefaultAction: 

--- a/doc_source/aws-resource-wafregional-webacl.md
+++ b/doc_source/aws-resource-wafregional-webacl.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-wafregional-webacl-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAFRegional::WebACL"
+Type: AWS::WAFRegional::WebACL
 Properties: 
   [DefaultAction](#cfn-wafregional-webacl-defaultaction):
     Action
@@ -121,7 +121,7 @@ The following example defines a web ACL that allows, by default, any web request
 
 ```
 MyWebACL: 
-  Type: "AWS::WAFRegional::WebACL"
+  Type: AWS::WAFRegional::WebACL
   Properties: 
     Name: "WebACL to with three rules"
     DefaultAction: 
@@ -208,7 +208,7 @@ The follow example associates the `MyWebACL` web ACL with a CloudFront distribut
 
 ```
 myDistribution: 
-  Type: "AWS::CloudFront::Distribution"
+  Type: AWS::CloudFront::Distribution
   Properties: 
     DistributionConfig: 
       WebACLId: 

--- a/doc_source/aws-resource-wafregional-webaclassociation.md
+++ b/doc_source/aws-resource-wafregional-webaclassociation.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-wafregional-webaclassociation-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAFRegional::WebACLAssociation"
+Type: AWS::WAFRegional::WebACLAssociation
 Properties: 
   [ResourceArn](#cfn-wafregional-webaclassociation-resourcearn): String
   [WebACLId](#cfn-wafregional-webaclassociation-webaclid): String
@@ -71,7 +71,7 @@ The following example associates an Application load balancer resource with a we
 
 ```
 MyWebACLAssociation:
-  Type: "AWS::WAFRegional::WebACLAssociation"
+  Type: AWS::WAFRegional::WebACLAssociation
   Properties:
     ResourceArn:
       Ref: MyLoadBalancer

--- a/doc_source/aws-resource-wafregional-xssmatchset.md
+++ b/doc_source/aws-resource-wafregional-xssmatchset.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-wafregional-xssmatchset-syntax.yaml"></a>
 
 ```
-Type: "AWS::WAFRegional::XssMatchSet"
+Type: AWS::WAFRegional::XssMatchSet
 Properties: 
   [Name](#cfn-wafregional-xssmatchset-name): String
   [XssMatchTuples](#cfn-wafregional-xssmatchset-xssmatchtuples):
@@ -91,7 +91,7 @@ The following example looks for cross\-site scripting in the URI or query string
 
 ```
 DetectXSS: 
-  Type: "AWS::WAFRegional::XssMatchSet"
+  Type: AWS::WAFRegional::XssMatchSet
   Properties: 
     Name: "XssMatchSet"
     XssMatchTuples: 
@@ -132,7 +132,7 @@ The following example associates the `DetectXSS` match set with a web access con
 
 ```
 XSSRule: 
-  Type: "AWS::WAFRegional::Rule"
+  Type: AWS::WAFRegional::Rule
   Properties: 
     Name: "XSSRule"
     MetricName: "XSSRule"
@@ -176,7 +176,7 @@ The following example associates the `XSSRule` rule with a web ACL\. The web ACL
 
 ```
 MyWebACL: 
-  Type: "AWS::WAFRegional::WebACL"
+  Type: AWS::WAFRegional::WebACL
   Properties: 
     Name: "Web ACL to block cross-site scripting"
     DefaultAction: 

--- a/doc_source/aws-resource-workspaces-workspace.md
+++ b/doc_source/aws-resource-workspaces-workspace.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-workspaces-workspace-syntax.yaml"></a>
 
 ```
-Type: "AWS::WorkSpaces::Workspace"
+Type: AWS::WorkSpaces::Workspace
 Properties: 
   [BundleId](#cfn-workspaces-workspace-bundleid): String
   [DirectoryId](#cfn-workspaces-workspace-directoryid): String
@@ -110,7 +110,7 @@ The following example creates a workspace for user `test`\. The bundle and direc
 
 ```
 workspace1: 
-  Type: "AWS::WorkSpaces::Workspace"
+  Type: AWS::WorkSpaces::Workspace
   Properties: 
     BundleId: 
       Ref: "BundleId"

--- a/doc_source/cfn-hup.md
+++ b/doc_source/cfn-hup.md
@@ -112,7 +112,7 @@ In the following template snippet, AWS CloudFormation triggers the `cfn-auto-rel
 ```
 ...
   LaunchConfig:
-    Type: "AWS::AutoScaling::LaunchConfiguration"
+    Type: AWS::AutoScaling::LaunchConfiguration
     Metadata:
       QBVersion: !Ref paramQBVersion
       AWS::CloudFormation::Init:

--- a/doc_source/cfn-whatis-concepts.md
+++ b/doc_source/cfn-whatis-concepts.md
@@ -50,7 +50,7 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: A sample template
 Resources:
   MyEC2Instance:
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Properties: 
       ImageId: "ami-2f726546"
       InstanceType: t1.micro
@@ -110,7 +110,7 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: A sample template
 Resources:
   MyEC2Instance:
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Properties: 
       ImageId: "ami-2f726546"
       InstanceType: t1.micro

--- a/doc_source/conditions-sample-templates.md
+++ b/doc_source/conditions-sample-templates.md
@@ -115,19 +115,19 @@ Conditions:
 
 Resources:
   EC2Instance:
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Properties:
       ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
       InstanceType: !If [CreateProdResources, c1.xlarge, !If [CreateDevResources, m1.large, m1.small]]    
   MountPoint:
-    Type: "AWS::EC2::VolumeAttachment"
+    Type: AWS::EC2::VolumeAttachment
     Condition: CreateProdResources
     Properties:
       InstanceId: !Ref EC2Instance
       VolumeId: !Ref NewVolume
       Device: /dev/sdh
   NewVolume:
-    Type: "AWS::EC2::Volume"
+    Type: AWS::EC2::Volume
     Condition: CreateProdResources
     Properties:
       Size: 100
@@ -246,7 +246,7 @@ Conditions:
   UseDBSnapshot: !Not [!Equals [!Ref DBSnapshotName, ""]]
 Resources: 
   MyDB: 
-    Type: "AWS::RDS::DBInstance"
+    Type: AWS::RDS::DBInstance
     Properties: 
       AllocatedStorage: 5
       DBInstanceClass: db.m1.small
@@ -257,7 +257,7 @@ Resources:
       DBParameterGroupName: !Ref MyRDSParamGroup
       DBSnapshotIdentifier: !If [UseDBSnapshot, !Ref DBSnapshotName, !Ref "AWS::NoValue"]
   MyRDSParamGroup: 
-    Type: "AWS::RDS::DBParameterGroup"
+    Type: AWS::RDS::DBParameterGroup
     Properties: 
       Family: MySQL5.5
       Description: CloudFormation Sample Database Parameter Group
@@ -350,12 +350,12 @@ Conditions:
   CreateNewSecurityGroup: !Equals [!Ref ExistingSecurityGroup, NONE
 Resources: 
   MyInstance: 
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Properties: 
       ImageId: "ami-1b814f72"
       SecurityGroups: !If [CreateNewSecurityGroup, !Ref NewSecurityGroup, !Ref ExistingSecurityGroup]
   NewSecurityGroup: 
-    Type: "AWS::EC2::SecurityGroup"
+    Type: AWS::EC2::SecurityGroup
     Condition: CreateNewSecurityGroup
     Properties: 
       GroupDescription: Enable HTTP access via port 80

--- a/doc_source/conditions-section-structure.md
+++ b/doc_source/conditions-section-structure.md
@@ -182,11 +182,11 @@ Conditions:
   CreateProdResources: !Equals [ !Ref EnvType, prod ]
 Resources: 
   EC2Instance: 
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Properties: 
       ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
   MountPoint: 
-    Type: "AWS::EC2::VolumeAttachment"
+    Type: AWS::EC2::VolumeAttachment
     Condition: CreateProdResources
     Properties: 
       InstanceId: 
@@ -195,7 +195,7 @@ Resources:
         !Ref NewVolume
       Device: /dev/sdh
   NewVolume: 
-    Type: "AWS::EC2::Volume"
+    Type: AWS::EC2::Volume
     Condition: CreateProdResources
     Properties: 
       Size: 100

--- a/doc_source/intrinsic-function-reference-conditions.md
+++ b/doc_source/intrinsic-function-reference-conditions.md
@@ -40,7 +40,7 @@ To conditionally create resources, resource properties, or outputs, you must ass
 
 ```
 NewVolume:
-  Type: "AWS::EC2::Volume"
+  Type: AWS::EC2::Volume
   Condition: CreateProdResources
   Properties: 
     Size: 100
@@ -71,7 +71,7 @@ For the `Fn::If` function, you only need to specify the condition name\. The fol
 
 ```
 NewVolume:
-  Type: "AWS::EC2::Volume"
+  Type: AWS::EC2::Volume
   Properties: 
     Size: 
       !If [CreateLargeSize, 100, 10]
@@ -333,7 +333,7 @@ The following snippet uses the `AWS::NoValue` pseudo parameter in an `Fn::If` fu
 
 ```
 MyDB:
-  Type: "AWS::RDS::DBInstance"
+  Type: AWS::RDS::DBInstance
   Properties: 
     AllocatedStorage: 5
     DBInstanceClass: db.m1.small

--- a/doc_source/intrinsic-function-reference-findinmap.md
+++ b/doc_source/intrinsic-function-reference-findinmap.md
@@ -107,7 +107,7 @@ Mappings:
       64: "ami-a003a8a1"
 Resources: 
   myEC2Instance: 
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Properties: 
       ImageId: !FindInMap [ RegionMap, !Ref "AWS::Region", 32 ]
       InstanceType: m1.small

--- a/doc_source/intrinsic-function-reference-getavailabilityzones.md
+++ b/doc_source/intrinsic-function-reference-getavailabilityzones.md
@@ -92,7 +92,7 @@ The following example uses `Fn::GetAZs` to specify a subnet's Availability Zone:
 
 ```
 mySubnet: 
-  Type: "AWS::EC2::Subnet"
+  Type: AWS::EC2::Subnet
   Properties: 
     VpcId: 
       !Ref VPC

--- a/doc_source/intrinsic-function-reference-ref.md
+++ b/doc_source/intrinsic-function-reference-ref.md
@@ -65,7 +65,7 @@ The following resource declaration for an Elastic IP address needs the instance 
 
 ```
 MyEIP:
-  Type: "AWS::EC2::EIP"
+  Type: AWS::EC2::EIP
   Properties:
     InstanceId: !Ref MyEC2Instance
 ```

--- a/doc_source/intrinsic-function-reference-select.md
+++ b/doc_source/intrinsic-function-reference-select.md
@@ -103,7 +103,7 @@ To specify one of the three CIDR blocks, use `Fn::Select` in the Resources secti
 
 ```
 Subnet0: 
-  Type: "AWS::EC2::Subnet"
+  Type: AWS::EC2::Subnet
   Properties: 
     VpcId: !Ref VPC
     CidrBlock: !Select [ 0, !Ref DbSubnetIpBlocks ]

--- a/doc_source/mappings-section-structure.md
+++ b/doc_source/mappings-section-structure.md
@@ -172,7 +172,7 @@ Mappings:
       "64": "ami-a003a8a1"
 Resources: 
   myEC2Instance: 
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Properties: 
       ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", 32]
       InstanceType: m1.small

--- a/doc_source/parameters-section-structure.md
+++ b/doc_source/parameters-section-structure.md
@@ -374,7 +374,7 @@ The following example declares two parameters with the types `AWS::EC2::KeyPair:
 Parameters: 
   myKeyPair: 
     Description: Amazon EC2 Key Pair
-    Type: "AWS::EC2::KeyPair::KeyName"
+    Type: AWS::EC2::KeyPair::KeyName
   mySubnetIDs: 
     Description: Subnet IDs
     Type: "List<AWS::EC2::Subnet::Id>"

--- a/doc_source/quickref-dynamodb.md
+++ b/doc_source/quickref-dynamodb.md
@@ -155,7 +155,7 @@ This example sets up Application Auto Scaling for a `AWS::DynamoDB::Table` resou
 ```
 Resources:
   DDBTable:
-    Type: "AWS::DynamoDB::Table"
+    Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
         -
@@ -190,7 +190,7 @@ Resources:
         ReadCapacityUnits: 5
         WriteCapacityUnits: 5
   WriteCapacityScalableTarget:
-    Type: "AWS::ApplicationAutoScaling::ScalableTarget"
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       MaxCapacity: 15
       MinCapacity: 5
@@ -202,7 +202,7 @@ Resources:
       ScalableDimension: dynamodb:table:WriteCapacityUnits
       ServiceNamespace: dynamodb
   ScalingRole:
-    Type: "AWS::IAM::Role"
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -233,7 +233,7 @@ Resources:
                   - "cloudwatch:DeleteAlarms"
                 Resource: "*"
   WriteScalingPolicy:
-    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: WriteAutoScalingPolicy
       PolicyType: TargetTrackingScaling

--- a/doc_source/resources-section-structure.md
+++ b/doc_source/resources-section-structure.md
@@ -59,7 +59,7 @@ Resource properties are additional options that you can specify for a resource\.
 ```
 Resources:
   MyEC2Instance:
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Properties:
       ImageId: "ami-2f726546"
 ```
@@ -133,7 +133,7 @@ The following example shows a resource declaration\. It defines two resources\. 
 ```
 Resources: 
   MyInstance: 
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Properties: 
       UserData: 
         "Fn::Base64":
@@ -142,6 +142,6 @@ Resources:
       AvailabilityZone: "us-east-1a"
       ImageId: "ami-20b65349"
   MyQueue: 
-    Type: "AWS::SQS::Queue"
+    Type: AWS::SQS::Queue
     Properties: {}
 ```

--- a/doc_source/template-formats.md
+++ b/doc_source/template-formats.md
@@ -14,7 +14,7 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: A sample template
 Resources:
   MyEC2Instance: #An inline comment
-    Type: "AWS::EC2::Instance"
+    Type: AWS::EC2::Instance
     Properties: 
       ImageId: "ami-2f726546" #Another comment -- This is a Linux AMI
       InstanceType: t1.micro


### PR DESCRIPTION
…in quotes.

*Issue #, if available:*

One of the great things about the YAML format is one does not have to spend so much time fussin' with commas, brackets, quotes, etc.  I've been using these samples a lot, and one thing I've noticed is all of the extra quotes on things like the CloudFormation type - they're not needed.  So I swept through and removed the double quotes enclosing the CloudFormation types from all of the YAML examples.  Sorry for the big PR, but I figure you all would want all the documentation to be consistent no matter what.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.