### PR TITLE
ReceiptRuleSet has Return Values provided with Ref

### DIFF
--- a/doc_source/aws-resource-ses-receiptruleset.md
+++ b/doc_source/aws-resource-ses-receiptruleset.md
@@ -5,6 +5,7 @@ The `AWS::SES::ReceiptRuleSet` resource specifies an empty rule set for Amazon S
 
 + [Syntax](#aws-resource-ses-receiptruleset-syntax)
 + [Properties](#aws-resource-ses-receiptruleset-properties)
++ [Return Values](#aws-resource-ses-receiptruleset-returnvalues)
 + [Example](#aws-resource-ses-receiptruleset-examples)
 + [See Also](#aws-resource-ses-receiptruleset-seealso)
 
@@ -44,6 +45,14 @@ The name of the rule set to create\. The name must:
  *Required*: No  
  *Type*: String  
  *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement) 
+
+## Return Values<a name="aws-resource-ses-receiptruleset-returnvalues">
+
+## Ref
+
+When the logical ID of this resource is provided to the `Ref` intrinsic function, `Ref` returns the ID of the ReceiptRuleSet resource \(the physical resource ID\)\.
+
+For more information about using the `Ref` function, see [Ref](intrinsic-function-reference-ref.md)\.
 
 ## Example<a name="aws-resource-ses-receiptruleset-examples"></a>
 


### PR DESCRIPTION
While helping a user of troposphere come up with a way to configure SES
`ReceiptRule`s/`ReceiptRuleSet`s I noticed that for some reason the docs
didn't list any Return Values for `ReceiptRuleSet`, which would make it
very difficult to configure in Cloudformation, and seemed like an
oversight.  I went ahead and tried using `Ref` on a `ReceiptRuleSet` to
provide an output of the physical resource created, and it appears to
work.

This is the example YAML I used:

```
AWSTemplateFormatVersion: 2010-09-09
Description: 'AWS SES ReceiptRuleSet Sample Template'
Resources:
  ReceiptRuleSet:
    Type: 'AWS::SES::ReceiptRuleSet'
Outputs:
  ReceiptRuleSetRef:
    Value: !Ref ReceiptRuleSet
```

And here's the resulting output:

https://www.dropbox.com/s/hwedbwyn3gwezrw/Screenshot%202018-05-19%2007.46.29.png?dl=0