### PR TITLE
Remove BadgeEnabled from the example since Build badges are not supported for CodePipeline source

### DIFF
--- a/doc_source/aws-resource-codebuild-project.md
+++ b/doc_source/aws-resource-codebuild-project.md
@@ -256,7 +256,6 @@ The following example creates a project that caches build dependencies in Amazon
         "Artifacts": {
           "Type": "CODEPIPELINE"
         },
-        "BadgeEnabled": "true",
         "Environment": {
           "Type": "LINUX_CONTAINER",
           "ComputeType": "BUILD_GENERAL1_SMALL",
@@ -397,7 +396,6 @@ Resources:
       ServiceRole: !Ref CodeBuildRole
       Artifacts:
         Type: CODEPIPELINE
-      BadgeEnabled: 'true'
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL


### PR DESCRIPTION
"BadgeEnabled": "true" in the example template for yaml/json is a little misleading since its not currently supported with a pipeline source of **codepipeline** and ultimately fails when attempting to create the stack.

proposed change is to remove it from the example templates so that they will succeed "out of the box"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
