### PR TITLE
Tag key/value names must be capitalized

### DIFF
--- a/doc_source/aws-resource-inspector-resourcegroup.md
+++ b/doc_source/aws-resource-inspector-resourcegroup.md
@@ -65,8 +65,8 @@ The following example shows how to declare an AWS::Inspector::ResourceGroup reso
         "Properties": {
             "ResourceGroupTags": [
                 {
-                    "key": "Name",
-                    "value": "example"
+                    "Key": "Name",
+                    "Value": "example"
                 }
             ]
         }


### PR DESCRIPTION
*Description of changes:*

"Key" and "Value" must be capitalized when creating an AWS::Inspector::ResourceGroup.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
