### PR TITLE
Multi-layer includes

### DIFF
--- a/doc_source/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.md
+++ b/doc_source/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.md
@@ -4,6 +4,8 @@ Use the `AWS::Include` transform, which is a macro hosted by AWS CloudFormation,
 
 For example, you might have a Lambda function that you want to reuse in one or more AWS CloudFormation templates\. 
 
+Note that the template provided to the`AWS::Include` function may not also leverage the `AWS::Include` function itself\. 
+
 Unlike custom macros, the `AWS::Include` transform doesn't require special permissions to use it because it is hosted by AWS CloudFormation\. It can be used by templates in any account within AWS CloudFormation\. Also, there is no charge incurred when using this transform\. AWS CloudFormation treats the `AWS::Include` transform the same as any other macro in terms of evaluation order and scope\. For more information about macros, see [Using AWS CloudFormation Macros to Perform Custom Processing on Templates](template-macros.md)\.
 
 ## Usage<a name="aws-include-transform-usage"></a>


### PR DESCRIPTION
using multi-layered includes (meaning, the included file also tries to use the include function) fails with errors like:

Transform AWS::Include failed with: The specified S3 object's content should be valid Yaml/JSON.

This is an easily prevented blocker, hence the suggested file change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
