### PR TITLE
fix ec2 launchtemplate to match specifications of the api

### DIFF
--- a/doc_source/aws-resource-ec2-launchtemplate.md
+++ b/doc_source/aws-resource-ec2-launchtemplate.md
@@ -37,8 +37,8 @@ Properties:
 
 `LaunchTemplateName`  <a name="cfn-ec2-launchtemplate-launchtemplatename"></a>
 A name for the launch template\.  
-Length Constraints: Minimum length of 3\. Maximum length of 128\.  
-Pattern: \[a\-zA\-Z0\-9\\\(\\\)\\\.\-/\_\]\+  
+Length Constraints: Minimum length of 3\. Maximum length of 125\.  
+Pattern: \[a\-zA\-Z0\-9\\\(\\\)\\\./\_\]\+  
  *Required*: No  
  *Type*: String  
  *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement) 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The AWS::EC2::LaunchTemplate resource property has wrong specification:
 - Max Length: Actual 125  vs. 128 in docs
 - Allowed characters : [a-zA-Z0-9\(\)\.-/_]+ VS. [a-zA-Z0-9\(\)\./_]+

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
