### PR TITLE
Mark the FromPort and ToPort options to a Security Group rule as required for TCP, UDP, and ICMP

### DIFF
--- a/doc_source/aws-properties-ec2-security-group-rule.md
+++ b/doc_source/aws-properties-ec2-security-group-rule.md
@@ -92,7 +92,7 @@ Specifies the GroupId of the destination Amazon VPC security group\.
 
 `FromPort`  <a name="cfn-ec2-security-group-rule-fromport"></a>
 The start of port range for the TCP and UDP protocols, or an ICMP type number\. An ICMP type number of \-1 indicates a wildcard \(i\.e\., any ICMP type number\)\.  
-*Required*: No  
+*Required*: No for ICMP, Yes for TCP or UDP  
 *Type*: Integer
 
 `IpProtocol`  <a name="cfn-ec2-security-group-rule-ipprotocol"></a>
@@ -117,7 +117,7 @@ Specifies the AWS Account ID of the owner of the Amazon EC2 Security Group that 
 
 `ToPort`  <a name="cfn-ec2-security-group-rule-toport"></a>
 The end of port range for the TCP and UDP protocols, or an ICMP code\. An ICMP code of \-1 indicates a wildcard \(i\.e\., any ICMP code\)\.  
-*Required*: No  
+*Required*: No for ICMP, Yes for TCP or UDP
 *Type*: Integer
 
 ## Examples<a name="w4ab1c21c10d102d104c21c11"></a>

--- a/doc_source/aws-properties-ec2-security-group-rule.md
+++ b/doc_source/aws-properties-ec2-security-group-rule.md
@@ -92,12 +92,12 @@ Specifies the GroupId of the destination Amazon VPC security group\.
 
 `FromPort`  <a name="cfn-ec2-security-group-rule-fromport"></a>
 The start of port range for the TCP and UDP protocols, or an ICMP type number\. An ICMP type number of \-1 indicates a wildcard \(i\.e\., any ICMP type number\)\.  
-*Required*: Yes
+*Required*: Conditional\. Required for TCP, UDP, or ICMP
 *Type*: Integer
 
 `IpProtocol`  <a name="cfn-ec2-security-group-rule-ipprotocol"></a>
 An IP protocol name or number\. For valid values, go to the IpProtocol parameter in [AuthorizeSecurityGroupIngress](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-AuthorizeSecurityGroupIngress.html)  
-*Required*: Yes  
+*Required*: Conditional\. Required for TCP, UDP, or ICMP  
 *Type*: String
 
 `SourceSecurityGroupId` \(SecurityGroupIngress only\)  <a name="cfn-ec2-security-group-rule-sourcesecuritygroupid"></a>

--- a/doc_source/aws-properties-ec2-security-group-rule.md
+++ b/doc_source/aws-properties-ec2-security-group-rule.md
@@ -92,7 +92,7 @@ Specifies the GroupId of the destination Amazon VPC security group\.
 
 `FromPort`  <a name="cfn-ec2-security-group-rule-fromport"></a>
 The start of port range for the TCP and UDP protocols, or an ICMP type number\. An ICMP type number of \-1 indicates a wildcard \(i\.e\., any ICMP type number\)\.  
-*Required*: No for ICMP, Yes for TCP or UDP  
+*Required*: Yes
 *Type*: Integer
 
 `IpProtocol`  <a name="cfn-ec2-security-group-rule-ipprotocol"></a>
@@ -117,7 +117,7 @@ Specifies the AWS Account ID of the owner of the Amazon EC2 Security Group that 
 
 `ToPort`  <a name="cfn-ec2-security-group-rule-toport"></a>
 The end of port range for the TCP and UDP protocols, or an ICMP code\. An ICMP code of \-1 indicates a wildcard \(i\.e\., any ICMP code\)\.  
-*Required*: No for ICMP, Yes for TCP or UDP
+*Required*: Yes
 *Type*: Integer
 
 ## Examples<a name="w4ab1c21c10d102d104c21c11"></a>


### PR DESCRIPTION
*Description of changes:*

Mark the FromPort and ToPort options to a Security Group rule as required. Not specifying these results in this errors from the CloudFormation engine:

> Invalid value 'Must specify both from and to ports with TCP/UDP.' for portRange

> Invalid value 'Must specify both from and to ports with ICMP.' for portRange

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
