### PR TITLE
added T3 instances for options related to CPU credits

### DIFF
--- a/doc_source/aws-properties-ec2-instance-creditspecification.md
+++ b/doc_source/aws-properties-ec2-instance-creditspecification.md
@@ -1,6 +1,6 @@
 # Amazon EC2 Instance CreditSpecification<a name="aws-properties-ec2-instance-creditspecification"></a>
 
-<a name="aws-properties-ec2-instance-creditspecification-description"></a>The `CreditSpecification` property type specifies the credit option for CPU usage of a T2 instance\.
+<a name="aws-properties-ec2-instance-creditspecification-description"></a>The `CreditSpecification` property type specifies the credit option for CPU usage of a T2 or T3 instance\.
 
 <a name="aws-properties-ec2-instance-creditspecification-inheritance"></a> `CreditSpecification` is a property of the [AWS::EC2::Instance](aws-properties-ec2-instance.md) resource\.
 
@@ -25,7 +25,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-ec2-instance-creditspecification-properties"></a>
 
 `CPUCredits`  <a name="cfn-ec2-instance-creditspecification-cpucredits"></a>
-The credit option for CPU usage of a T2 instance\. Valid values are `standard` and `unlimited`\. By default, `standard` is specified\.  
+The credit option for CPU usage of a T2 or T3 instance\. Valid values are `standard` and `unlimited`\. T3 instances launch as `unlimited` by default\. T2 instances launch as `standard` by default\.  
  *Required*: No  
  *Type*: String  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 

--- a/doc_source/aws-properties-ec2-instance.md
+++ b/doc_source/aws-properties-ec2-instance.md
@@ -126,7 +126,7 @@ Defines a set of Amazon Elastic Block Store block device mappings, ephemeral ins
 *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement)\. If you change only the `DeleteOnTermination` property for one or more block devices, update requires [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)\.
 
 `CreditSpecification`  <a name="cfn-ec2-instance-creditspecification"></a>
-Specifies the credit option for CPU usage of a T2 instance\.  
+Specifies the credit option for CPU usage of a T2 or T3 instance\.  
 *Required*: No  
 *Type*: [Amazon EC2 Instance CreditSpecification](aws-properties-ec2-instance-creditspecification.md)\.  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding T3 instances where we talk about credit options for EC2 T2 family.
(this is to replace #193)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
