### PR TITLE
Fixed incorrect AlarmActions - value needs to be a list of strings.

### DIFF
--- a/doc_source/quickref-cloudwatch.md
+++ b/doc_source/quickref-cloudwatch.md
@@ -172,8 +172,7 @@ Resources:
       EvaluationPeriods: '15'
       ComparisonOperator: GreaterThanThreshold
       Threshold: '0'
-      AlarmActions: !Sub >
-        "arn:aws:automate:${AWS::Region}:ec2:recover"
+      AlarmActions: [ !Sub "arn:aws:automate:${AWS::Region}:ec2:recover" ]
       Dimensions:
       - Name: InstanceId
         Value:


### PR DESCRIPTION
Fixed incorrect AlarmActions - value needs to be a list of strings, was causing CloudFormation to fail.  Now the CFN template has no issues.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
