### PR TITLE
Clarify wording of domain name requirements for API Gateway resource

### DIFF
--- a/doc_source/aws-resource-apigateway-domainname.md
+++ b/doc_source/aws-resource-apigateway-domainname.md
@@ -50,7 +50,7 @@ The reference to an AWS\-managed certificate for use by the edge\-optimized endp
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)
 
 `DomainName`  <a name="cfn-apigateway-domainname-domainname"></a>
-The custom domain name for your API in Amazon API Gateway\.  
+The custom domain name for your API in Amazon API Gateway\.The domain must be lower case\.
 *Required*: Yes  
 *Type*: String  
 *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement)


### PR DESCRIPTION
*Description of changes:*

Users have indicated unexpected stack failures when using capital letters in the DomainName property. The stack error message is not clear enough to indicate that capital letters are not allowed. A use case for why capital letters may be inserted is if the user is trying to Fn::Sub the stack name into the DomainName property, and it's common for stack names to have capital letters. Adding this change would prevent confusion for future users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
