### PR TITLE
Change MonitoringInterval property type to Number

### DIFF
--- a/doc_source/aws-properties-rds-database-instance.md
+++ b/doc_source/aws-properties-rds-database-instance.md
@@ -47,7 +47,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "[LicenseModel](#cfn-rds-dbinstance-licensemodel)" : String,
     "[MasterUsername](#cfn-rds-dbinstance-masterusername)" : String,
     "[MasterUserPassword](#cfn-rds-dbinstance-masteruserpassword)" : String,
-    "[MonitoringInterval](#cfn-rds-dbinstance-monitoringinterval)" : Integer,
+    "[MonitoringInterval](#cfn-rds-dbinstance-monitoringinterval)" : Number,
     "[MonitoringRoleArn](#cfn-rds-dbinstance-monitoringrolearn)" : String,
     "[MultiAZ](#cfn-rds-dbinstance-multiaz)" : Boolean,
     "[OptionGroupName](#cfn-rds-dbinstance-optiongroupname)" : String,
@@ -96,7 +96,7 @@ Properties:
   [LicenseModel](#cfn-rds-dbinstance-licensemodel): String
   [MasterUsername](#cfn-rds-dbinstance-masterusername): String
   [MasterUserPassword](#cfn-rds-dbinstance-masteruserpassword): String
-  [MonitoringInterval](#cfn-rds-dbinstance-monitoringinterval): Integer
+  [MonitoringInterval](#cfn-rds-dbinstance-monitoringinterval): Number
   [MonitoringRoleArn](#cfn-rds-dbinstance-monitoringrolearn): String
   [MultiAZ](#cfn-rds-dbinstance-multiaz): Boolean
   [OptionGroupName](#cfn-rds-dbinstance-optiongroupname): String
@@ -312,7 +312,7 @@ If you specify the `SourceDBInstanceIdentifier` or `DBSnapshotIdentifier` proper
 The interval, in seconds, between points when Amazon RDS collects enhanced monitoring metrics for the DB instance\. To disable metrics collection, specify `0`\.  
 For default and valid values, see the `MonitoringInterval` parameter for the [CreateDBInstance](http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html) action in the *Amazon RDS API Reference*\.  
 *Required*: Conditional\. If you specify the `MonitoringRoleArn` property, specify a value other than `0` for `MonitoringInterval`\.  
-*Type*: Integer  
+*Type*: Number  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) or [some interruptions](using-cfn-updating-stacks-update-behaviors.md#update-some-interrupt)\. For more information, see [ModifyDBInstance](http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBInstance.html) in the *Amazon RDS API Reference*\.
 
 `MonitoringRoleArn`  <a name="cfn-rds-dbinstance-monitoringrolearn"></a>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The [AWS::RDS::DBInstance](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html) page uses a mix of `Integer` (e.g. for `MonitoringInterval`) and `Number` (e.g. for `Iops`) to describe numerical property types.  As CFN only has a `Number` type internally (see: [Parameter Types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#parameters-section-structure-properties-type)), and it seems to be the most accepted type for describe numerical properties elsewhere, I've changed the `MonitoringInterval` property type to `Number`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
