### PR TITLE
Include definition of ProvisioningArtifact

### DIFF
--- a/doc_source/aws-resource-servicecatalog-cloudformationprovisionedproduct.md
+++ b/doc_source/aws-resource-servicecatalog-cloudformationprovisionedproduct.md
@@ -90,13 +90,13 @@ A user\-friendly name for the provisioned product\. This name must be unique for
  *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement) 
 
 `ProvisioningArtifactId`  <a name="cfn-servicecatalog-cloudformationprovisionedproduct-provisioningartifactid"></a>
-The identifier of the provisioning artifact\. You must specify either the ID or the name of the provisioning artifact, but not both\.  
+The identifier of the provisioning artifact\. A provisioning artifact is also known as a product version\. You must specify either the ID or the name of the provisioning artifact, but not both\.  
  *Required*: No  
  *Type*: String  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `ProvisioningArtifactName`  <a name="cfn-servicecatalog-cloudformationprovisionedproduct-provisioningartifactname"></a>
-The name of the provisioning artifact\. This name must be unique for the product\. You must specify either the name or the ID of the provisioning artifact, but not both\.  
+The name of the provisioning artifact\. A provisioning artifact is also known as a product version\. This name must be unique for the product\. You must specify either the name or the ID of the provisioning artifact, but not both\.  
  *Required*: No  
  *Type*: String  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated aws-resource-servicecatalog-cloudformationprovisionedproduct.md

The term ProvisioningArtifact is misleading when working with Service Catalog. It should be clearer from this page that it is the same of product version. Either the update I suggest here or a link to https://docs.aws.amazon.com/servicecatalog/latest/dg/API_ProvisioningArtifact.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
