### PR TITLE
Fix yaml syntax of AWS::SNS::Topic

### DIFF
--- a/doc_source/aws-properties-sns-topic.md
+++ b/doc_source/aws-properties-sns-topic.md
@@ -33,7 +33,7 @@ Type: "AWS::SNS::Topic"
 Properties: 
   [DisplayName](#cfn-sns-topic-displayname): String
   [Subscription](#cfn-sns-topic-subscription):
-    SNS Subscription
+    - SNS Subscription
   [TopicName](#cfn-sns-topic-name): String
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Type of `Subscription` is list but current description is lacking `-`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.