### PR TITLE
Clarify example security group description

### DIFF
--- a/doc_source/aws-properties-ec2-security-group-rule.md
+++ b/doc_source/aws-properties-ec2-security-group-rule.md
@@ -225,7 +225,7 @@ This snippet grants SSH access with CidrIp, and HTTP access with `SourceSecurity
 "InstanceSecurityGroup" : {
    "Type" : "AWS::EC2::SecurityGroup",
    "Properties" : {
-      "GroupDescription" : "Enable SSH access and HTTP from the load balancer only",
+      "GroupDescription" : "Allow SSH access from all IP addresses and HTTP from the load balancer only",
       "SecurityGroupIngress" : [ {
          "IpProtocol" : "tcp",
          "FromPort" : 22,
@@ -272,7 +272,7 @@ ElasticLoadBalancer:
 InstanceSecurityGroup: 
   Type: "AWS::EC2::SecurityGroup"
   Properties: 
-    GroupDescription: "Enable SSH access and HTTP from the load balancer only"
+    GroupDescription: "Allow SSH access from all IP addresses and HTTP from the load balancer only"
     SecurityGroupIngress: 
       - 
         IpProtocol: "tcp"


### PR DESCRIPTION
The form "Enable SSH access and HTTP from the load balancer only" can easily be understood in the way that ssh is only open from the load balancer while it is open to the world.

I suggest : "Allow SSH access from all IP addresses and HTTP from the load balancer only" which also has the benefit to resemble the EC2 console launch wizard warning "Rules with source of 0.0.0.0/0 allow all IP addresses to access your instance"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
