### PR TITLE
Update aws-properties-lambda-function-code.md Fix YAML example typo

### DIFF
--- a/doc_source/aws-properties-lambda-function-code.md
+++ b/doc_source/aws-properties-lambda-function-code.md
@@ -122,7 +122,7 @@ In the following Node\.js example, the inline Lambda function takes an input val
 ##### YAML<a name="cfn-lambda-function-code-zipfile-examplenodejs.yaml"></a>
 
 ```
-ZipFile: >
+ZipFile: |
   var response = require('cfn-response');
   exports.handler = function(event, context) {
     var input = parseInt(event.ResourceProperties.Input);


### PR DESCRIPTION
Hello,

Not sure if

```yaml
key: >
  foo
  bar
```

is valid syntax.  I think the `>` should be a `|`.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
