### PR TITLE
Update aws-resource-appsync-graphqlapi.md

### DIFF
--- a/doc_source/aws-resource-appsync-graphqlapi.md
+++ b/doc_source/aws-resource-appsync-graphqlapi.md
@@ -127,7 +127,7 @@ The following example creates a GraphQL API
           "Ref": "graphQlApiName"
         },
         "AuthenticationType": "AMAZON_COGNITO_USER_POOLS",
-        UserPoolConfig": {
+        "UserPoolConfig": {
           "UserPoolId": {
             "Ref": "userPoolId"
           },
@@ -163,7 +163,7 @@ Resources:
       Name:
 	Ref: graphQlApiName
       AuthenticationType: "AMAZON_COGNITO_USER_POOLS"
-      "UserPoolConfig":
+      UserPoolConfig:
         UserPoolId:
           Ref: userPoolId
         AwsRegion:


### PR DESCRIPTION
Corrects the " usage on JSON and YAML for UserPoolConfig

*Issue #, if available:*

*Description of changes:*
Fixes double quote issue I noticed in the documentation for the JSON and YAML examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
