### PR TITLE
Add link to default/valid values for ELBv2 healthcheck interval

### DIFF
--- a/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
@@ -68,6 +68,7 @@ Properties:
 
 `HealthCheckIntervalSeconds`  <a name="cfn-elasticloadbalancingv2-targetgroup-healthcheckintervalseconds"></a>
 The approximate number of seconds between health checks for an individual target\.  
+For valid and default values when using the TCP protocol for the load balancer see the `HealthCheckIntervalSeconds` parameter for the [CreateTargetGroup](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html) action in the *Elastic Load Balancing API Reference version 2015\-12\-01*\.
 *Required*: No  
 *Type*: Integer  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adding a link as with other parameters to the relevant API reference docs around valid and default values for the HealthCheckIntervalSeconds parameter. Ran into this when attempting to create a NetworkLoadBalancer and trying to set the interval to 5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
