### PR TITLE
Capitalize Key and Value in Example

### DIFF
--- a/doc_source/aws-resource-inspector-resourcegroup.md
+++ b/doc_source/aws-resource-inspector-resourcegroup.md
@@ -65,8 +65,8 @@ The following example shows how to declare an AWS::Inspector::ResourceGroup reso
         "Properties": {
             "ResourceGroupTags": [
                 {
-                    "key": "Name",
-                    "value": "example"
+                    "Key": "Name",
+                    "Value": "example"
                 }
             ]
         }


### PR DESCRIPTION
The attributes "Key" and "Value" need to be capitalized in the JSON example.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
