### PR TITLE
Be clear about what happens when no revision is specified

### DIFF
--- a/doc_source/aws-properties-events-rule-ecsparameters.md
+++ b/doc_source/aws-properties-events-rule-ecsparameters.md
@@ -35,7 +35,7 @@ The number of tasks to create based on the task definition\. The default is `1`\
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `TaskDefinitionArn`  <a name="cfn-events-rule-ecsparameters-taskdefinitionarn"></a>
-The Amazon Resource Name \(ARN\) of the task definition to use\.  If no Task revision is supplied it defaults to the most recent revision\.
+The Amazon Resource Name \(ARN\) of the task definition to use\.  If no Task revision is supplied it defaults to the most recent revision at the time of resource creation\.
  *Required*: Yes  
  *Type*: String  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 

--- a/doc_source/aws-properties-events-rule-ecsparameters.md
+++ b/doc_source/aws-properties-events-rule-ecsparameters.md
@@ -35,7 +35,7 @@ The number of tasks to create based on the task definition\. The default is `1`\
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `TaskDefinitionArn`  <a name="cfn-events-rule-ecsparameters-taskdefinitionarn"></a>
-The Amazon Resource Name \(ARN\) of the task definition to use\.  
+The Amazon Resource Name \(ARN\) of the task definition to use\.  If no Task revision is supplied it defaults to the most recent revision\.
  *Required*: Yes  
  *Type*: String  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 


### PR DESCRIPTION
*Description of changes:*

If we don't supply a revision the most recent revision is selected. Further updates to the task definition are therefore do not take effect on the Event Rule.
