### PR TITLE
AWS::Elasticsearch::Domain clarify subnetid requirements

### DIFF
--- a/doc_source/aws-properties-elasticsearch-domain-vpcoptions.md
+++ b/doc_source/aws-properties-elasticsearch-domain-vpcoptions.md
@@ -35,7 +35,7 @@ The list of security group IDs that are associated with the VPC endpoints for th
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `SubnetIds`  <a name="cfn-elasticsearch-domain-vpcoptions-subnetids"></a>
-A list of subnet IDs that are associated with the VPC endpoints for the domain\. If your domain has zone awareness enabled, you need to provide two subnet IDs, one per zone\. Otherwise, you only need to provide one\. To learn more, see [VPCs and Subnets](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html) in the *Amazon VPC User Guide*\.  
+A list of subnet IDs that are associated with the VPC endpoints for the domain\. If your domain has zone awareness enabled, you need to provide two subnet IDs, one per zone\. Otherwise, you need to provide one subnet ID\. To learn more, see [VPCs and Subnets](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html) in the *Amazon VPC User Guide*\.  
  *Required*: No  
  *Type*: List of String values  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 


### PR DESCRIPTION
Clarifying that your only allowed to specify ONE subnet, and not multiple when you don't use zone-awareness


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
