### PR TITLE
Change Name to ID

### DIFF
--- a/doc_source/aws-properties-ec2-security-group-ingress.md
+++ b/doc_source/aws-properties-ec2-security-group-ingress.md
@@ -164,7 +164,7 @@ The following template snippet creates an EC2 security group with an ingress rul
                 "IpProtocol": "tcp",
                 "FromPort": "80",
                 "ToPort": "80",
-                "SourceSecurityGroupName": {
+                "SourceSecurityGroupId": {
                     "Ref": "SGBase"
                 }
             }
@@ -194,7 +194,7 @@ Resources:
       IpProtocol: tcp
       FromPort: '80'
       ToPort: '80'
-      SourceSecurityGroupName: !Ref SGBase
+      SourceSecurityGroupId: !Ref SGBase
 ```
 
 ### VPC Security Groups with Egress and Ingress Rules<a name="w3ab2c21c10d475c13b4"></a>


### PR DESCRIPTION
*Issue #, if available:*
Not available

*Description of changes:*
A ref to a security group returns the group ID, not the group name.  This example was broken as-is.  Changing to Id allows the example to execute.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
