### PR TITLE
removed unintentional ambiguity in working-with-templates-cfn-designer-walkthrough-createbasicwebserver.md

### DIFF
--- a/doc_source/working-with-templates-cfn-designer-walkthrough-createbasicwebserver.md
+++ b/doc_source/working-with-templates-cfn-designer-walkthrough-createbasicwebserver.md
@@ -144,7 +144,7 @@ When you rename a resource, you rename its logical ID, which is the name that is
 
    The `WebServerInstance` resource depends on the public route to route traffic to the Internet\. Without the public route, the instance cannot send a signal \(using the cfn\-signal helper script\) to notify AWS CloudFormation when the instance configuration and application deployments are complete\.
 
-1. Drag a connection from the `PublicRouteTable` resource to the `PublicSubnet` resource to associate the route table and subnet\.
+1. Create another dependency from the `PublicRouteTable` resource to the `PublicSubnet` resource to associate the route table and subnet\.
 
    Now the public subnet will use the public route table to direct traffic\.
 


### PR DESCRIPTION
changed "drag a connection" to "create another dependency" as the old language is ambiguous, while it still makes sense I found it confusing while following along. Explicit instructions help remove roadblocks.

file: working-with-templates-cfn-designer-walkthrough-createbasicwebserver.md

Thank you!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
