### PR TITLE
Update aws-resource-directoryservice-microsoftad.md

### DIFF
--- a/doc_source/aws-resource-directoryservice-microsoftad.md
+++ b/doc_source/aws-resource-directoryservice-microsoftad.md
@@ -1,6 +1,6 @@
 # AWS::DirectoryService::MicrosoftAD<a name="aws-resource-directoryservice-microsoftad"></a>
 
-The `AWS::DirectoryService::MicrosoftAD` resource creates a Microsoft Active Directory in AWS so that your directory users and groups can access the AWS Management Console and AWS applications using their existing credentials\. For more information, see [What Is AWS Directory Service?](http://docs.aws.amazon.com/directoryservice/latest/admin-guide/what_is.html) in the *AWS Directory Service Administration Guide*\.
+The `AWS::DirectoryService::MicrosoftAD` resource creates a Enterprise Edition Microsoft Active Directory in AWS so that your directory users and groups can access the AWS Management Console and AWS applications using their existing credentials\. For more information, see [What Is AWS Directory Service?](http://docs.aws.amazon.com/directoryservice/latest/admin-guide/what_is.html) in the *AWS Directory Service Administration Guide*\.
 
 
 + [Syntax](#aws-resource-directoryservice-microsoftad-syntax)


### PR DESCRIPTION
Changed "resource creates a Microsoft Active Directory in AWS" to "resource creates a Enterprise Edition Microsoft Active Directory in AWS" to show that CloudFormation currently only builds Enterprise Edition and not Standard Edition AD.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
