### PR TITLE
add ACM certificate timeout warning

### DIFF
--- a/doc_source/aws-resource-certificatemanager-certificate.md
+++ b/doc_source/aws-resource-certificatemanager-certificate.md
@@ -5,6 +5,8 @@ The `AWS::CertificateManager::Certificate` resource requests an AWS Certificate 
 **Important**  
 When you use the `AWS::CertificateManager::Certificate` resource in an AWS CloudFormation stack, the stack will remain in the `CREATE_IN_PROGRESS` state and any further stack operations will be delayed until you validate the certificate request, either by acting upon the instructions in the certificate validation email, or by adding a CNAME record to your DNS configuration\.
 
+If the certificate request is not validated within XXX hours, the stack will time out and be rolled back, deleting the pending certificate.
+
 **Topics**
 + [Syntax](#aws-resource-certificatemanager-certificate-syntax)
 + [Properties](#aws-resource-certificatemanager-certificate-properties)


### PR DESCRIPTION
[Setting AWS CloudFormation Stack Options](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html) says:

> By default, there is no timeout for stack creation. However, individual resources may have their own timeouts based on the nature of the service they implement. For example, if an individual resource in your stack times out, stack creation also times out even if the timeout you specified for stack creation has not yet been reached.

It would be very helpful to have the resource timeout (currently appears to be 12 hours) included in the documentation for this resource.

*Issue #, if available:*

*Description of changes:*
Add a note about the resource timeout for this resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
