### PR TITLE
Adding missing word in the example title

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,3 @@ The open source version of the AWS CloudFormation User Guide
 The documentation is made available under the Creative Commons Attribution-ShareAlike 4.0 International License. See the LICENSE file.
 
 The sample code within this documentation is made available under a modified MIT license. See the LICENSE-SAMPLECODE file.
-foo

--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ The open source version of the AWS CloudFormation User Guide
 The documentation is made available under the Creative Commons Attribution-ShareAlike 4.0 International License. See the LICENSE file.
 
 The sample code within this documentation is made available under a modified MIT license. See the LICENSE-SAMPLECODE file.
+foo

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The open source version of the AWS CloudFormation User Guide
 
 The documentation is made available under the Creative Commons Attribution-ShareAlike 4.0 International License. See the LICENSE file.
 
-The sample code within this documentation is made available under a modified MIT license. See the LICENSE-SAMPLECODE file.
+The sample code within this documentation is made available under a modified MIT license. See the LICENSE-SAMPLECODE file.foo again

--- a/doc_source/aws-resource-dynamodb-table.md
+++ b/doc_source/aws-resource-dynamodb-table.md
@@ -182,7 +182,7 @@ For more information about using `Fn::GetAtt`, see [Fn::GetAtt](intrinsic-functi
 
 ## Examples<a name="cfn-dynamodb-table-examples"></a>
 
-### DynamoDB Table with Local and Secondary Indexes<a name="cfn-dynamodb-table-example1"></a>
+### DynamoDB Table with Local and Global Secondary Indexes<a name="cfn-dynamodb-table-example1"></a>
 
 The following sample creates an DynamoDB table with `Album`, `Artist`, `Sales`, `NumberOfSongs` as attributes\. The primary key includes the `Album` attribute as the hash key and `Artist` attribute as the range key\. The table also includes two global and one secondary index\. For querying the number of sales for a given artist, the global secondary index uses the `Sales` attribute as the hash key and the `Artist` attribute as the range key\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The title of the first example seems to be missing the word "Global" to properly match the template showed. Minor change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
