### PR TITLE
Fix formatting of YAML example

### DIFF
--- a/doc_source/aws-properties-codebuild-project-source.md
+++ b/doc_source/aws-properties-codebuild-project-source.md
@@ -24,7 +24,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-properties-codebuild-project-source-syntax.yaml"></a>
 
 ```
-[Auth](#cfn-codebuild-project-source-auth):[*SourceAuth*](aws-properties-codebuild-project-sourceauth.md)
+[Auth](#cfn-codebuild-project-source-auth): [*SourceAuth*](aws-properties-codebuild-project-sourceauth.md)
 [BuildSpec](#cfn-codebuild-project-source-buildspec): String
 [GitCloneDepth](#cfn-codebuild-project-source-gitclonedepth): Integer
 [InsecureSsl](#cfn-codebuild-project-source-insecuressl): Boolean


### PR DESCRIPTION
*Description of changes:* Added a space between the `Auth` key and value.

(Apologies for the non-change on line 79; I guess the GitHub editor added/removed the final carriage return.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.