### PR TITLE
Add Pattern restriction docs for IdentityPoolName

### DIFF
--- a/doc_source/aws-resource-cognito-identitypool.md
+++ b/doc_source/aws-resource-cognito-identitypool.md
@@ -138,5 +138,4 @@ For more information about using the `Ref` function, see [Ref](intrinsic-functio
 
 `Name`  
 The name of the Amazon Cognito identity pool, returned as a string\.
-
 For more information about using `Fn::GetAtt`, see [Fn::GetAtt](intrinsic-function-reference-getatt.md)\.


### PR DESCRIPTION
I couldn't figure out why my `IdentityPoolName` was failing validation with `-` in it as from the docs there only appeared to be a length restriction.
 
I finally found the pattern restriction on the property here: https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_CreateIdentityPool.html#API_CreateIdentityPool_RequestSyntax

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
