### PR TITLE
added "WindowTargetIds" to the Target parameter

### DIFF
--- a/doc_source/aws-resource-ssm-maintenancewindowtask.md
+++ b/doc_source/aws-resource-ssm-maintenancewindowtask.md
@@ -86,10 +86,10 @@ The maximum number of targets that you can run this task for, in parallel\.
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `Targets`  <a name="cfn-ssm-maintenancewindowtask-targets"></a>
-The targets, either instances, tags, or a window target id\.  
+The targets, either instances, tags, or window target id's\.  
 + Specify instances using `Key=instanceids,Values=instanceid1,instanceid2`\.
 + Specify tags using `Key=tag name,Values=tag value`\.
-+ Specify window target id's using `Key=WindowTargetIds,Values=windowtargetid1,windowstargetid2`
++ Specify window target id's using `Key=WindowTargetIds,Values=windowtargetid1,windowtargetid2`
  *Required*: Yes  
  *Type*: List of [Systems Manager MaintenanceWindowTask Target](aws-properties-ssm-maintenancewindowtask-target.md)  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 

--- a/doc_source/aws-resource-ssm-maintenancewindowtask.md
+++ b/doc_source/aws-resource-ssm-maintenancewindowtask.md
@@ -86,9 +86,10 @@ The maximum number of targets that you can run this task for, in parallel\.
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `Targets`  <a name="cfn-ssm-maintenancewindowtask-targets"></a>
-The targets, either instances or tags\.  
+The targets, either instances, tags, or a window target id\.  
 + Specify instances using `Key=instanceids,Values=instanceid1,instanceid2`\.
 + Specify tags using `Key=tag name,Values=tag value`\.
++ Specify window target id's using `Key=WindowTargetIds,Values=windowtargetid1,windowstargetid2`
  *Required*: Yes  
  *Type*: List of [Systems Manager MaintenanceWindowTask Target](aws-properties-ssm-maintenancewindowtask-target.md)  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 


### PR DESCRIPTION
*Description of changes:*
Documentation was missing infomation about using "WindowTargetIds" for the Target parameter of the "AWS::SSM::MaintenanceWindowTask" resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
