### PR TITLE
Update parameters-section-structure.md

### DIFF
--- a/doc_source/parameters-section-structure.md
+++ b/doc_source/parameters-section-structure.md
@@ -163,8 +163,8 @@ For example, users could specify `"MyUserName"`\.
 An integer or float\. AWS CloudFormation validates the parameter value as a number; however, when you use the parameter elsewhere in your template \(for example, by using the `Ref` intrinsic function\), the parameter value becomes a string\.  
 For example, users could specify `"8888"`\.  
 `List<Number>`  
-An array of integers or floats that are separated by commas\. AWS CloudFormation validates the parameter value as numbers; however, when you use the parameter elsewhere in your template \(for example, by using the `Ref` intrinsic function\), the parameter value becomes a list of strings\.  
-For example, users could specify `"80,20"`, and a `Ref` would result in `["80","20"]`\.  
+An array of integers or floats that are separated by commas\. AWS CloudFormation validates the parameter value as numbers;  
+For example, users could specify `80,20`, and a `Ref` would result in List of numbers `80 20`\. To convert this to string you can use 'Join'. For example, !Join [',',[!Ref Parameter]] would result in 80,20  
 `CommaDelimitedList`  
 An array of literal strings that are separated by commas\. The total number of strings should be one more than the total number of commas\. Also, each member string is space trimmed\.  
 For example, users could specify `"test,dev,prod"`, and a `Ref` would result in `["test","dev","prod"]`\.  


### PR DESCRIPTION
List<Number> evaluates a number and the Ref function also evaluates to a number and Not to a string as was described in this section. So modified as Under

Removed - “ however, when you use the parameter elsewhere in your template \(for example, by using the `Ref` intrinsic function\), the parameter value becomes a list of strings\.

Added - For example, users could specify `80,20`, and a `Ref` would result in List of numbers `80 20`\. To convert this to string you can use 'Join'. For example, !Join [',',[!Ref Parameter]] would result in 80,20

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
