### PR TITLE
Removed reference to non-existing "nested stacks" section

### DIFF
--- a/doc_source/using-cfn-nested-stacks.md
+++ b/doc_source/using-cfn-nested-stacks.md
@@ -44,4 +44,6 @@ Certain stack operations, such as stack updates, should be initiated from the ro
 
 1. Sign in to the AWS Management Console and open the AWS CloudFormation console at [https://console\.aws\.amazon\.com/cloudformation/](https://console.aws.amazon.com/cloudformation/)\. Click the name of the root stack whose nested stacks you want to view\.
 
-1. Expand the **Nested stacks** section\.
+1. Expand the **Resources** section\.
+
+1. Look for resources of type **AWS::CloudFormation::Stack**\.


### PR DESCRIPTION
Update to doc as there is no "Nested stacks" section on CloudFormation console

*Issue #, if available:*

*Description of changes:*
the mentioned section doesn't exist on the console, so we might change the documentation to reflect existing items

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
