### PR TITLE
Update EncryptionConfiguration parent property

### DIFF
--- a/doc_source/aws-properties-s3-bucket-encryptionconfiguration.md
+++ b/doc_source/aws-properties-s3-bucket-encryptionconfiguration.md
@@ -2,7 +2,7 @@
 
 <a name="aws-properties-s3-bucket-encryptionconfiguration-description"></a>The `EncryptionConfiguration` property type specifies encryption\-related information for an Amazon S3 bucket that is a destination for replicated objects\.
 
-<a name="aws-properties-s3-bucket-encryptionconfiguration-inheritance"></a>`EncryptionConfiguration` is a property type of the [AWS::S3::Bucket](aws-properties-s3-bucket.md) resource\.
+<a name="aws-properties-s3-bucket-encryptionconfiguration-inheritance"></a>`EncryptionConfiguration` is a property of the [Amazon S3 Bucket ReplicationDestination](aws-properties-s3-bucket-replicationconfiguration-rules-destination.md) property\.
 
 ## Syntax<a name="aws-properties-s3-bucket-encryptionconfiguration-syntax"></a>
 


### PR DESCRIPTION
`EncryptionConfiguration` is a property of `ReplicationDestination`, but the documentation implies it's a property of the top-level `AWS::S3::Bucket` resource type. I have updated the document so it references `ReplicationDestination` as the property's direct parent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.