### PR TITLE
Fix naming of CloudFront Distribution S3Origin to S3OriginConfig

### DIFF
--- a/doc_source/aws-properties-cloudfront-distribution-origin.md
+++ b/doc_source/aws-properties-cloudfront-distribution-origin.md
@@ -13,7 +13,7 @@
   "[Id](#cfn-cloudfront-distribution-origin-id)" : String,
   "[OriginCustomHeaders](#cfn-cloudfront-distribution-origin-origincustomheaders)" : [ OriginCustomHeader, ... ]
   "[OriginPath](#cfn-cloudfront-distribution-origin-originpath)" : String,
-  "[S3OriginConfig](#cfn-cloudfront-distribution-origin-s3origin)" : S3 Origin
+  "[S3OriginConfig](#cfn-cloudfront-distribution-origin-s3originconfig)" : S3 Origin
 }
 ```
 
@@ -27,7 +27,7 @@
 [OriginCustomHeaders](#cfn-cloudfront-distribution-origin-origincustomheaders):
   - OriginCustomHeader
 [OriginPath](#cfn-cloudfront-distribution-origin-originpath): String
-[S3OriginConfig](#cfn-cloudfront-distribution-origin-s3origin):
+[S3OriginConfig](#cfn-cloudfront-distribution-origin-s3originconfig):
   S3 Origin
 ```
 
@@ -61,7 +61,7 @@ The path that CloudFront uses to request content from an S3 bucket or custom ori
 *Required*: No  
 *Type*: String
 
-`S3OriginConfig`  <a name="cfn-cloudfront-distribution-origin-s3origin"></a>
+`S3OriginConfig`  <a name="cfn-cloudfront-distribution-origin-s3originconfig"></a>
 Origin information to specify an S3 origin\.  
 *Required*: Conditional\. You cannot use `S3OriginConfig` and `CustomOriginConfig` in the same `Origin`, but you *must* specify one or the other\.  
-*Type*: [S3Origin](aws-properties-cloudfront-distribution-s3originconfig.md) type
+*Type*: [S3OriginConfig](aws-properties-cloudfront-distribution-s3originconfig.md) type

--- a/doc_source/aws-properties-cloudfront-distribution-s3originconfig.md
+++ b/doc_source/aws-properties-cloudfront-distribution-s3originconfig.md
@@ -1,6 +1,6 @@
-# CloudFront Distribution S3Origin<a name="aws-properties-cloudfront-distribution-s3originconfig"></a>
+# CloudFront Distribution S3OriginConfig<a name="aws-properties-cloudfront-distribution-s3originconfig"></a>
 
-`S3Origin` is a property of the [Origin](aws-properties-cloudfront-distribution-origin.md) property that describes the Amazon Simple Storage Service \(S3\) origin to associate with an Amazon CloudFront origin\.
+`S3OriginConfig` is a property of the [Origin](aws-properties-cloudfront-distribution-origin.md) property that describes the Amazon Simple Storage Service \(S3\) origin to associate with an Amazon CloudFront origin\.
 
 ## Syntax<a name="w4ab1c21c10c54c14c79b5"></a>
 
@@ -21,7 +21,7 @@
 ## Properties<a name="w4ab1c21c10c54c14c79b7"></a>
 
 **Note**  
-For more information about the constraints and valid values of each property, see the [S3Origin](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_S3Origin.html) data type in the *Amazon CloudFront API Reference*\.
+For more information about the constraints and valid values of each property, see the [S3OriginConfig](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_S3OriginConfig.html) data type in the *Amazon CloudFront API Reference*\.
 
 `OriginAccessIdentity`  <a name="cfn-cloudfront-distribution-s3originconfig-originaccessidentity"></a>
 The CloudFront origin access identity to associate with the origin\. You must specify the full origin ID—for example:  


### PR DESCRIPTION
The documentation for CloudFront Distribution Origin incorrectly
used S3Origin (used in CloudFront StreamingDistribution) instead
of S3OriginConfig.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.