### PR TITLE
Update deploying.applications.md

### DIFF
--- a/doc_source/deploying.applications.md
+++ b/doc_source/deploying.applications.md
@@ -535,7 +535,7 @@ The following example adds a creation policy to the Amazon EC2 instance to ensur
 
 The creation policy attribute uses the ISO 8601 format to define a timeout period of 5 minutes\. And because you're waiting for just 1 instance to be configured, you only need to wait for one success signal, which is the default count\.
 
-In the `UserData` property, the template runs the cfn\-signal script to send a success signal with an exit code if all the services are configured and started successfully\. When you use the cfn\-signal script, you must include the stack ID or name and the logical ID of the resource that you want to signal\. If the configuration fails or if the timeout period is exceeded, cfn\-signal sends a failure signal that causes the resource creation to fail\.
+In the `UserData` property, the template runs the cfn\-signal script to send a success signal with an exit code if all the services are configured and started successfully\. When you use the cfn\-signal script, you must include the stack ID or name and the logical ID of the resource that you want to signal\. If the configuration fails, cfn\-signal sends a failure signal that causes the resource creation to fail\.  The resource creation also fails if the cfn\-signal is not received within the timeout period.
 
 The following example shows final complete template\. You can also view the template at the following location:
 


### PR DESCRIPTION
Clarify: cfn-signal doesn't send a signal if the timeout is exceeded.  Rather when the timeout is exceeded, the resource creation fails.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
