### PR TITLE
Document size restriction on MinInstancesInService

### DIFF
--- a/doc_source/aws-attribute-updatepolicy.md
+++ b/doc_source/aws-attribute-updatepolicy.md
@@ -97,7 +97,7 @@ Specifies the maximum number of instances that AWS CloudFormation updates\.
 *Required*: No
 
 `MinInstancesInService`  <a name="cfn-attributes-updatepolicy-rollingupdate-mininstancesinservice"></a>
-Specifies the minimum number of instances that must be in service within the Auto Scaling group while AWS CloudFormation updates old instances\.  
+Specifies the minimum number of instances that must be in service within the Auto Scaling group while AWS CloudFormation updates old instances\. Must be less than the Auto Scaling group's Max size.
 *Default*: `0`  
 *Type*: Integer  
 *Required*: No


### PR DESCRIPTION
After seeing this error during a deployment:

> AWS::AutoScaling::AutoScalingGroup AutoScalingGroup UPDATE_FAILED: MinInstancesInService must be less than the autoscaling group's MaxSize

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
