### PR TITLE
Correct valid json in KMS Key

### DIFF
--- a/doc_source/aws-resource-kms-key.md
+++ b/doc_source/aws-resource-kms-key.md
@@ -21,8 +21,8 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "[Description](#cfn-kms-key-description)" : String,
     "[Enabled](#cfn-kms-key-enabled)" : Boolean,
     "[EnableKeyRotation](#cfn-kms-key-enablekeyrotation)" : Boolean,
-    "[KeyPolicy](#cfn-kms-key-keypolicy)" : JSON object
-    "[Tags](#cfn-kms-key-tags)" : [ Resource Tag, ... ],
+    "[KeyPolicy](#cfn-kms-key-keypolicy)" : JSON object,
+    "[Tags](#cfn-kms-key-tags)" : [ Resource Tag, ... ]
   }
 }
 ```


### PR DESCRIPTION
Minor fix: json syntax block has the comma in the wrong spot for the properties

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
