### PR TITLE
Corrects the Fn::GetCidr function name, and expands on the description of the parameters

### DIFF
--- a/doc_source/intrinsic-function-reference-getcidr.md
+++ b/doc_source/intrinsic-function-reference-getcidr.md
@@ -1,13 +1,13 @@
-# `Fn::GetCidr`<a name="intrinsic-function-reference-getcidr"></a>
+# `Fn::Cidr`<a name="intrinsic-function-reference-cidr"></a>
 
-The intrinsic function `Fn::GetCidr` returns the specified Cidr address block\.
+The intrinsic function `Fn::Cidr` returns an array of Cidr address blocks\. The number of Cidr blocks returned is dependent on the count parameter\.
 
 ## Declaration<a name="w3ab2c21c28c37b5"></a>
 
 ### JSON<a name="intrinsic-function-reference-getcidr-syntax.json"></a>
 
 ```
-{ "Fn::GetCidr" : [ipBlock, count, sizeMask]}
+{ "Fn::Cidr" : [ipBlock, count, sizeMask] }
 ```
 
 ### YAML<a name="intrinsic-function-reference-cidr-syntax.yaml"></a>
@@ -15,13 +15,13 @@ The intrinsic function `Fn::GetCidr` returns the specified Cidr address block\.
 Syntax for the full function name:
 
 ```
-Fn::GetCidr: [ ipBlock, count, sizeMask ] 
+Fn::Cidr: [ ipBlock, count, sizeMask ] 
 ```
 
 Syntax for the short form:
 
 ```
-!GetCidr [ ipBlock, count, sizeMask ]
+!Cidr [ ipBlock, count, sizeMask ]
 ```
 
 ## Parameters<a name="w3ab2c21c28c37b7"></a>
@@ -30,18 +30,20 @@ ipBlock
 The user\-specified default Cidr address block\.
 
 count  
-The number of subnets' Cidr block wanted\. Count can be 1 to 256\.
+The number of subnets to generate. Valid values for count are 1 to 256\.
 
 sizeMask  
-Optional\. The digit covered in the subnet\.
+Optional\. The number of host bits for the subnet\. For example, a sizeMask of "8" will create a subnet with a range of "/24".
+
 
 ## Return Value<a name="w3ab2c21c28c37b9"></a>
 
-The specified Cidr block\.
+An array of Cidr address blocks\.
+
 
 ## Supported Functions<a name="w3ab2c21c28c37c13"></a>
 
-You can use the following functions in a `Fn::GetCidr` function:
+You can use the following functions in a `Fn::Cidr` function:
 
 + `[`Fn::Select`](intrinsic-function-reference-select.md)` 
 

--- a/doc_source/intrinsic-function-reference-getcidr.md
+++ b/doc_source/intrinsic-function-reference-getcidr.md
@@ -33,7 +33,7 @@ count
 The number of subnets to generate. Valid values for count are 1 to 256\.
 
 sizeMask  
-Optional\. The number of host bits for the subnet\. For example, a sizeMask of "8" will create a subnet with a range of "/24".
+The number of host bits for the subnet\. For example, a sizeMask of "8" will create a subnet with a range of "/24".
 
 
 ## Return Value<a name="w3ab2c21c28c37b9"></a>


### PR DESCRIPTION
*Description of changes:*

The actual name of this function is "Fn::Cidr" not "Fn::GetCidr". Additionally, the description of some of the parameters are quite confusing (particularly sizeMask). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
