### PR TITLE
Update aws-properties-cloudtrail-trail-dataresource.md

### DIFF
--- a/doc_source/aws-properties-cloudtrail-trail-dataresource.md
+++ b/doc_source/aws-properties-cloudtrail-trail-dataresource.md
@@ -35,7 +35,7 @@ The resource type to log data events for\. You can specify the following values:
 
 `Values`  <a name="cfn-cloudtrail-trail-dataresource-values"></a>
 A list of ARN\-like strings for the specified Amazon S3 objects\.  
-To log data events for all objects in all Amazon S3 buckets in your AWS account, specify the prefix as `arn:aws:s3:::`\.  
+To log data events for all objects in all Amazon S3 buckets in your AWS account, specify the prefix as `arn:aws:s3`\.  
 To log data events for all objects in an Amazon S3 bucket, specify the bucket and an empty object prefix such as `arn:aws:s3:::bucket-1/`\. The trail logs data events for all objects in this Amazon S3 bucket\.  
 To log data events for specific objects, specify the Amazon S3 bucket and object prefix such as `arn:aws:s3:::bucket-1/example-images`\. The trail logs data events for objects in the bucket that match the prefix\.  
  *Required*: No  


### PR DESCRIPTION
Typo? arn:aws:s3 works as opposed to arn:aws:s3::: for all current (& future?) buckets. The docs suggested to use 3 trailing ::: but that gave errors at deploy time, ommitting the ::: works.

*Issue #, if available:*

typo?

*Description of changes:*

removed 3 trailing ::: in setting for all buckets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
