### PR TITLE
Fix ENUM value for SubscriptionType

### DIFF
--- a/doc_source/aws-properties-budgets-budget-subscriber.md
+++ b/doc_source/aws-properties-budgets-budget-subscriber.md
@@ -27,7 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-budgets-budget-subscriber-properties"></a>
 
 `SubscriptionType`  <a name="cfn-budgets-budget-subscriber-subscriptiontype"></a>
-The type of notification that AWS sends to a subscriber, such as `email` or `SNS`\.  
+The type of notification that AWS sends to a subscriber, such as `EMAIL` or `SNS`\.  
  *Required*: Yes  
  *Type*: String  
  *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement)


### PR DESCRIPTION
The ENUM for this resource is case sensitive.

*Issue #, if available:*

*Description of changes:*
Discovered the case sensitivity when provisioning a Budget resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
