### PR TITLE
"!Ref" is not shorter than "Ref"

### DIFF
--- a/doc_source/intrinsic-function-reference-ref.md
+++ b/doc_source/intrinsic-function-reference-ref.md
@@ -29,7 +29,7 @@ Syntax for the full function name:
 Ref: logicalName
 ```
 
-Syntax for the short form:
+Syntax for the "short" form:
 
 ```
 !Ref logicalName


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Self explanatory. I'm guessing this was generated automatically, but it seems silly to even offer "!Ref" as an option when "Ref" is valid.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
