### PR TITLE
Fix indentation in example YAML.

### DIFF
--- a/doc_source/aws-resource-inspector-resourcegroup.md
+++ b/doc_source/aws-resource-inspector-resourcegroup.md
@@ -80,7 +80,7 @@ myresourcegroup:
   Type: "AWS::Inspector::ResourceGroup"
   Properties: 
     ResourceGroupTags : 
-	  -
+      -
         Key: "Name"
         Value": "example"
 ```


### PR DESCRIPTION
The list indicator (-) was indented with a tab rather than spaces in the example YAML which was making the indentation incorrect.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
