### PR TITLE
Fix reference to Amazon Redshift in AWS::RDS::DBCluster

### DIFF
--- a/doc_source/aws-resource-rds-dbcluster.md
+++ b/doc_source/aws-resource-rds-dbcluster.md
@@ -221,7 +221,7 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 The connection endpoint for the DB cluster\. For example: `mystack-mydbcluster-1apw1j4phylrk.cg034hpkmmjt.``us-east-2``.rds.amazonaws.com`\.
 
 `Endpoint.Port`  
-The port number on which the Amazon Redshift cluster accepts connections\. For example: `5439`\.
+The port number on which the DB cluster accepts connections\. For example: `3306`\.
 
 `ReadEndpoint.Address`  
 The reader endpoint for the DB cluster\. For example: `mystack-mydbcluster-ro-1apw1j4phylrk.cg034hpkmmjt.``us-east-2``.rds.amazonaws.com`\.


### PR DESCRIPTION
*Description of changes:*
The _Return Values_ description for `Endpoint.Port` was referring to _Amazon Redshift_, but the documentation is intended for RDS DB clusters. This looks like a copy-paste issue. I've also updated the port to reflect the exemple of `AWS::RDS::DBInstance`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
