### PR TITLE
SpotFleet LaunchTemplateConfig requires LaunchTemplateSpecification

### DIFF
--- a/doc_source/aws-properties-ec2-spotfleet-launchtemplateconfig.md
+++ b/doc_source/aws-properties-ec2-spotfleet-launchtemplateconfig.md
@@ -25,7 +25,7 @@
 
 `LaunchTemplateSpecification`  <a name="cfn-ec2-spotfleet-launchtemplateconfig-launchtemplatespecification"></a>
 The launch template\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: [Amazon EC2 SpotFleet FleetLaunchTemplateSpecification](aws-properties-ec2-spotfleet-fleetlaunchtemplatespecification.md)  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)
 


### PR DESCRIPTION
LaunchTemplateSpecification is listed as not required in LaunchTemplateConfig, but when omitted, CF returns: "At least one LaunchTemplateConfig does not have LaunchTemplateSpecification." (This makes sense -- a LaunchTemplateConfig wouldn't be much good without a launch template to refer to.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
