### PR TITLE
Ref returns resource ID, not name

### DIFF
--- a/doc_source/aws-resource-route53-hostedzone.md
+++ b/doc_source/aws-resource-route53-hostedzone.md
@@ -79,13 +79,7 @@ If this property was specified previously and you're modifying values, updates r
 
 ### Ref<a name="w4ab1c21c10e1049c11b2"></a>
 
-When the logical ID of this resource is provided to the `Ref` intrinsic function, `Ref` returns the resource name\. For example:
-
-```
-{ "Ref": "myHostedZone" }
-```
-
-`Ref` returns the hosted zone ID, such as `Z23ABC4XYZL05B`\.
+When the logical ID of this resource is provided to the `Ref` intrinsic function, `Ref` returns the hosted zone ID, such as `Z23ABC4XYZL05B`\.
 
 For more information about using the `Ref` function, see [Ref](intrinsic-function-reference-ref.md)\.
 


### PR DESCRIPTION
also, I'm not sure why some of the doc pages provide the example of calling Ref, and some don't - so I removed that

also, just btw, the [docs page](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html) has a bad link to the github file (.xml rather than .md)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
