### PR TITLE
Clarifying docs for AWS::APIGateway::Method::Integration CacheKeyParameters

### DIFF
--- a/doc_source/aws-properties-apitgateway-method-integration.md
+++ b/doc_source/aws-properties-apitgateway-method-integration.md
@@ -52,7 +52,7 @@
 ## Properties<a name="w4ab1c21c14c41b7"></a>
 
 `CacheKeyParameters`  <a name="cfn-apigateway-method-integration-cachekeyparameters"></a>
-A list of request parameters whose values API Gateway caches\.  
+A list of request parameters whose values API Gateway caches\. To be valid, any request parameters used here must also be present in the method's configured `RequestParameters` property\.
 *Required*: No  
 *Type*: List of String values
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This modifies the documentation for `AWS::APIGateway::Method::Integration` to make it clear that anything listed in the `CacheKeyParameters` property must also be present in the `Method`'s `RequestParameters` property to be valid.

I recently had some back and forth with AWS Support (I can share a Case ID if it's helpful) in which we were trying to enable caching for an endpoint and were unable to because we didn't realize the parameters we were using for `CacheKeyParameters` needed to also be in `RequestParameters` as that's not explicitly documented.
