### PR TITLE
Security Group example syntax updates

### DIFF
--- a/doc_source/aws-properties-ec2-security-group-ingress.md
+++ b/doc_source/aws-properties-ec2-security-group-ingress.md
@@ -149,8 +149,8 @@ The following template snippet creates an EC2 security group with an ingress rul
                     {
                         "IpProtocol": "tcp",
                         "CidrIp": "0.0.0.0/0",
-                        "FromPort": "22",
-                        "ToPort": "22"
+                        "FromPort": 22,
+                        "ToPort": 22
                     }
                 ]
             }
@@ -162,8 +162,8 @@ The following template snippet creates an EC2 security group with an ingress rul
                     "Ref": "SGBase"
                 },
                 "IpProtocol": "tcp",
-                "FromPort": "80",
-                "ToPort": "80",
+                "FromPort": 80,
+                "ToPort": 80,
                 "SourceSecurityGroupName": {
                     "Ref": "SGBase"
                 }
@@ -185,15 +185,15 @@ Resources:
       SecurityGroupIngress:
         - IpProtocol: tcp
           CidrIp: 0.0.0.0/0
-          FromPort: '22'
-          ToPort: '22'
+          FromPort: 22
+          ToPort: 22
   SGBaseIngress:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
       GroupName: !Ref SGBase
       IpProtocol: tcp
-      FromPort: '80'
-      ToPort: '80'
+      FromPort: 80
+      ToPort: 80
       SourceSecurityGroupName: !Ref SGBase
 ```
 
@@ -225,8 +225,8 @@ In some cases, you might have an originating \(source\) security group to which 
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties":{
         "IpProtocol": "tcp",
-        "FromPort": "0",
-        "ToPort": "65535",
+        "FromPort": 0,
+        "ToPort": 65535,
         "DestinationSecurityGroupId": {
           "Fn::GetAtt": [
             "TargetSG",
@@ -245,8 +245,8 @@ In some cases, you might have an originating \(source\) security group to which 
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties":{
         "IpProtocol": "tcp",
-        "FromPort": "0",
-        "ToPort": "65535",
+        "FromPort": 0,
+        "ToPort": 65535,
         "SourceSecurityGroupId": {
           "Fn::GetAtt": [
             "SourceSG",
@@ -284,8 +284,8 @@ Resources:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
       IpProtocol: tcp
-      FromPort: '0'
-      ToPort: '65535'
+      FromPort: 0
+      ToPort: 65535
       DestinationSecurityGroupId:
         Fn::GetAtt:
         - TargetSG
@@ -298,8 +298,8 @@ Resources:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       IpProtocol: tcp
-      FromPort: '0'
-      ToPort: '65535'
+      FromPort: 0
+      ToPort: 65535
       SourceSecurityGroupId:
         Fn::GetAtt:
         - SourceSG
@@ -324,8 +324,8 @@ To allow ping requests, add the ICMP protocol type and specify `8` \(echo reques
     "GroupDescription" : "SG to test ping",
     "VpcId" : {"Ref" : "VPC"},
     "SecurityGroupIngress" : [ 
-      { "IpProtocol" : "tcp", "FromPort" : "22", "ToPort" : "22", "CidrIp" : "10.0.0.0/24" },
-      { "IpProtocol" : "icmp", "FromPort" : "8", "ToPort" : "-1", "CidrIp" : "10.0.0.0/24" }
+      { "IpProtocol" : "tcp", "FromPort" : 22, "ToPort" : 22, "CidrIp" : "10.0.0.0/24" },
+      { "IpProtocol" : "icmp", "FromPort" : 8, "ToPort" : -1, "CidrIp" : "10.0.0.0/24" }
     ]
   }
 }
@@ -343,11 +343,11 @@ SGPing:
       Ref: VPC
     SecurityGroupIngress:
     - IpProtocol: tcp
-      FromPort: '22'
-      ToPort: '22'
+      FromPort: 22
+      ToPort: 22
       CidrIp: 10.0.0.0/24
     - IpProtocol: icmp
-      FromPort: '8'
-      ToPort: "-1"
+      FromPort: 8
+      ToPort: -1
       CidrIp: 10.0.0.0/24
 ```

--- a/doc_source/aws-properties-ec2-security-group-rule.md
+++ b/doc_source/aws-properties-ec2-security-group-rule.md
@@ -133,8 +133,8 @@ The end of port range for the TCP and UDP protocols, or an ICMP code\. An ICMP c
       "GroupDescription" : "Enable SSH access via port 22",
       "SecurityGroupIngress" : [ {
          "IpProtocol" : "tcp",
-         "FromPort" : "22",
-         "ToPort" : "22",
+         "FromPort" : 22,
+         "ToPort" : 22,
          "CidrIp" : "0.0.0.0/0"
       } ]
    }
@@ -151,8 +151,8 @@ InstanceSecurityGroup:
     SecurityGroupIngress: 
       - 
         IpProtocol: "tcp"
-        FromPort: "22"
-        ToPort: "22"
+        FromPort: 22
+        ToPort: 22
         CidrIp: "0.0.0.0/0"
 ```
 
@@ -228,8 +228,8 @@ This snippet grants SSH access with CidrIp, and HTTP access with `SourceSecurity
       "GroupDescription" : "Enable SSH access and HTTP from the load balancer only",
       "SecurityGroupIngress" : [ {
          "IpProtocol" : "tcp",
-         "FromPort" : "22",
-         "ToPort" : "22",
+         "FromPort" : 22,
+         "ToPort" : 22,
          "CidrIp" : "0.0.0.0/0"
       }, {
          "IpProtocol" : "tcp",
@@ -276,8 +276,8 @@ InstanceSecurityGroup:
     SecurityGroupIngress: 
       - 
         IpProtocol: "tcp"
-        FromPort: "22"
-        ToPort: "22"
+        FromPort: 22
+        ToPort: 22
         CidrIp: "0.0.0.0/0"
       - 
         IpProtocol: "tcp"

--- a/doc_source/aws-properties-ec2-security-group.md
+++ b/doc_source/aws-properties-ec2-security-group.md
@@ -125,14 +125,14 @@ The following example defines a security group with an ingress and egress rule\.
       "VpcId" : {"Ref" : "myVPC"},
       "SecurityGroupIngress" : [{
             "IpProtocol" : "tcp",
-            "FromPort" : "80",
-            "ToPort" : "80",
+            "FromPort" : 80,
+            "ToPort" : 80,
             "CidrIp" : "0.0.0.0/0"
          }],
       "SecurityGroupEgress" : [{
          "IpProtocol" : "tcp",
-         "FromPort" : "80",
-         "ToPort" : "80",
+         "FromPort" : 80,
+         "ToPort" : 80,
          "CidrIp" : "0.0.0.0/0"
       }]
    }
@@ -150,13 +150,13 @@ InstanceSecurityGroup:
       Ref: myVPC
     SecurityGroupIngress:
     - IpProtocol: tcp
-      FromPort: '80'
-      ToPort: '80'
+      FromPort: 80
+      ToPort: 80
       CidrIp: 0.0.0.0/0
     SecurityGroupEgress:
     - IpProtocol: tcp
-      FromPort: '80'
-      ToPort: '80'
+      FromPort: 80
+      ToPort: 80
       CidrIp: 0.0.0.0/0
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
Really minor, but will possibly save people from cleaning syntax to prevent errors/warnings when using IDEs that have syntax checking, e.g. Atom with atom-cfn-lint.

The examples show FromPort and ToPort as strings, when the specification has them as integers.  When I copied the example I had to clean the syntax to avoid errors.

*Description of changes:*
Changed FromPort and ToPort to integer values instead of strings in the examples section. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.