### PR TITLE
Add Pattern restriction docs for IdentityPoolName

### DIFF
--- a/doc_source/aws-resource-cognito-identitypool.md
+++ b/doc_source/aws-resource-cognito-identitypool.md
@@ -66,6 +66,7 @@ The name of your Amazon Cognito identity pool\.
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)  
 MinLength: 1  
 MaxLength: 128
+Pattern: [\w ]+
 
 `AllowUnauthenticatedIdentities`  <a name="cfn-cognito-identitypool-allowunauthenticatedidentities"></a>
 Specifies whether the identity pool supports unauthenticated logins\.  


### PR DESCRIPTION
*Issue #, if available:*

I couldn't figure out why my IdentityPoolName was failing validation with - in it as from the docs there only appeared to be a length restriction.

*Description of changes:*

I finally found the pattern restriction on the property [here](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_CreateIdentityPool.html#API_CreateIdentityPool_RequestSyntax), and have updated the cloudformation docc to include the Pattern.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
