### PR TITLE
Update aws-properties-glue-job-jobcommand.md

### DIFF
--- a/doc_source/aws-properties-glue-job-jobcommand.md
+++ b/doc_source/aws-properties-glue-job-jobcommand.md
@@ -36,7 +36,7 @@ The location of a script that executes a job\.
 
 `Name`  <a name="cfn-glue-job-jobcommand-name"></a>
 The name of the job command\.  
- *Required*: No  
+ *Required*: Yes  
  *Type*: String  
  *Valid values*: `glueetl`  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 


### PR DESCRIPTION
Attempting to deploy a template without the "Name" key in the jobcommand resulted in the error 'Command name should not be null or empty'.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
