### PR TITLE
Clarify that RouteTableIds property applies to gateway endpoints only

### DIFF
--- a/doc_source/aws-resource-ec2-vpcendpoint.md
+++ b/doc_source/aws-resource-ec2-vpcendpoint.md
@@ -63,7 +63,7 @@ Properties:
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)
 
 `RouteTableIds`  <a name="cfn-ec2-vpcendpoint-routetableids"></a>
-One or more route table IDs that are used by the VPC to reach the endpoint\.  
+\[Gateway endpoint\] One or more route table IDs that are used by the VPC to reach the endpoint\.  
 *Required*: No  
 *Type*: List of String values  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpcEndpoint.html

*Issue #, if available:*

*Description of changes:*
* Clarify that RouteTableIds property applies to gateway endpoints only

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.