### PR TITLE
Fixed conflicting RestApi references in example

### DIFF
--- a/doc_source/aws-resource-apigateway-method.md
+++ b/doc_source/aws-resource-apigateway-method.md
@@ -153,7 +153,7 @@ The following example creates a mock GET method for the `MyApi` API\.
   "Type": "AWS::ApiGateway::Method",
   "Properties": {
     "RestApiId": { "Ref": "MyApi" },
-    "ResourceId": { "Fn::GetAtt": ["RestApi", "RootResourceId"] },
+    "ResourceId": { "Fn::GetAtt": ["MyApi", "RootResourceId"] },
     "HttpMethod": "GET",
     "AuthorizationType": "NONE",
     "Integration": { "Type": "MOCK" }
@@ -171,7 +171,7 @@ MockMethod:
       Ref: "MyApi"
     ResourceId: 
       Fn::GetAtt: 
-        - "RestApi"
+        - "MyApi"
         - "RootResourceId"
     HttpMethod: "GET"
     AuthorizationType: "NONE"


### PR DESCRIPTION
*Description of changes:*
In the first example of `AWS::ApiGateway::Method` there were conflicting references to a RestApi; `MyApi` and `RestApi`. Both should be `MyApi`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
