### PR TITLE
Clarified EngineVersion behaviour when specifying only major version.

### DIFF
--- a/doc_source/aws-properties-rds-database-instance.md
+++ b/doc_source/aws-properties-rds-database-instance.md
@@ -343,7 +343,7 @@ If you've specified `oracle-se` or `oracle-se1` as the database engine, you can 
 
 `EngineVersion`  <a name="cfn-rds-dbinstance-engineversion"></a>
 The version number of the database engine that the DB instance uses\.  
-To prevent automatic upgrades, be sure to specify the full version number \(for example, 5\.6\.13\)\. If the default version for the database engine changes and you specify only the major version \(for example, 5\.6\), your DB instance will be upgraded to use the latest default version\.
+To prevent automatic upgrades, be sure to specify the full version number \(for example, 5\.6\.13\)\. If the default version for the database engine changes and you specify only the major version \(for example, 5\.6\), your DB instance will be upgraded to use the new default version\. Please note that the default version is not always the latest version available and may be a few minor versions behind\.
 *Required*: No  
 *Type*: String  
 *Update requires*: [Some interruptions](using-cfn-updating-stacks-update-behaviors.md#update-some-interrupt)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The `EngineVersion` behaviour mentioned in the "Note" can be misunderstood to mean that when using only major versions, the latest major version will be deployed. Clarified the wording to make it clear that only when the default version changes will it update, and further that the default version is not always the latest version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
