### PR TITLE
Update conditions-section-structure.md

### DIFF
--- a/doc_source/conditions-section-structure.md
+++ b/doc_source/conditions-section-structure.md
@@ -60,6 +60,9 @@ You can use the following intrinsic functions to define conditions:
 
 For the syntax and information about each function, see [Condition Functions](intrinsic-function-reference-conditions.md)\. 
 
+**Note**
+Conditions cannot refer to other Conditions.
+
 **Note**  
 `Fn::If` is only supported in the metadata attribute, update policy attribute, and property values in the Resources section and Outputs sections of a template\.
 


### PR DESCRIPTION
Apparently, you cannot refer to one condition from another condition to build complex conditions.  But the document doesn't mention this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
