### PR TITLE
Removing line numbers from json/yaml examples

### DIFF
--- a/doc_source/aws-attribute-dependson.md
+++ b/doc_source/aws-attribute-dependson.md
@@ -30,77 +30,89 @@ The following template contains an [AWS::EC2::Instance](aws-properties-ec2-insta
 ### JSON<a name="aws-attribute-dependson-example-1.json"></a>
 
 ```
- 1. {
- 2.     "AWSTemplateFormatVersion" : "2010-09-09",
- 3.     "Mappings" : {
- 4.         "RegionMap" : {
- 5.             "us-east-1" : { "AMI" : "ami-76f0061f" },
- 6.             "us-west-1" : { "AMI" : "ami-655a0a20" },
- 7.             "eu-west-1" : { "AMI" : "ami-7fd4e10b" },
- 8.             "ap-northeast-1" : { "AMI" : "ami-8e08a38f" },
- 9.             "ap-southeast-1" : { "AMI" : "ami-72621c20" }
-10.         }
-11.     },
-12.     "Resources" : {
-13.         "Ec2Instance" : {
-14.             "Type" : "AWS::EC2::Instance",
-15.             "Properties" : {
-16.                 "ImageId" : {
-17.                    "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AMI" ]
-18.                 }
-19.             },
-20.             "DependsOn" : "myDB"
-21.         },
-22.         "myDB" : {
-23.             "Type" : "AWS::RDS::DBInstance",
-24.             "Properties" : {
-25.                "AllocatedStorage" : "5",
-26.                "DBInstanceClass" : "db.m1.small",
-27.                "Engine" : "MySQL",
-28.                "EngineVersion" : "5.5",
-29.                "MasterUsername" : "MyName",
-30.                "MasterUserPassword" : "MyPassword"
-31.             }
-32.         }
-33.     }
-34. }
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Mappings": {
+        "RegionMap": {
+            "us-east-1": {
+                "AMI": "ami-76f0061f"
+            },
+            "us-west-1": {
+                "AMI": "ami-655a0a20"
+            },
+            "eu-west-1": {
+                "AMI": "ami-7fd4e10b"
+            },
+            "ap-northeast-1": {
+                "AMI": "ami-8e08a38f"
+            },
+            "ap-southeast-1": {
+                "AMI": "ami-72621c20"
+            }
+        }
+    },
+    "Resources": {
+        "Ec2Instance": {
+            "Type": "AWS::EC2::Instance",
+            "Properties": {
+                "ImageId": {
+                    "Fn::FindInMap": ["RegionMap", {
+                        "Ref": "AWS::Region"
+                    }, "AMI"]
+                }
+            },
+            "DependsOn": "myDB"
+        },
+        "myDB": {
+            "Type": "AWS::RDS::DBInstance",
+            "Properties": {
+                "AllocatedStorage": "5",
+                "DBInstanceClass": "db.t2.small",
+                "Engine": "MySQL",
+                "EngineVersion": "5.5",
+                "MasterUsername": "MyName",
+                "MasterUserPassword": "MyPassword"
+            }
+        }
+    }
+}
 ```
 
 ### YAML<a name="aws-attribute-dependson-example-1.yaml"></a>
 
 ```
- 1. AWSTemplateFormatVersion: '2010-09-09'
- 2. Mappings:
- 3.   RegionMap:
- 4.     us-east-1:
- 5.       AMI: ami-76f0061f
- 6.     us-west-1:
- 7.       AMI: ami-655a0a20
- 8.     eu-west-1:
- 9.       AMI: ami-7fd4e10b
-10.     ap-northeast-1:
-11.       AMI: ami-8e08a38f
-12.     ap-southeast-1:
-13.       AMI: ami-72621c20
-14. Resources:
-15.   Ec2Instance:
-16.     Type: AWS::EC2::Instance
-17.     Properties:
-18.       ImageId:
-19.         Fn::FindInMap:
-20.         - RegionMap
-21.         - Ref: AWS::Region
-22.         - AMI
-23.     DependsOn: myDB
-24.   myDB:
-25.     Type: AWS::RDS::DBInstance
-26.     Properties:
-27.       AllocatedStorage: '5'
-28.       DBInstanceClass: db.m1.small
-29.       Engine: MySQL
-30.       EngineVersion: '5.5'
-31.       MasterUsername: MyName
-32.       MasterUserPassword: MyPassword
+AWSTemplateFormatVersion: '2010-09-09'
+Mappings:
+  RegionMap:
+    us-east-1:
+      AMI: ami-76f0061f
+    us-west-1:
+      AMI: ami-655a0a20
+    eu-west-1:
+      AMI: ami-7fd4e10b
+    ap-northeast-1:
+      AMI: ami-8e08a38f
+    ap-southeast-1:
+      AMI: ami-72621c20
+Resources:
+  Ec2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId:
+        Fn::FindInMap:
+        - RegionMap
+        - Ref: AWS::Region
+        - AMI
+    DependsOn: myDB
+  myDB:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      AllocatedStorage: '5'
+      DBInstanceClass: db.t2.small
+      Engine: MySQL
+      EngineVersion: '5.5'
+      MasterUsername: MyName
+      MasterUserPassword: MyPassword
 ```
 
 ## When a DependsOn attribute is required<a name="gatewayattachment"></a>
@@ -124,29 +136,50 @@ The following snippet shows a sample gateway attachment and an Amazon EC2 instan
 ### JSON<a name="aws-attribute-dependson-example-2.json"></a>
 
 ```
-"GatewayToInternet" : {
-  "Type" : "AWS::EC2::VPCGatewayAttachment",
-  "Properties" : {
-    "VpcId" : { "Ref" : "VPC" },
-    "InternetGatewayId" : { "Ref" : "InternetGateway" }
-  }
+"GatewayToInternet": {
+    "Type": "AWS::EC2::VPCGatewayAttachment",
+    "Properties": {
+        "VpcId": {
+            "Ref": "VPC"
+        },
+        "InternetGatewayId": {
+            "Ref": "InternetGateway"
+        }
+    }
 },
 
-"EC2Host" : {
-  "Type" : "AWS::EC2::Instance",
-  "DependsOn" : "GatewayToInternet",
-    "Properties" : {
-      "InstanceType" : { "Ref" : "EC2InstanceType" },
-      "KeyName"  : { "Ref" : "KeyName" },
-      "ImageId"  : { "Fn::FindInMap" : [ "AWSRegionArch2AMI", { "Ref" : "AWS::Region" },
-        { "Fn::FindInMap" : [ "AWSInstanceType2Arch", { "Ref" : "EC2InstanceType" }, "Arch" ] } ] },
-      "NetworkInterfaces" : [{
-        "GroupSet"                 : [{ "Ref" : "EC2SecurityGroup" }],
-        "AssociatePublicIpAddress" : "true",
-        "DeviceIndex"              : "0",
-        "DeleteOnTermination"      : "true",
-        "SubnetId"                 : { "Ref" : "PublicSubnet" }
-      }]
+"EC2Host": {
+    "Type": "AWS::EC2::Instance",
+    "DependsOn": "GatewayToInternet",
+    "Properties": {
+        "InstanceType": {
+            "Ref": "EC2InstanceType"
+        },
+        "KeyName": {
+            "Ref": "KeyName"
+        },
+        "ImageId": {
+            "Fn::FindInMap": ["AWSRegionArch2AMI", {
+                    "Ref": "AWS::Region"
+                },
+                {
+                    "Fn::FindInMap": ["AWSInstanceType2Arch", {
+                        "Ref": "EC2InstanceType"
+                    }, "Arch"]
+                }
+            ]
+        },
+        "NetworkInterfaces": [{
+            "GroupSet": [{
+                "Ref": "EC2SecurityGroup"
+            }],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "SubnetId": {
+                "Ref": "PublicSubnet"
+            }
+        }]
     }
 }
 ```

--- a/doc_source/aws-attribute-metadata.md
+++ b/doc_source/aws-attribute-metadata.md
@@ -14,25 +14,25 @@ The following template contains an Amazon S3 bucket resource with a Metadata att
 ### JSON<a name="aws-attribute-metadata-example.json"></a>
 
 ```
-1. {
-2.    "AWSTemplateFormatVersion" : "2010-09-09",
-3.    "Resources" : {
-4.       "MyS3Bucket" : {
-5.          "Type" : "AWS::S3::Bucket",
-6.          "Metadata" : { "Object1" : "Location1",  "Object2" : "Location2" }
-7.       }
-8.    }
-9. }
+{
+   "AWSTemplateFormatVersion" : "2010-09-09",
+   "Resources" : {
+      "MyS3Bucket" : {
+         "Type" : "AWS::S3::Bucket",
+         "Metadata" : { "Object1" : "Location1",  "Object2" : "Location2" }
+      }
+   }
+}
 ```
 
 ### YAML<a name="aws-attribute-metadata-example.yaml"></a>
 
 ```
-1. AWSTemplateFormatVersion: '2010-09-09'
-2. Resources:
-3.   MyS3Bucket:
-4.     Type: AWS::S3::Bucket
-5.     Metadata:
-6.       Object1: Location1
-7.       Object2: Location2
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyS3Bucket:
+    Type: AWS::S3::Bucket
+    Metadata:
+      Object1: Location1
+      Object2: Location2
 ```

--- a/doc_source/aws-properties-as-tags.md
+++ b/doc_source/aws-properties-as-tags.md
@@ -53,44 +53,44 @@ The following example template snippet creates two Auto Scaling tags\. The first
 ### JSON<a name="aws-properties-as-tags-example.json"></a>
 
 ```
- 1. "WebServerGroup" : {
- 2.    "Type" : "AWS::AutoScaling::AutoScalingGroup",
- 3.    "Properties" : {
- 4.       "AvailabilityZones" : { "Fn::GetAZs" : "" },
- 5.       "LaunchConfigurationName" : { "Ref" : "LaunchConfig" },
- 6.       "MinSize" : "1",
- 7.       "MaxSize" : "2",
- 8.       "LoadBalancerNames" : [ { "Ref" : "ElasticLoadBalancer" } ],
- 9.       "Tags" : [ {
-10.          "Key" : "MyTag1",
-11.          "Value" : "Hello World 1",
-12.          "PropagateAtLaunch" : "true"
-13.       }, {
-14.          "Key" : "MyTag2",
-15.          "Value" : "Hello World 2",
-16.          "PropagateAtLaunch" : "false"
-17.       } ]
-18.    }
-19. }
+"WebServerGroup" : {
+   "Type" : "AWS::AutoScaling::AutoScalingGroup",
+   "Properties" : {
+      "AvailabilityZones" : { "Fn::GetAZs" : "" },
+      "LaunchConfigurationName" : { "Ref" : "LaunchConfig" },
+      "MinSize" : "1",
+      "MaxSize" : "2",
+      "LoadBalancerNames" : [ { "Ref" : "ElasticLoadBalancer" } ],
+      "Tags" : [ {
+         "Key" : "MyTag1",
+         "Value" : "Hello World 1",
+         "PropagateAtLaunch" : "true"
+      }, {
+         "Key" : "MyTag2",
+         "Value" : "Hello World 2",
+         "PropagateAtLaunch" : "false"
+      } ]
+   }
+}
 ```
 
 ### YAML<a name="aws-properties-as-tags-example.yaml"></a>
 
 ```
- 1. WebServerGroup:
- 2.   Type: 'AWS::AutoScaling::AutoScalingGroup'
- 3.   Properties:
- 4.     AvailabilityZones: !GetAZs ''
- 5.     LaunchConfigurationName: !Ref LaunchConfig
- 6.     MinSize: '1'
- 7.     MaxSize: '2'
- 8.     LoadBalancerNames:
- 9.       - !Ref ElasticLoadBalancer
-10.     Tags:
-11.       - Key: MyTag1
-12.         Value: Hello World 1
-13.         PropagateAtLaunch: 'true'
-14.       - Key: MyTag2
-15.         Value: Hello World 2
-16.         PropagateAtLaunch: 'false'
+WebServerGroup:
+  Type: 'AWS::AutoScaling::AutoScalingGroup'
+  Properties:
+    AvailabilityZones: !GetAZs ''
+    LaunchConfigurationName: !Ref LaunchConfig
+    MinSize: '1'
+    MaxSize: '2'
+    LoadBalancerNames:
+      - !Ref ElasticLoadBalancer
+    Tags:
+      - Key: MyTag1
+        Value: Hello World 1
+        PropagateAtLaunch: 'true'
+      - Key: MyTag2
+        Value: Hello World 2
+        PropagateAtLaunch: 'false'
 ```

--- a/doc_source/aws-properties-resource-tags.md
+++ b/doc_source/aws-properties-resource-tags.md
@@ -49,28 +49,28 @@ This example shows a `Tags` property\. You specify this property within the `Pro
 ### JSON<a name="aws-properties-resource-tags-example.json"></a>
 
 ```
- 1. "Tags" : [
- 2.       {
- 3.         "Key" : "keyname1",
- 4.         "Value" : "value1"
- 5.       },
- 6.       {
- 7.         "Key" : "keyname2",
- 8.         "Value" : "value2"
- 9.       }
-10.     ]
+"Tags" : [
+      {
+        "Key" : "keyname1",
+        "Value" : "value1"
+      },
+      {
+        "Key" : "keyname2",
+        "Value" : "value2"
+      }
+    ]
 ```
 
 ### YAML<a name="aws-properties-resource-tags-example.yaml"></a>
 
 ```
-1. Tags: 
-2.   - 
-3.     Key: "keyname1"
-4.     Value: "value1"
-5.   - 
-6.     Key: "keyname2"
-7.     Value: "value2"
+Tags: 
+  - 
+    Key: "keyname1"
+    Value: "value1"
+  - 
+    Key: "keyname2"
+    Value: "value2"
 ```
 
 ## See Also<a name="w3ab2c21c14e1626c19"></a>

--- a/doc_source/aws-properties-stack-parameters.md
+++ b/doc_source/aws-properties-stack-parameters.md
@@ -7,39 +7,39 @@ The `Parameters` type contains a set of value pairs that represent the parameter
 ## JSON<a name="aws-properties-stack-parameters-example1.json"></a>
 
 ```
- 1. "Parameters" : {
- 2.    "InstanceType" : {
- 3.       "Type" : "String",
- 4.       "Default" : "m1.small",
- 5.       "Description" : "EC2 instance type, e.g. m1.small, m1.large, etc."
- 6.    },
- 7.    "WebServerPort" : {
- 8.       "Type" : "String",
- 9.       "Default" : "80",
-10.       "Description" : "TCP/IP port of the web server"
-11.    },
-12.    "KeyName" : {
-13.       "Type" : "String",
-14.       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the web server"
-15.    }
-16. }
+"Parameters" : {
+   "InstanceType" : {
+      "Type" : "String",
+      "Default" : "m5.small",
+      "Description" : "EC2 instance type, e.g. m1.small, m1.large, etc."
+   },
+   "WebServerPort" : {
+      "Type" : "String",
+      "Default" : "80",
+      "Description" : "TCP/IP port of the web server"
+   },
+   "KeyName" : {
+      "Type" : "String",
+      "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the web server"
+   }
+}
 ```
 
 ## YAML<a name="aws-properties-stack-parameters-example1.yaml"></a>
 
 ```
- 1. Parameters: 
- 2.   InstanceType: 
- 3.     Type: "String"
- 4.     Default: "m1.small"
- 5.     Description: "EC2 instance type, e.g. m1.small, m1.large, etc."
- 6.   WebServerPort: 
- 7.     Type: "String"
- 8.     Default: "80"
- 9.     Description: "TCP/IP port of the web server"
-10.   KeyName: 
-11.     Type: "String"
-12.     Description: "Name of an existing EC2 KeyPair to enable SSH access to the web server"
+Parameters: 
+  InstanceType: 
+    Type: "String"
+    Default: "m5.large"
+    Description: "EC2 instance type, e.g. m1.small, m1.large, etc."
+  WebServerPort:
+    Type: "String"
+    Default: "80"
+    Description: "TCP/IP port of the web server"
+  KeyName:
+    Type: "String"
+    Description: "Name of an existing EC2 KeyPair to enable SSH access to the web server"
 ```
 
 ## Nested Stack<a name="w3ab2c21c14d223c11"></a>
@@ -49,33 +49,33 @@ You could use the following template to embed a stack \(myStackWithParams\) usin
 ### JSON<a name="aws-properties-stack-parameters-example2.json"></a>
 
 ```
- 1. {
- 2.    "AWSTemplateFormatVersion" : "2010-09-09",
- 3.    "Resources" : {
- 4.       "myStackWithParams" : {
- 5.          "Type" : "AWS::CloudFormation::Stack",
- 6.          "Properties" : {
- 7.             "TemplateURL" : "https://s3.amazonaws.com/cloudformation-templates-us-east-1/EC2ChooseAMI.template",
- 8.             "Parameters" : {
- 9.                "InstanceType" : "t1.micro",
-10.                "KeyName" : "mykey"
-11.             }
-12.          }
-13.       }
-14.    }
-15. }
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+        "myStackWithParams": {
+            "Type": "AWS::CloudFormation::Stack",
+            "Properties": {
+                "TemplateURL": "https://s3.amazonaws.com/cloudformation-templates-us-east-1/EC2ChooseAMI.template",
+                "Parameters": {
+                    "InstanceType": "t3.micro",
+                    "KeyName": "mykey"
+                }
+            }
+        }
+    }
+}
 ```
 
 ### YAML<a name="aws-properties-stack-parameters-example2.yaml"></a>
 
 ```
-1. AWSTemplateFormatVersion: "2010-09-09"
-2. Resources: 
-3.   myStackWithParams: 
-4.     Type: "AWS::CloudFormation::Stack"
-5.     Properties: 
-6.       TemplateURL: "https://s3.amazonaws.com/cloudformation-templates-us-east-1/EC2ChooseAMI.template"
-7.       Parameters: 
-8.         InstanceType: "t1.micro"
-9.         KeyName: "mykey"
+AWSTemplateFormatVersion: "2010-09-09"
+Resources: 
+  myStackWithParams: 
+    Type: "AWS::CloudFormation::Stack"
+    Properties: 
+      TemplateURL: "https://s3.amazonaws.com/cloudformation-templates-us-east-1/EC2Choose.template"
+      Parameters: 
+        InstanceType: "t1.micro"
+        KeyName: "mykey"
 ```

--- a/doc_source/aws-resource-servicecatalog-cloudformationprovisionedproduct.md
+++ b/doc_source/aws-resource-servicecatalog-cloudformationprovisionedproduct.md
@@ -135,26 +135,24 @@ The value for the tag\. You can specify a value that is 1 to 255 Unicode charact
 *Type*: String    Example  This example shows a `Tags` property\. You specify this property within the `Properties` section of a resource that supports it\. When the resource is created, it is tagged with the tags you declare\. JSON 
 
 ```
- 1. "Tags" : [
- 2.       {
- 3.         "Key" : "keyname1",
- 4.         "Value" : "value1"
- 5.       },
- 6.       {
- 7.         "Key" : "keyname2",
- 8.         "Value" : "value2"
- 9.       }
-10.     ]
+"Tags" : [
+      {
+        "Key" : "keyname1",
+        "Value" : "value1"
+      },
+      {
+        "Key" : "keyname2",
+        "Value" : "value2"
+      }
+    ]
 ```  YAML 
 
 ```
-1. Tags: 
-2.   - 
-3.     Key: "keyname1"
-4.     Value: "value1"
-5.   - 
-6.     Key: "keyname2"
-7.     Value: "value2"
+Tags: 
+  - Key: "keyname1"
+    Value: "value1"
+  - Key: "keyname2"
+    Value: "value2"
 ```   See Also   [Setting Stack Options](cfn-console-add-tags.md)   [Viewing Stack Data and Resources](cfn-console-view-stack-data-resources.md)    ](aws-properties-resource-tags.md) property types  
  *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement) 
 

--- a/doc_source/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.md
+++ b/doc_source/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.md
@@ -1,6 +1,6 @@
 # AWS::Include Transform<a name="create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform"></a>
 
-You can use the `AWS::Include` transform to work with template snippets that are stored separately from the main AWS CloudFormation template\. When you specify `Name: 'AWS::Include'` and the `Location` parameter, the `Transform` key is a placeholder where snippets are injected\. AWS CloudFormation inserts those snippets into your main template when [Creating a Change Set](using-cfn-updating-stacks-changesets-create.md) or [Updating Stacks Using Change Sets](using-cfn-updating-stacks-changesets.md)\.
+You can use the `AWS::Include` transform to work with template snippets that are stored separately from the main AWS CloudFormation template\. When you specify `Name: "AWS::Include"` and the `Location` parameter, the `Transform` key is a placeholder where snippets are injected\. AWS CloudFormation inserts those snippets into your main template when [Creating a Change Set](using-cfn-updating-stacks-changesets-create.md) or [Updating Stacks Using Change Sets](using-cfn-updating-stacks-changesets.md)\.
 
 You might have a Lambda function that you want to reuse in one or more AWS CloudFormation templates\. The `AWS::Include` transform lets you create a reference to a transform snippet in an Amazon S3 bucket\. You can add `AWS::Include` to the `Transform` function in your AWS CloudFormation template\. The `AWS::Include` function behaves similarly to an `include`, `copy`, or `import` directive in programming languages\.
 
@@ -15,23 +15,23 @@ To include a transform at the top level of a template, use the following syntax\
 #### JSON<a name="aws-include-syntax-top-level.json"></a>
 
 ```
-1. {
-2.    "Transform" : {
-3.        "Name" : "AWS::Include",
-4.        "Parameters" : {
-5.            "Location" : "s3://MyAmazonS3BucketName/MyFileName.json"
-6.         }
-7.     }
-8. }
+{
+    "Transform": {
+        "Name": "AWS::Include",
+        "Parameters": {
+            "Location": "s3://MyAmazonS3BucketName/MyFileName.json"
+        }
+    }
+}
 ```
 
 #### YAML<a name="aws-include-syntax-top-level.yaml"></a>
 
 ```
-1. Transform:
-2.   Name: 'AWS::Include'
-3.   Parameters:
-4.     Location: 's3://MyAmazonS3BucketName/MyFileName.yaml'
+Transform:
+  Name: "AWS::Include"
+  Parameters:
+    Location: "s3://MyAmazonS3BucketName/MyFileName.yaml"
 ```
 
 ### Syntax When the Transform Is Embedded Within a Section of a Template<a name="aws-include-syntax-embedded-within-section-overview"></a>
@@ -41,23 +41,23 @@ To include a transform that is embedded within a section, use the following synt
 #### JSON<a name="aws-include-syntax-within-section.json"></a>
 
 ```
-1. {
-2.    "Fn::Transform" : {
-3.        "Name" : "AWS::Include",
-4.        "Parameters" : {
-5.            "Location" : "s3://MyAmazonS3BucketName/MyFileName.json"
-6.         }
-7.     }
-8. }
+{
+    "Fn::Transform": {
+        "Name": "AWS::Include",
+        "Parameters": {
+            "Location": "s3://MyAmazonS3BucketName/MyFileName.json"
+        }
+    }
+}
 ```
 
 #### YAML<a name="aws-include-syntax-embedded-within-section.yaml"></a>
 
 ```
-1. 'Fn::Transform':
-2.   Name: 'AWS::Include'
-3.   Parameters:
-4.     Location: s3://MyAmazonS3BucketName/MyFileName.yaml
+"Fn::Transform":
+  Name: "AWS::Include"
+  Parameters:
+    Location: s3://MyAmazonS3BucketName/MyFileName.yaml
 ```
 
 ## Parameters<a name="aws-include-transform-parameters"></a>
@@ -93,35 +93,35 @@ Both the JSON and the YAML versions use the following wait condition snippet\. S
 
 ```
 WebServerWaitHandle:
-  Type: 'AWS::CloudFormation::WaitConditionHandle'
+  Type: "AWS::CloudFormation::WaitConditionHandle"
 ```
 
 ### JSON<a name="aws-include-example.json"></a>
 
 ```
- 1. {
- 2.    "Resources": {
- 3.       "MyWaitHandle": {
- 4.          "Type": "AWS::CloudFormation::WaitConditionHandle"
- 5.       },
- 6.       "Fn::Transform": {
- 7.          "Name": "AWS::Include",
- 8.          "Parameters": {
- 9.             "Location": "s3://MyAmazonS3BucketName/single_wait_condition.yaml"
-10.          }
-11.       }
-12.    }
-13. }
+{
+   "Resources": {
+      "MyWaitHandle": {
+         "Type": "AWS::CloudFormation::WaitConditionHandle"
+      },
+      "Fn::Transform": {
+         "Name": "AWS::Include",
+         "Parameters": {
+            "Location": "s3://MyAmazonS3BucketName/single_wait_condition.yaml"
+         }
+      }
+   }
+}
 ```
 
 ### YAML<a name="aws-include-example.yaml"></a>
 
 ```
-1. Resources:
-2.   MyWaitHandle:
-3.     Type: 'AWS::CloudFormation::WaitConditionHandle'
-4.   'Fn::Transform':
-5.     Name: 'AWS::Include'
-6.     Parameters:
-7.       Location : "s3://MyAmazonS3BucketName/single_wait_condition.yaml"
+Resources:
+  MyWaitHandle:
+    Type: "AWS::CloudFormation::WaitConditionHandle"
+  "Fn::Transform":
+    Name: "AWS::Include"
+    Parameters:
+      Location : "s3://MyAmazonS3BucketName/single_wait_condition.yaml"
 ```

--- a/doc_source/intrinsic-function-reference-findinmap.md
+++ b/doc_source/intrinsic-function-reference-findinmap.md
@@ -58,28 +58,28 @@ The example template contains an `AWS::EC2::Instance` resource whose `ImageId` p
 ### JSON<a name="intrinsic-function-reference-findinmap-example.json"></a>
 
 ```
- 1. {
- 2.   ...
- 3.   "Mappings" : {
- 4.     "RegionMap" : {
- 5.       "us-east-1" : { "32" : "ami-6411e20d", "64" : "ami-7a11e213" },
- 6.       "us-west-1" : { "32" : "ami-c9c7978c", "64" : "ami-cfc7978a" },
- 7.       "eu-west-1" : { "32" : "ami-37c2f643", "64" : "ami-31c2f645" },
- 8.       "ap-southeast-1" : { "32" : "ami-66f28c34", "64" : "ami-60f28c32" },
- 9.       "ap-northeast-1" : { "32" : "ami-9c03a89d", "64" : "ami-a003a8a1" }
-10.     }
-11.   },
-12. 
-13.   "Resources" : {
-14.      "myEC2Instance" : {
-15.         "Type" : "AWS::EC2::Instance",
-16.         "Properties" : {
-17.            "ImageId" : { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "32"]},
-18.            "InstanceType" : "m1.small"
-19.         }
-20.      }
-21.  }
-22. }
+{
+  ...
+  "Mappings" : {
+    "RegionMap" : {
+      "us-east-1" : { "32" : "ami-6411e20d", "64" : "ami-7a11e213" },
+      "us-west-1" : { "32" : "ami-c9c7978c", "64" : "ami-cfc7978a" },
+      "eu-west-1" : { "32" : "ami-37c2f643", "64" : "ami-31c2f645" },
+      "ap-southeast-1" : { "32" : "ami-66f28c34", "64" : "ami-60f28c32" },
+      "ap-northeast-1" : { "32" : "ami-9c03a89d", "64" : "ami-a003a8a1" }
+    }
+  },
+
+  "Resources" : {
+     "myEC2Instance" : {
+        "Type" : "AWS::EC2::Instance",
+        "Properties" : {
+           "ImageId" : { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "32"]},
+           "InstanceType" : "m1.small"
+        }
+     }
+  }
+}
 ```
 
 ### YAML<a name="intrinsic-function-reference-findinmap-example.yaml"></a>

--- a/doc_source/intrinsic-function-reference-getatt.md
+++ b/doc_source/intrinsic-function-reference-getatt.md
@@ -45,13 +45,13 @@ This example snippet returns a string containing the DNS name of the load balanc
 #### JSON<a name="intrinsic-function-reference-getatt-example.json"></a>
 
 ```
-1. "Fn::GetAtt" : [ "myELB" , "DNSName" ]
+"Fn::GetAtt" : [ "myELB" , "DNSName" ]
 ```
 
 #### YAML<a name="intrinsic-function-reference-getatt-example.yaml"></a>
 
 ```
-1. !GetAtt myELB.DNSName
+!GetAtt myELB.DNSName
 ```
 
 #### <a name="intrinsic-function-reference-getatt-example2"></a>

--- a/doc_source/intrinsic-function-reference-getavailabilityzones.md
+++ b/doc_source/intrinsic-function-reference-getavailabilityzones.md
@@ -53,18 +53,18 @@ For these examples, AWS CloudFormation evaluates `Fn::GetAZs` to the following a
 #### JSON<a name="intrinsic-function-reference-getazs-example1.json"></a>
 
 ```
-1. { "Fn::GetAZs" : "" }
-2. { "Fn::GetAZs" : { "Ref" : "AWS::Region" } }
-3. { "Fn::GetAZs" : "us-east-1" }
+{ "Fn::GetAZs" : "" }
+{ "Fn::GetAZs" : { "Ref" : "AWS::Region" } }
+{ "Fn::GetAZs" : "us-east-1" }
 ```
 
 #### YAML<a name="intrinsic-function-reference-getazs-example1.yaml"></a>
 
 ```
-1. Fn::GetAZs: ""
-2. Fn::GetAZs:
-3.   Ref: "AWS::Region"
-4. Fn::GetAZs: us-east-1
+Fn::GetAZs: ""
+Fn::GetAZs:
+  Ref: "AWS::Region"
+Fn::GetAZs: us-east-1
 ```
 
  
@@ -112,18 +112,18 @@ The following examples show valid patterns for using nested intrinsic functions 
 #### YAML<a name="intrinsic-function-reference-select-example3.yaml"></a>
 
 ```
-1. AvailabilityZone: !Select 
-2.   - 0
-3.   - !GetAZs 
-4.     Ref: 'AWS::Region'
+AvailabilityZone: !Select 
+  - 0
+  - !GetAZs 
+    Ref: 'AWS::Region'
 ```
 
 #### YAML<a name="intrinsic-function-reference-select-example4.yaml"></a>
 
 ```
-1. AvailabilityZone: !Select 
-2.   - 0
-3.   - Fn::GetAZs: !Ref 'AWS::Region'
+AvailabilityZone: !Select 
+  - 0
+  - Fn::GetAZs: !Ref 'AWS::Region'
 ```
 
 ## Supported Functions<a name="w3ab2c21c28c36c19"></a>

--- a/doc_source/intrinsic-function-reference-join.md
+++ b/doc_source/intrinsic-function-reference-join.md
@@ -45,13 +45,13 @@ The following example returns: `"a:b:c"`\.
 #### JSON<a name="intrinsic-function-reference-join-example1.json"></a>
 
 ```
-1. "Fn::Join" : [ ":", [ "a", "b", "c" ] ]
+"Fn::Join" : [ ":", [ "a", "b", "c" ] ]
 ```
 
 #### YAML<a name="intrinsic-function-reference-join-example1.yaml"></a>
 
 ```
-1. !Join [ ":", [ a, b, c ] ]
+!Join [ ":", [ a, b, c ] ]
 ```
 
 ### Join Using the Ref Function with Parameters<a name="intrinsic-function-reference-join-example2"></a>
@@ -61,31 +61,31 @@ The following example uses `Fn::Join` to construct a string value\. It uses the 
 #### JSON<a name="intrinsic-function-reference-join-example2.json"></a>
 
 ```
- 1. {
- 2.   "Fn::Join": [
- 3.     "", [
- 4.       "arn:",
- 5.       {
- 6.         "Ref": "Partition"
- 7.       },
- 8.       ":s3:::elasticbeanstalk-*-",
- 9.       {
-10.         "Ref": "AWS::AccountId"
-11.       }
-12.     ]
-13.   ]
-14. }
+{
+  "Fn::Join": [
+    "", [
+      "arn:",
+      {
+        "Ref": "Partition"
+      },
+      ":s3:::elasticbeanstalk-*-",
+      {
+        "Ref": "AWS::AccountId"
+      }
+    ]
+  ]
+}
 ```
 
 #### YAML<a name="intrinsic-function-reference-join-example2.yaml"></a>
 
 ```
-1. !Join
-2.   - ''
-3.   - - 'arn:'
-4.     - !Ref Partition
-5.     - ':s3:::elasticbeanstalk-*-'
-6.     - !Ref 'AWS::AccountId'
+!Join
+  - ''
+  - - 'arn:'
+    - !Ref Partition
+    - ':s3:::elasticbeanstalk-*-'
+    - !Ref 'AWS::AccountId'
 ```
 
 **Note**  

--- a/doc_source/intrinsic-function-reference-select.md
+++ b/doc_source/intrinsic-function-reference-select.md
@@ -66,23 +66,23 @@ You can use `Fn::Select` to select an object from a `CommaDelimitedList` paramet
 #### JSON<a name="intrinsic-function-reference-select-example1.json"></a>
 
 ```
-1. "Parameters" : {
-2.   "DbSubnetIpBlocks": {
-3.     "Description": "Comma-delimited list of three CIDR blocks",
-4.     "Type": "CommaDelimitedList",
-5.       "Default": "10.0.48.0/24, 10.0.112.0/24, 10.0.176.0/24"
-6.   }
-7. }
+"Parameters" : {
+  "DbSubnetIpBlocks": {
+    "Description": "Comma-delimited list of three CIDR blocks",
+    "Type": "CommaDelimitedList",
+      "Default": "10.0.48.0/24, 10.0.112.0/24, 10.0.176.0/24"
+  }
+}
 ```
 
 #### YAML<a name="intrinsic-function-reference-select-example1.yaml"></a>
 
 ```
-1. Parameters: 
-2.   DbSubnetIpBlocks: 
-3.     Description: "Comma-delimited list of three CIDR blocks"
-4.     Type: CommaDelimitedList
-5.     Default: "10.0.48.0/24, 10.0.112.0/24, 10.0.176.0/24"
+Parameters: 
+  DbSubnetIpBlocks: 
+    Description: "Comma-delimited list of three CIDR blocks"
+    Type: CommaDelimitedList
+    Default: "10.0.48.0/24, 10.0.112.0/24, 10.0.176.0/24"
 ```
 
 To specify one of the three CIDR blocks, use `Fn::Select` in the Resources section of the same template, as shown in the following sample snippet:
@@ -118,18 +118,18 @@ The following examples show valid patterns for using nested intrinsic functions 
 #### YAML<a name="intrinsic-function-reference-select-example3.yaml"></a>
 
 ```
-1. AvailabilityZone: !Select 
-2.   - 0
-3.   - !GetAZs 
-4.     Ref: 'AWS::Region'
+AvailabilityZone: !Select 
+  - 0
+  - !GetAZs 
+    Ref: 'AWS::Region'
 ```
 
 #### YAML<a name="intrinsic-function-reference-select-example4.yaml"></a>
 
 ```
-1. AvailabilityZone: !Select 
-2.   - 0
-3.   - Fn::GetAZs: !Ref 'AWS::Region'
+AvailabilityZone: !Select 
+  - 0
+  - Fn::GetAZs: !Ref 'AWS::Region'
 ```
 
 ## Supported Functions<a name="w3ab2c21c28c51c15"></a>

--- a/doc_source/intrinsic-function-reference-split.md
+++ b/doc_source/intrinsic-function-reference-split.md
@@ -51,13 +51,13 @@ The following example splits a string at each vertical bar \(`|`\)\. The functio
 #### JSON<a name="intrinsic-function-reference-split-example.json"></a>
 
 ```
-1. { "Fn::Split" : [ "|" , "a|b|c" ] }
+{ "Fn::Split" : [ "|" , "a|b|c" ] }
 ```
 
 #### YAML<a name="intrinsic-function-reference-split-example.yaml"></a>
 
 ```
-1. !Split [ "|" , "a|b|c" ]
+!Split [ "|" , "a|b|c" ]
 ```
 
  
@@ -69,13 +69,13 @@ If you split a string with consecutive delimiters, the resulting list will inclu
 #### JSON<a name="w3ab2c21c28c55c13b6b4"></a>
 
 ```
-1. { "Fn::Split" : [ "|" , "a||c|" ] }
+{ "Fn::Split" : [ "|" , "a||c|" ] }
 ```
 
 #### YAML<a name="w3ab2c21c28c55c13b6b6"></a>
 
 ```
-1. !Split [ "|" , "a||c|" ]
+!Split [ "|" , "a||c|" ]
 ```
 
  
@@ -87,13 +87,13 @@ The following example splits an imported output value, and then selects the thir
 #### JSON<a name="w3ab2c21c28c55c13b8b4"></a>
 
 ```
-1. { "Fn::Select" : [ "2", { "Fn::Split": [",", {"Fn::ImportValue": "AccountSubnetIDs"}]}] }
+{ "Fn::Select" : [ "2", { "Fn::Split": [",", {"Fn::ImportValue": "AccountSubnetIDs"}]}] }
 ```
 
 #### YAML<a name="w3ab2c21c28c55c13b8b6"></a>
 
 ```
-1. !Select [2, !Split [",", !ImportValue AccountSubnetIDs]]
+!Select [2, !Split [",", !ImportValue AccountSubnetIDs]]
 ```
 
 ## Supported Functions<a name="w3ab2c21c28c55c15"></a>

--- a/doc_source/quickref-cloudwatch.md
+++ b/doc_source/quickref-cloudwatch.md
@@ -74,46 +74,46 @@ The following sample snippet creates an alarm that sends a notification when the
 ### JSON<a name="quickref-cloudwatch-example-2.json"></a>
 
 ```
- 1. "CPUAlarm" : {
- 2.   "Type" : "AWS::CloudWatch::Alarm",
- 3.   "Properties" : {
- 4.     "AlarmDescription" : "CPU alarm for my instance",
- 5.     "AlarmActions" : [ { "Ref" : "logical name of an AWS::SNS::Topic resource" } ],
- 6.     "MetricName" : "CPUUtilization",
- 7.     "Namespace" : "AWS/EC2",
- 8.     "Statistic" : "Average",
- 9.     "Period" : "60",
-10.     "EvaluationPeriods" : "3",
-11.     "Threshold" : "90",
-12.     "ComparisonOperator" : "GreaterThanThreshold",
-13.     "Dimensions" : [ {
-14.       "Name" : "InstanceId",
-15.       "Value" : { "Ref" : "logical name of an AWS::EC2::Instance resource" }
-16.     } ]
-17.   }
-18. }
+ "CPUAlarm" : {
+   "Type" : "AWS::CloudWatch::Alarm",
+   "Properties" : {
+     "AlarmDescription" : "CPU alarm for my instance",
+     "AlarmActions" : [ { "Ref" : "logical name of an AWS::SNS::Topic resource" } ],
+     "MetricName" : "CPUUtilization",
+     "Namespace" : "AWS/EC2",
+     "Statistic" : "Average",
+     "Period" : "60",
+     "EvaluationPeriods" : "3",
+     "Threshold" : "90",
+     "ComparisonOperator" : "GreaterThanThreshold",
+     "Dimensions" : [ {
+       "Name" : "InstanceId",
+       "Value" : { "Ref" : "logical name of an AWS::EC2::Instance resource" }
+     } ]
+   }
+ }
 ```
 
 ### YAML<a name="quickref-cloudwatch-example-2.yaml"></a>
 
 ```
- 1. CPUAlarm:
- 2.   Type: AWS::CloudWatch::Alarm
- 3.   Properties:
- 4.     AlarmDescription: CPU alarm for my instance
- 5.     AlarmActions:
- 6.     - Ref: "logical name of an AWS::SNS::Topic resource"
- 7.     MetricName: CPUUtilization
- 8.     Namespace: AWS/EC2
- 9.     Statistic: Average
-10.     Period: '60'
-11.     EvaluationPeriods: '3'
-12.     Threshold: '90'
-13.     ComparisonOperator: GreaterThanThreshold
-14.     Dimensions:
-15.     - Name: InstanceId
-16.       Value:
-17.         Ref: "logical name of an AWS::EC2::Instance resource"
+CPUAlarm:
+  Type: AWS::CloudWatch::Alarm
+  Properties:
+    AlarmDescription: CPU alarm for my instance
+    AlarmActions:
+    - Ref: "logical name of an AWS::SNS::Topic resource"
+    MetricName: CPUUtilization
+    Namespace: AWS/EC2
+    Statistic: Average
+    Period: '60'
+    EvaluationPeriods: '3'
+    Threshold: '90'
+    ComparisonOperator: GreaterThanThreshold
+    Dimensions:
+    - Name: InstanceId
+      Value:
+        Ref: "logical name of an AWS::EC2::Instance resource"
 ```
 
 ## Recover an Amazon Elastic Compute Cloud Instance<a name="cloudwatch-sample-recover-instance"></a>

--- a/doc_source/quickref-elb.md
+++ b/doc_source/quickref-elb.md
@@ -7,31 +7,31 @@ This example shows an Elastic Load Balancing load balancer with a single listene
 ### JSON<a name="quickref-elb-example-1.json"></a>
 
 ```
- 1. "MyLoadBalancer" : {
- 2.     "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
- 3.     "Properties" : {
- 4.         "AvailabilityZones" : [ "us-east-1a" ],
- 5.         "Listeners" : [ {
- 6.             "LoadBalancerPort" : "80",
- 7.             "InstancePort" : "80",
- 8.             "Protocol" : "HTTP"
- 9.         } ]
-10.     }
-11. }
+"MyLoadBalancer" : {
+    "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
+    "Properties" : {
+        "AvailabilityZones" : [ "us-east-1a" ],
+        "Listeners" : [ {
+            "LoadBalancerPort" : "80",
+            "InstancePort" : "80",
+            "Protocol" : "HTTP"
+        } ]
+    }
+}
 ```
 
 ### YAML<a name="quickref-elb-example-1.yaml"></a>
 
 ```
-1. MyLoadBalancer:
-2.   Type: AWS::ElasticLoadBalancing::LoadBalancer
-3.   Properties:
-4.     AvailabilityZones:
-5.     - "us-east-1a"
-6.     Listeners:
-7.     - LoadBalancerPort: '80'
-8.       InstancePort: '80'
-9.       Protocol: HTTP
+MyLoadBalancer:
+  Type: AWS::ElasticLoadBalancing::LoadBalancer
+  Properties:
+    AvailabilityZones:
+    - "us-east-1a"
+    Listeners:
+    - LoadBalancerPort: '80'
+      InstancePort: '80'
+      Protocol: HTTP
 ```
 
 ## Elastic Load Balancing Load Balancer Resource with Health Check<a name="scenario-elb-load-balancer-with-healthcheck"></a>
@@ -41,50 +41,50 @@ This example shows an Elastic Load Balancing load balancer with two Amazon EC2 i
 ### JSON<a name="quickref-elb-example-2.json"></a>
 
 ```
- 1. "MyLoadBalancer" : {
- 2.     "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
- 3.     "Properties" : {
- 4.         "AvailabilityZones" : [ "us-east-1a" ],
- 5.         "Instances" : [
- 6.             { "Ref" : "logical name of AWS::EC2::Instance resource 1" },
- 7.             { "Ref" : "logical name of AWS::EC2::Instance resource 2" }
- 8.         ],
- 9.         "Listeners" : [ {
-10.             "LoadBalancerPort" : "80",
-11.             "InstancePort" : "80",
-12.             "Protocol" : "HTTP"
-13.         } ],
-14. 
-15.         "HealthCheck" : {
-16.             "Target" : "HTTP:80/",
-17.             "HealthyThreshold" : "3",
-18.             "UnhealthyThreshold" : "5",
-19.             "Interval" : "30",
-20.             "Timeout" : "5"
-21.         }
-22.     }
-23. }
+"MyLoadBalancer" : {
+    "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
+    "Properties" : {
+        "AvailabilityZones" : [ "us-east-1a" ],
+        "Instances" : [
+            { "Ref" : "logical name of AWS::EC2::Instance resource 1" },
+            { "Ref" : "logical name of AWS::EC2::Instance resource 2" }
+        ],
+        "Listeners" : [ {
+            "LoadBalancerPort" : "80",
+            "InstancePort" : "80",
+            "Protocol" : "HTTP"
+        } ],
+
+        "HealthCheck" : {
+            "Target" : "HTTP:80/",
+            "HealthyThreshold" : "3",
+            "UnhealthyThreshold" : "5",
+            "Interval" : "30",
+            "Timeout" : "5"
+        }
+    }
+}
 ```
 
 ### YAML<a name="quickref-elb-example-2.yaml"></a>
 
 ```
- 1. MyLoadBalancer:
- 2.   Type: AWS::ElasticLoadBalancing::LoadBalancer
- 3.   Properties:
- 4.     AvailabilityZones:
- 5.     - "us-east-1a"
- 6.     Instances:
- 7.     - Ref: logical name of AWS::EC2::Instance resource 1
- 8.     - Ref: logical name of AWS::EC2::Instance resource 2
- 9.     Listeners:
-10.     - LoadBalancerPort: '80'
-11.       InstancePort: '80'
-12.       Protocol: HTTP
-13.     HealthCheck:
-14.       Target: HTTP:80/
-15.       HealthyThreshold: '3'
-16.       UnhealthyThreshold: '5'
-17.       Interval: '30'
-18.       Timeout: '5'
+MyLoadBalancer:
+  Type: AWS::ElasticLoadBalancing::LoadBalancer
+  Properties:
+    AvailabilityZones:
+    - "us-east-1a"
+    Instances:
+    - Ref: logical name of AWS::EC2::Instance resource 1
+    - Ref: logical name of AWS::EC2::Instance resource 2
+    Listeners:
+    - LoadBalancerPort: '80'
+      InstancePort: '80'
+      Protocol: HTTP
+    HealthCheck:
+      Target: HTTP:80/
+      HealthyThreshold: '3'
+      UnhealthyThreshold: '5'
+      Interval: '30'
+      Timeout: '5'
 ```

--- a/doc_source/quickref-sns.md
+++ b/doc_source/quickref-sns.md
@@ -5,24 +5,24 @@ This example shows an Amazon SNS topic resource\. It requires a valid email addr
 ## JSON<a name="quickref-sns-example-1.json"></a>
 
 ```
-1. "MySNSTopic" : {
-2.     "Type" : "AWS::SNS::Topic",
-3.     "Properties" : {
-4.         "Subscription" : [ {
-5.             "Endpoint" : "add valid email address",
-6.             "Protocol" : "email"
-7.         } ]
-8.     }
-9. }
+"MySNSTopic" : {
+    "Type" : "AWS::SNS::Topic",
+    "Properties" : {
+        "Subscription" : [ {
+            "Endpoint" : "add valid email address",
+            "Protocol" : "email"
+        } ]
+    }
+}
 ```
 
 ## YAML<a name="quickref-sns-example-1.yaml"></a>
 
 ```
-1. MySNSTopic:
-2.   Type: AWS::SNS::Topic
-3.   Properties:
-4.     Subscription:
-5.     - Endpoint: "add valid email address"
-6.       Protocol: email
+MySNSTopic:
+  Type: AWS::SNS::Topic
+  Properties:
+    Subscription:
+    - Endpoint: "add valid email address"
+      Protocol: email
 ```

--- a/doc_source/scenario-sqs-queue.md
+++ b/doc_source/scenario-sqs-queue.md
@@ -5,19 +5,19 @@ This example shows an Amazon SQS queue\.
 ## JSON<a name="scenario-sqs-queue-example-1.json"></a>
 
 ```
-1. "MyQueue" : {
-2.     "Type" : "AWS::SQS::Queue",
-3.     "Properties" : {
-4.         "VisibilityTimeout" : "value"
-5.     }
-6. }
+"MyQueue" : {
+    "Type" : "AWS::SQS::Queue",
+    "Properties" : {
+        "VisibilityTimeout" : "value"
+    }
+}
 ```
 
 ## YAML<a name="scenario-sqs-queue-example-1.yaml"></a>
 
 ```
-1. MyQueue:
-2.   Type: AWS::SQS::Queue
-3.   Properties:
-4.     VisibilityTimeout: value
+MyQueue:
+  Type: AWS::SQS::Queue
+  Properties:
+    VisibilityTimeout: value
 ```

--- a/doc_source/using-cfn-cli-creating-stack.md
+++ b/doc_source/using-cfn-cli-creating-stack.md
@@ -13,8 +13,9 @@ By default, `aws cloudformation describe-stacks` returns parameter values\. To p
 The following example creates the `myteststack` stack:
 
 ```
-1. PROMPT> aws cloudformation create-stack --stack-name myteststack --template-body file:///home/testuser/mytemplate.json --parameters ParameterKey=Parm1,ParameterValue=test1 ParameterKey=Parm2,ParameterValue=test2
-2. {
-3.   "StackId" : "arn:aws:cloudformation:us-west-2:123456789012:stack/myteststack/330b0120-1771-11e4-af37-50ba1b98bea6"
-4. }
+PROMPT> aws cloudformation create-stack --stack-name myteststack --template-body file:///home/testuser/mytemplate.json --parameters ParameterKey=Parm1,ParameterValue=test1 ParameterKey=Parm2,ParameterValue=test2
+
+{
+   "StackId" : "arn:aws:cloudformation:us-west-2:123456789012:stack/myteststack/330b0120-1771-11e4-af37-50ba1b98bea6"
+}
 ```

--- a/doc_source/using-cfn-cli-deleting-stack.md
+++ b/doc_source/using-cfn-cli-deleting-stack.md
@@ -5,7 +5,7 @@ To delete a stack, you run the `[aws cloudformation delete\-stack](http://docs.a
 The following example deletes the `myteststack` stack:
 
 ```
-1. PROMPT> aws cloudformation delete-stack --stack-name myteststack
+aws cloudformation delete-stack --stack-name myteststack
 ```
 
 **Note**  

--- a/doc_source/using-cfn-get-template.md
+++ b/doc_source/using-cfn-get-template.md
@@ -8,30 +8,31 @@ The `aws cloudformation get-template` command returns the deleted stacks templat
 The following example shows the template for the `myteststack` stack:
 
 ```
- 1. PROMPT> aws cloudformation get-template --stack-name myteststack
- 2. {
- 3.     "TemplateBody": {
- 4.         "AWSTemplateFormatVersion": "2010-09-09",
- 5.         "Outputs": {
- 6.             "BucketName": {
- 7.                 "Description": "Name of S3 bucket to hold website content",
- 8.                 "Value": {
- 9.                     "Ref": "S3Bucket"
-10.                 }
-11.             }
-12.         },
-13.         "Description": "AWS CloudFormation Sample Template S3_Bucket: Sample template showing how to create a publicly accessible S3 bucket. **WARNING** This template creates an S3 bucket.
-14. You will be billed for the AWS resources used if you create a stack from this template.",
-15.         "Resources": {
-16.             "S3Bucket": {
-17.                 "Type": "AWS::S3::Bucket",
-18.                 "Properties": {
-19.                     "AccessControl": "PublicRead"
-20.                 }
-21.             }
-22.         }
-23.     }
-24. }
+ PROMPT> aws cloudformation get-template --stack-name myteststack
+
+ {
+     "TemplateBody": {
+         "AWSTemplateFormatVersion": "2010-09-09",
+         "Outputs": {
+             "BucketName": {
+                 "Description": "Name of S3 bucket to hold website content",
+                 "Value": {
+                     "Ref": "S3Bucket"
+                 }
+             }
+         },
+         "Description": "AWS CloudFormation Sample Template S3_Bucket: Sample template showing how to create a publicly accessible S3 bucket. **WARNING** This template creates an S3 bucket.
+ You will be billed for the AWS resources used if you create a stack from this template.",
+         "Resources": {
+             "S3Bucket": {
+                 "Type": "AWS::S3::Bucket",
+                 "Properties": {
+                     "AccessControl": "PublicRead"
+                 }
+             }
+         }
+     }
+ }
 ```
 
 The output contains the entire template body, enclosed in quotation marks\.

--- a/doc_source/using-cfn-listing-event-history.md
+++ b/doc_source/using-cfn-listing-event-history.md
@@ -6,94 +6,96 @@ In the following example, a sample stack is created from a template file by usin
 
 The following example creates a stack with the name `myteststack` using the `sampletemplate.json` template file: 
 
+`aws cloudformation create-stack --stack-name myteststack --template-body file:///home/local/test/sampletemplate.json `
+
 ```
- 1. PROMPT> aws cloudformation create-stack --stack-name myteststack --template-body file:///home/local/test/sampletemplate.json  
- 2. [
- 3.     {
- 4.         "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
- 5.         "Description": "AWS CloudFormation Sample Template S3_Bucket: Sample template showing how to create a publicly accessible S3 bucket. **WARNING** This template creates an S3 bucket.
- 6. You will be billed for the AWS resources used if you create a stack from this template.",
- 7.         "Tags": [],
- 8.         "Outputs": [
- 9.             {
-10.                 "Description": "Name of S3 bucket to hold website content",
-11.                 "OutputKey": "BucketName",
-12.                 "OutputValue": "myteststack-s3bucket-jssofi1zie2w"
-13.             }
-14.         ],
-15.         "StackStatusReason": null,
-16.         "CreationTime": "2013-08-23T01:02:15.422Z",
-17.         "Capabilities": [],
-18.         "StackName": "myteststack",
-19.         "StackStatus": "CREATE_COMPLETE",
-20.         "DisableRollback": false
-21.     }
-22. ]
+ [
+     {
+         "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
+         "Description": "AWS CloudFormation Sample Template S3_Bucket: Sample template showing how to create a publicly accessible S3 bucket. **WARNING** This template creates an S3 bucket.
+ You will be billed for the AWS resources used if you create a stack from this template.",
+         "Tags": [],
+         "Outputs": [
+             {
+                 "Description": "Name of S3 bucket to hold website content",
+                 "OutputKey": "BucketName",
+                 "OutputValue": "myteststack-s3bucket-jssofi1zie2w"
+             }
+         ],
+         "StackStatusReason": null,
+         "CreationTime": "2013-08-23T01:02:15.422Z",
+         "Capabilities": [],
+         "StackName": "myteststack",
+         "StackStatus": "CREATE_COMPLETE",
+         "DisableRollback": false
+     }
+ ]
 ```
 
 The following example describes the `myteststack` stack:
 
+`aws cloudformation describe-stack-events --stack-name myteststack`
+
 ```
- 1. PROMPT> aws cloudformation describe-stack-events --stack-name myteststack
- 2. {
- 3.     "StackEvents": [
- 4.         {
- 5.             "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
- 6.             "EventId": "af67ef60-0b8f-11e3-8b8a-500150b352e0",
- 7.             "ResourceStatus": "CREATE_COMPLETE",
- 8.             "ResourceType": "AWS::CloudFormation::Stack",
- 9.             "Timestamp": "2013-08-23T01:02:30.070Z",
-10.             "StackName": "myteststack",
-11.             "PhysicalResourceId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/a69442d0-0b8f-11e3-8b8a-500150b352e0",
-12.             "LogicalResourceId": "myteststack"
-13.         },
-14.         {
-15.             "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
-16.             "EventId": "S3Bucket-CREATE_COMPLETE-1377219748025",
-17.             "ResourceStatus": "CREATE_COMPLETE",
-18.             "ResourceType": "AWS::S3::Bucket",
-19.             "Timestamp": "2013-08-23T01:02:28.025Z",
-20.             "StackName": "myteststack",
-21.             "ResourceProperties": "{\"AccessControl\":\"PublicRead\"}",
-22.             "PhysicalResourceId": "myteststack-s3bucket-jssofi1zie2w",
-23.             "LogicalResourceId": "S3Bucket"
-24.         },
-25.         {
-26.             "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
-27.             "EventId": "S3Bucket-CREATE_IN_PROGRESS-1377219746688",
-28.             "ResourceStatus": "CREATE_IN_PROGRESS",
-29.             "ResourceType": "AWS::S3::Bucket",
-30.             "Timestamp": "2013-08-23T01:02:26.688Z",
-31.             "ResourceStatusReason": "Resource creation Initiated",
-32.             "StackName": "myteststack",
-33.             "ResourceProperties": "{\"AccessControl\":\"PublicRead\"}",
-34.             "PhysicalResourceId": "myteststack-s3bucket-jssofi1zie2w",
-35.             "LogicalResourceId": "S3Bucket"
-36.         },
-37.         {
-38.             "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
-39.             "EventId": "S3Bucket-CREATE_IN_PROGRESS-1377219743862",
-40.             "ResourceStatus": "CREATE_IN_PROGRESS",
-41.             "ResourceType": "AWS::S3::Bucket",
-42.             "Timestamp": "2013-08-23T01:02:23.862Z",
-43.             "StackName": "myteststack",
-44.             "ResourceProperties": "{\"AccessControl\":\"PublicRead\"}",
-45.             "PhysicalResourceId": null,
-46.             "LogicalResourceId": "S3Bucket"
-47.         },
-48.         {
-49.             "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
-50.             "EventId": "a69469e0-0b8f-11e3-8b8a-500150b352e0",
-51.             "ResourceStatus": "CREATE_IN_PROGRESS",
-52.             "ResourceType": "AWS::CloudFormation::Stack",
-53.             "Timestamp": "2013-08-23T01:02:15.422Z",
-54.             "ResourceStatusReason": "User Initiated",
-55.             "StackName": "myteststack",
-56.             "PhysicalResourceId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/a69442d0-0b8f-11e3-8b8a-500150b352e0",
-57.             "LogicalResourceId": "myteststack"
-58.         }
-59.     ]
-60. }
+{
+    "StackEvents": [
+        {
+            "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
+            "EventId": "af67ef60-0b8f-11e3-8b8a-500150b352e0",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "2013-08-23T01:02:30.070Z",
+            "StackName": "myteststack",
+            "PhysicalResourceId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/a69442d0-0b8f-11e3-8b8a-500150b352e0",
+            "LogicalResourceId": "myteststack"
+        },
+        {
+            "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
+            "EventId": "S3Bucket-CREATE_COMPLETE-1377219748025",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::S3::Bucket",
+            "Timestamp": "2013-08-23T01:02:28.025Z",
+            "StackName": "myteststack",
+            "ResourceProperties": "{\"AccessControl\":\"PublicRead\"}",
+            "PhysicalResourceId": "myteststack-s3bucket-jssofi1zie2w",
+            "LogicalResourceId": "S3Bucket"
+        },
+        {
+            "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
+            "EventId": "S3Bucket-CREATE_IN_PROGRESS-1377219746688",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::S3::Bucket",
+            "Timestamp": "2013-08-23T01:02:26.688Z",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "StackName": "myteststack",
+            "ResourceProperties": "{\"AccessControl\":\"PublicRead\"}",
+            "PhysicalResourceId": "myteststack-s3bucket-jssofi1zie2w",
+            "LogicalResourceId": "S3Bucket"
+        },
+        {
+            "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
+            "EventId": "S3Bucket-CREATE_IN_PROGRESS-1377219743862",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::S3::Bucket",
+            "Timestamp": "2013-08-23T01:02:23.862Z",
+            "StackName": "myteststack",
+            "ResourceProperties": "{\"AccessControl\":\"PublicRead\"}",
+            "PhysicalResourceId": null,
+            "LogicalResourceId": "S3Bucket"
+        },
+        {
+            "StackId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896",
+            "EventId": "a69469e0-0b8f-11e3-8b8a-500150b352e0",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "2013-08-23T01:02:15.422Z",
+            "ResourceStatusReason": "User Initiated",
+            "StackName": "myteststack",
+            "PhysicalResourceId": "arn:aws:cloudformation:us-east-2:123456789012:stack/myteststack/a69442d0-0b8f-11e3-8b8a-500150b352e0",
+            "LogicalResourceId": "myteststack"
+        }
+    ]
+}
 ```
 
 **Note**  

--- a/doc_source/using-cfn-listing-stack-resources.md
+++ b/doc_source/using-cfn-listing-stack-resources.md
@@ -5,19 +5,20 @@ Immediately after you run the `[aws cloudformation create\-stack](http://docs.aw
 The following example shows the resources for the `myteststack` stack:
 
 ```
- 1. PROMPT> aws cloudformation list-stack-resources --stack-name myteststack
- 2. {
- 3.     "StackResourceSummaries": [
- 4.         {
- 5.             "ResourceStatus": "CREATE_COMPLETE",
- 6.             "ResourceType": "AWS::S3::Bucket",
- 7.             "ResourceStatusReason": null,
- 8.             "LastUpdatedTimestamp": "2013-08-23T01:02:28.025Z",
- 9.             "PhysicalResourceId": "myteststack-s3bucket-sample",
-10.             "LogicalResourceId": "S3Bucket"
-11.         }
-12.     ]
-13. }
+PROMPT> aws cloudformation list-stack-resources --stack-name myteststack
+
+{
+    "StackResourceSummaries": [
+        {
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::S3::Bucket",
+            "ResourceStatusReason": null,
+            "LastUpdatedTimestamp": "2013-08-23T01:02:28.025Z",
+            "PhysicalResourceId": "myteststack-s3bucket-sample",
+            "LogicalResourceId": "S3Bucket"
+        }
+    ]
+}
 ```
 
 AWS CloudFormation reports resource details on any running or deleted stack\. If you specify the name of a stack whose status is `CREATE_IN_PROCESS`, AWS CloudFormation reports only those resources whose status is `CREATE_COMPLETE`\.


### PR DESCRIPTION
*Description of changes:*
There are inconsistencies when it comes to JSON/YAML examples. Some of the examples include line numbers which make it tedious to copy and paste. In order to streamline the usability of our examples, I propose that we remove line numbers from code example areas. Also, where possible the structure of our JSON examples could be run through a "beautifier" which format's into a standardized structure. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
