### PR TITLE
Add ref to valid/default values for TargetGroup HealthCheckPath

### DIFF
--- a/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
@@ -75,6 +75,7 @@ For valid and default values when using the TCP protocol for the load balancer s
 
 `HealthCheckPath`  <a name="cfn-elasticloadbalancingv2-targetgroup-healthcheckpath"></a>
 The ping path destination where Elastic Load Balancing sends health check requests\.  
+For valid and default values, see the `HealthCheckPath` parameter for the [CreateTargetGroup](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html) action in the *Elastic Load Balancing API Reference version 2015\-12\-01*\.
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)

--- a/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
@@ -75,7 +75,7 @@ For valid and default values when using the TCP protocol for the load balancer s
 
 `HealthCheckPath`  <a name="cfn-elasticloadbalancingv2-targetgroup-healthcheckpath"></a>
 The ping path destination where Elastic Load Balancing sends health check requests\.  
-For valid and default values, see the `HealthCheckPath` parameter for the [CreateTargetGroup](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html) action in the *Elastic Load Balancing API Reference version 2015\-12\-01*\.
+This must start with a '/'. For more detail on valid and default values, see the `HealthCheckPath` parameter for the [CreateTargetGroup](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html) action in the *Elastic Load Balancing API Reference version 2015\-12\-01*\.
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding, as with other parameters, a link to the API docs to make clear that there's defaults and limits on the `HealthCheckPath` param on ELB V2 TargetGroups. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
