### PR TITLE
Fix YAML syntax example

### DIFF
--- a/doc_source/aws-properties-codedeploy-deploymentgroup-deploymentstyle.md
+++ b/doc_source/aws-properties-codedeploy-deploymentgroup-deploymentstyle.md
@@ -21,7 +21,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 ```
 [DeploymentOption](#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption): String
-  [DeploymentType](#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype): String
+[DeploymentType](#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype): String
 ```
 
 ## Properties<a name="aws-properties-codedeploy-deploymentgroup-deploymentstyle-properties"></a>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix the YAML example for this page. It currently looks like:

```yaml
DeploymentOption: String
  DeploymentType: String
```

And it should look like:

```yaml
DeploymentOption: String
DeploymentType: String
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
