### PR TITLE
Correcting inconsistent Update Behavior for DynamoDB SSESpecification

### DIFF
--- a/doc_source/aws-resource-dynamodb-table.md
+++ b/doc_source/aws-resource-dynamodb-table.md
@@ -116,7 +116,7 @@ Throughput for the specified table, which consists of values for `ReadCapacityUn
 Specifies the settings to enable server\-side encryption\.  
 *Required: *No  
 *Type*: [DynamoDB SSESpecification](aws-properties-dynamodb-table-ssespecification.md)  
-*Update requires*: [Some interruptions](using-cfn-updating-stacks-update-behaviors.md#update-some-interrupt)
+*Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement)
 
 `StreamSpecification`  <a name="cfn-dynamodb-table-streamspecification"></a>
 The settings for the DynamoDB table stream, which capture changes to items stored in the table\.  


### PR DESCRIPTION
… on different pages

The only property of DynamoDB SSESpecification says update will require replacement here:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html

*Issue #, if available:*

 https://github.com/awsdocs/aws-cloudformation-user-guide/issues/41

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
