### PR TITLE
Fix typo UsagePlan-ApiStage throttle

### DIFF
--- a/doc_source/aws-properties-apigateway-usageplan-apistage.md
+++ b/doc_source/aws-properties-apigateway-usageplan-apistage.md
@@ -40,5 +40,5 @@ The name of an API Gateway stage to associate with the usage plan\.
 Map containing method\-level throttling information for API stage in a usage plan\.  
 Duplicates are not allowed\.  
 *Required*: No  
-*Type*: Map of sting\-to\-[Amazon API Gateway UsagePlan ThrottleSettings](aws-properties-apigateway-usageplan-throttlesettings.md)  
+*Type*: Map of string\-to\-[Amazon API Gateway UsagePlan ThrottleSettings](aws-properties-apigateway-usageplan-throttlesettings.md)  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*
None. Opportunistic.

*Description of changes:*
Fixes a typo in UsagePlan-ApiStage from `_sting_` -> `_string_`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
