### PR TITLE
Add `Fn::Sub` as an allowed function in `Fn::Split` values

### DIFF
--- a/doc_source/intrinsic-function-reference-split.md
+++ b/doc_source/intrinsic-function-reference-split.md
@@ -108,4 +108,5 @@ For the `Fn::Split` list of values, you can use the following functions:
 + `Fn::If`
 + `Fn::Join`
 + `Fn::Select`
++ `Fn::Sub`
 + `Ref`


### PR DESCRIPTION
Based off my observation in `ap-southeast-2` region, `Fn::Split` is happy to accept `Fn::Sub` in its' list of values.

Template snippet:

```
...<snip>...
Parameters:
  MandatoryPolicies:
    Description: Provide a list of policies that are mandatory on all roles
    Type: CommaDelimitedList
...<snip>...
Resources:
  EnhancedMonitoringRole:
    Type: AWS::IAM::Role
    Properties:
      Path: /
      AssumeRolePolicyDocument:
        Version: 2012-10-17
        Statement:
          - Effect: Allow
            Principal:
              Service: monitoring.rds.amazonaws.com
            Action: sts:AssumeRole
      ManagedPolicyArns: !Split
        - ","
        - !Sub
          - "${PolicyList},arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
          - PolicyList: !Join [",", !Ref "MandatoryPolicies"]
```

Where I provided something similar to this string in the `MandatoryPolicies` parameter:

```
arn:aws:iam::999912312399:policy/SecOpsRestrictionPolicy,arn:aws:iam::999912312399:policy/IAMRestrictionPolicy
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
