### PR TITLE
Add EnableNonSecurity to PatchBaseline Rule

### DIFF
--- a/doc_source/aws-properties-ssm-patchbaseline-rule.md
+++ b/doc_source/aws-properties-ssm-patchbaseline-rule.md
@@ -14,7 +14,8 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
   "[PatchFilterGroup](#cfn-ssm-patchbaseline-rule-patchfiltergroup)" : [*PatchFilterGroup*](aws-properties-ssm-patchbaseline-patchfiltergroup.md),
   "[ApproveAfterDays](#cfn-ssm-patchbaseline-rule-approveafterdays)" : Integer,
-  "[ComplianceLevel](#cfn-ssm-patchbaseline-rule-compliancelevel)" : String
+  "[ComplianceLevel](#cfn-ssm-patchbaseline-rule-compliancelevel)" : String,
+  "[EnableNonSecurity](#cfn-ssm-patchbaseline-rule-enablenonsecurity)" : Boolean
 }
 ```
 
@@ -25,6 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
   [*PatchFilterGroup*](aws-properties-ssm-patchbaseline-patchfiltergroup.md)
 [ApproveAfterDays](#cfn-ssm-patchbaseline-rule-approveafterdays): Integer
 [ComplianceLevel](#cfn-ssm-patchbaseline-rule-compliancelevel): String
+[EnableNonSecurity](#cfn-ssm-patchbaseline-rule-enablenonsecurity): Boolean
 ```
 
 ## Properties<a name="aws-properties-ssm-patchbaseline-rule-properties"></a>
@@ -45,4 +47,10 @@ The number of days after the release date of each patch matched by the rule that
 A compliance severity level for all approved patches in a patch baseline\. Valid compliance severity levels include the following: `Unspecified`, `Critical`, `High`, `Medium`, `Low`, and `Informational`\.  
  *Required*: No  
  *Type*: String  
+ *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
+ 
+`EnableNonSecurity`  <a name="cfn-ssm-patchbaseline-rule-enablenonsecurity"></a>
+For instances identified by the approval rule filters, enables a patch baseline to apply non-security updates available in the specified repository\. The default value is `false`\. Applies to Linux instances only\.   
+ *Required*: No  
+ *Type*: Boolean  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The EnableNonSecurity parameter is documented in the API but is seemingly left out of the CloudFormation documentation. Despite its undocumented status, it appears to actually be available through CFN as I have deployed baselines in my account using this in my templates.  As a result, I assume that it is there and just missing from the docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
