### PR TITLE
aws-resource-lambda-function: update lambda max memory value to 3008

### DIFF
--- a/doc_source/aws-resource-lambda-function.md
+++ b/doc_source/aws-resource-lambda-function.md
@@ -114,7 +114,7 @@ The Amazon Resource Name \(ARN\) of an AWS Key Management Service \(AWS KMS\) ke
 
 `MemorySize`  <a name="cfn-lambda-function-memorysize"></a>
 The amount of memory, in MB, that is allocated to your Lambda function\. Lambda uses this value to proportionally allocate the amount of CPU power\. For more information, see [Resource Model](http://docs.aws.amazon.com/lambda/latest/dg/resource-model.html) in the *AWS Lambda Developer Guide*\.  
-Your function use case determines your CPU and memory requirements\. For example, a database operation might need less memory than an image processing function\. You must specify a value that is greater than or equal to `128`, and it must be a multiple of 64\. You cannot specify a size larger than `1536`\. The default value is 128 MB\.  
+Your function use case determines your CPU and memory requirements\. For example, a database operation might need less memory than an image processing function\. You must specify a value that is greater than or equal to `128`, and it must be a multiple of 64\. You cannot specify a size larger than `3008`\. The default value is 128 MB\.  
 *Required: *No  
 *Type*: Integer  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 update lambda max memory value from 1536 to 3008

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
