### PR TITLE
Update aws-resource-dynamodb-table.md

### DIFF
--- a/doc_source/aws-resource-dynamodb-table.md
+++ b/doc_source/aws-resource-dynamodb-table.md
@@ -116,7 +116,7 @@ Throughput for the specified table, which consists of values for `ReadCapacityUn
 Specifies the settings to enable server\-side encryption\.  
 *Required: *No  
 *Type*: [DynamoDB SSESpecification](aws-properties-dynamodb-table-ssespecification.md)  
-*Update requires*: [Some interruptions](using-cfn-updating-stacks-update-behaviors.md#update-some-interrupt)
+*Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement)
 
 `StreamSpecification`  <a name="cfn-dynamodb-table-streamspecification"></a>
 The settings for the DynamoDB table stream, which capture changes to items stored in the table\.  


### PR DESCRIPTION
In my experience adding in the SSESpecification Property to an existing table causes a new physical resource to be created.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
