### PR TITLE
VPC Peering SG

### DIFF
--- a/doc_source/aws-properties-ec2-security-group-ingress.md
+++ b/doc_source/aws-properties-ec2-security-group-ingress.md
@@ -126,7 +126,7 @@ Specifies the name of the Amazon EC2 security group \(non\-VPC security group\) 
 `SourceSecurityGroupOwnerId`  <a name="cfn-ec2-security-group-ingress-sourcesecuritygroupownerid"></a>
 Specifies the AWS Account ID of the owner of the Amazon EC2 security group specified in the `SourceSecurityGroupName` property\.  
 *Type*: String  
-*Required*: Conditional\. If you specify `SourceSecurityGroupName` and that security group is owned by a different account than the account creating the stack, you must specify the `SourceSecurityGroupOwnerId`; otherwise, this property is optional\.  
+*Required*: Conditional\. If you specify `SourceSecurityGroupName` or `SourceSecurityGroupId` and that security group is owned by a different account than the account creating the stack, you must specify the `SourceSecurityGroupOwnerId`; otherwise, this property is optional\.  
 *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement)
 
 `ToPort`  <a name="cfn-ec2-security-group-ingress-toport"></a>


### PR DESCRIPTION
For a peered VPC, we need to include SourceSecurityGroupOwnerId and SourceSecurityGroupId together if the SourceSecurityGroupId is in another account. The way this is written now makes it sound like SourceSecurityGroupOwnerId only applies to non-vpc SGs

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
