### PR TITLE
Update YAML example for AWS::Lambda::Function

### DIFF
--- a/doc_source/aws-resource-lambda-function.md
+++ b/doc_source/aws-resource-lambda-function.md
@@ -226,7 +226,7 @@ AMIIDLookup:
       S3Bucket: "lambda-functions"
       S3Key: "amilookup.zip"
     Runtime: "nodejs4.3"
-    Timeout: "25"
+    Timeout: 25
     TracingConfig:
       Mode: "Active"
 ```


### PR DESCRIPTION
The Timeout property needs to be expressed as an integer (not a string).

*Issue #, if available:* 
Currently, the documentation's YAML syntax is incorrect regarding the Timeout property of the AWS::Lambda::Function type. If you were to copy / paste the YAML example and try to execute it you would receive errors on the Timeout property. The documentation even makes mention that this is to be expressed as an integer and not a string.

*Description of changes:*
Removed the double-quotes ("") surrounding the Timeout property in the example code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
