### PR TITLE
SpotFleet LaunchTemplate version is required

### DIFF
--- a/doc_source/aws-properties-ec2-spotfleet-fleetlaunchtemplatespecification.md
+++ b/doc_source/aws-properties-ec2-spotfleet-fleetlaunchtemplatespecification.md
@@ -38,7 +38,9 @@ Minimum length of 3\. Maximum length of 128\. Names must match the following pat
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)
 
 `Version`  <a name="cfn-ec2-spotfleet-fleetlaunchtemplatespecification-version"></a>
-The version number\. By default, the default version of the launch template is used\.  
-*Required*: No  
+The version number\. AWS CloudFormation does not support specifying `$Latest`, or `$Default` for the template version number\.  
+Minimum length of 1\. Maximum length of 255\. Versions must fit the following pattern:   
+`[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]* `  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)


### PR DESCRIPTION
Change "Version" in SpotFleet LaunchTemplateSpecification to required, matching my tests with CloudFormation (I receive the error message "Property Version cannot be empty" when I attempt to create this resource without a Version.) Text copied from ASG equivalent: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-launchtemplatespecification.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
