### PR TITLE
Listener Rule Condition Values Clarification

### DIFF
--- a/doc_source/aws-properties-elasticloadbalancingv2-listenerrule-conditions.md
+++ b/doc_source/aws-properties-elasticloadbalancingv2-listenerrule-conditions.md
@@ -30,6 +30,6 @@ For valid values, see the `Field` contents for the [RuleCondition](https://docs.
 *Type*: String
 
 `Values`  <a name="cfn-elasticloadbalancingv2-listenerrule-conditions-values"></a>
-The value for the field that you specified in the `Field` property\.  
+The values for the field that you specified in the `Field` property\. For the number of values required for the `Field` you have selected, please refer to the [RuleCondition](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_RuleCondition.html) data type in the *Elastic Load Balancing API Reference version 2015\-12\-01*\.  
 *Required*: No  
 *Type*: List of String values


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Updated the wording on the listernerrules-condition properties page to better clarify what the values are. This is because it may be confusing for some customers who try and combine multiple `host-headers` together that they need to refer to the API to know how many values are accepted by a given `Field`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
