### PR TITLE
Fixing minor typo in the Serverless Transform page.

### DIFF
--- a/doc_source/transform-aws-serverless.md
+++ b/doc_source/transform-aws-serverless.md
@@ -2,7 +2,7 @@
 
 The `AWS::Serverless` transform, which is a macro hosted by AWS CloudFormation, takes an entire template written in the AWS Serverless Application Model \(AWS SAM\) syntax and transforms and expands it into a compliant AWS CloudFormation template\. For more information about serverless applications and AWS SAM, see [Deploying Lambda\-based Applications](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html) in the *AWS Lambda Developer Guide*\.
 
-Unlike custom macros, the `AWS::Serverless` transform doesn't require any special permissions to use it because it is hosted by AWS CloudFormation\. It can be used by templates in any account within AWS CloudFormation\. Also, there is no charge incured when using this tranform\. AWS CloudFormation treats the `AWS::Serverless` transform the same as any other macro in terms of evaluation order and scope\. For more information about macros, see [Using AWS CloudFormation Macros to Perform Custom Processing on Templates](template-macros.md)\.
+Unlike custom macros, the `AWS::Serverless` transform doesn't require any special permissions to use it because it is hosted by AWS CloudFormation\. It can be used by templates in any account within AWS CloudFormation\. Also, there is no charge incured when using this transform\. AWS CloudFormation treats the `AWS::Serverless` transform the same as any other macro in terms of evaluation order and scope\. For more information about macros, see [Using AWS CloudFormation Macros to Perform Custom Processing on Templates](template-macros.md)\.
 
 In the following example, the template uses AWS SAM syntax to simplify the declaration of a Lambda function and its execution role\.
 


### PR DESCRIPTION
*Issue #, if available:* No issue filed. 

*Description of changes:* Fixing minor typo in the serverless transform page ( "tranform" fixed to "transform"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
