### PR TITLE
Mark ServiceRole as mandatory

### DIFF
--- a/doc_source/aws-properties-elasticbeanstalk-application-applicationresourcelifecycleconfig.md
+++ b/doc_source/aws-properties-elasticbeanstalk-application-applicationresourcelifecycleconfig.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 `ServiceRole`  <a name="cfn-elasticbeanstalk-application-applicationresourcelifecycleconfig-servicerole"></a>
 The ARN of an IAM service role that Elastic Beanstalk has permission to assume\.  
- *Required*: No  
+ *Required*: Yes
  *Type*: String  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 


### PR DESCRIPTION
If you attempt to update an existing `AWS::ElasticBeanstalk::Application` resource without a `ResourceLifecycleConfig` property defined, adding one without `ServiceRole` defined will result in the error `Parameter ServiceRole is invalid. Must be a valid IAM Role ARN.` (and rollback will fail with the same error). There might be some corner cases where this parameter isn't required, but it seems easiest to mark it as mandatory (especially when 99% of use-cases will use the service-linked account that's automatically created).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
