### PR TITLE
AWS::EC2::VPCPeeringConnection should document the lack of PeerRegion

### DIFF
--- a/doc_source/aws-resource-ec2-vpcpeeringconnection.md
+++ b/doc_source/aws-resource-ec2-vpcpeeringconnection.md
@@ -45,6 +45,9 @@ Properties:
 
 ## Properties<a name="w3ab2c21c10d531c10"></a>
 
+**Note**  
+Currently, `PeerRegion` is not supported by CloudFormation, please use [the AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-vpc-peering-connection.html) or [the API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpcPeeringConnection.html) if you need to create an inter-region VPC Peering Connection\.
+
 `PeerVpcId`  <a name="cfn-ec2-vpcpeeringconnection-peervpcid"></a>
 The ID of the VPC with which you are creating the peering connection\.  
 *Required*: Yes  


### PR DESCRIPTION
*Description of changes:*

Creating an inter-region VPCPeeringConnection is currently not possible with CloudFormation, and it is not clearly stated in this documentation.

While:

- the AWS CLI [does support and document `--peer-region`](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-vpc-peering-connection.html),
- and the API [does support and document `PeerRegion`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpcPeeringConnection.html)

There is no support for `PeerRegion` in CloudFormation, and users end up searching for additional (and mostly unreliable) sources of information on the web as nothing [in the CloudFormation documentation about VPC Peering](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcpeeringconnection.html) is mentioning `PeerRegion`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Thanks :)