### PR TITLE
Moving Type above Properties in example YAML

### DIFF
--- a/doc_source/aws-resource-inspector-assessmenttemplate.md
+++ b/doc_source/aws-resource-inspector-assessmenttemplate.md
@@ -114,6 +114,7 @@ The following example shows how to declare an AWS::Inspector::AssessmentTemplate
 
 ```
 myassessmenttemplate: 
+  Type: "AWS::Inspector::AssessmentTemplate"
   Properties: 
     AssessmentTargetArn: "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX"
     AssessmentTemplateName: MyAssessmentTemplate
@@ -124,5 +125,4 @@ myassessmenttemplate:
       - 
         Key: Example
         Value: example
-  Type: "AWS::Inspector::AssessmentTemplate"
 ```


### PR DESCRIPTION
Pretty much all example CloudFormation YAML has the order Resource Name -> Type -> Properties, updating the example to match this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
