### PR TITLE
Replace short resource ID with long resource ID

### DIFF
--- a/doc_source/aws-properties-ec2-instance.md
+++ b/doc_source/aws-properties-ec2-instance.md
@@ -340,7 +340,7 @@ Reserved\.
 
 ### Ref<a name="aws-properties-ec2-instance-ref"></a>
 
-When you pass the logical ID of an AWS::EC2::Instance object to the intrinsic `Ref` function, the object's InstanceId is returned\. For example: `i-636be302`\.
+When you pass the logical ID of an AWS::EC2::Instance object to the intrinsic `Ref` function, the object's InstanceId is returned\. For example: `i-636be3023efb7fe52`\.
 
 For more information about using the `Ref` function, see [Ref](intrinsic-function-reference-ref.md)\.
 


### PR DESCRIPTION
Since there is no short resource ids for ec2 anymore they should not
be uses in docs as well.

*Issue #, if available:*

*Description of changes:*

See: https://aws.amazon.com/ec2/faqs/#longer-ids

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
