### PR TITLE
Use Network Interface Security group if using NI 

### DIFF
--- a/doc_source/aws-properties-ec2-launchtemplate-launchtemplatedata.md
+++ b/doc_source/aws-properties-ec2-launchtemplate-launchtemplatedata.md
@@ -170,6 +170,7 @@ We recommend that you use PV\-GRUB instead of kernels and RAM disks\. For more i
 
 `SecurityGroups`  <a name="cfn-ec2-launchtemplate-launchtemplatedata-securitygroups"></a>
 \[EC2\-Classic, default VPC\] One or more security group names\. For a nondefault VPC, you must use SecurityGroupIds instead\. You cannot specify both a security group ID and security name in the same request\. 
+
 If you specify a network interface, you must configure the security group as part of the network interface, and not in the Security Groups section of the template.
  *Required*: No  
  *Type*: List of String values  
@@ -177,6 +178,7 @@ If you specify a network interface, you must configure the security group as par
 
 `SecurityGroupIds`  <a name="cfn-ec2-launchtemplate-launchtemplatedata-securitygroupids"></a>
 One or more security group IDs\. You cannot specify both a security group ID and security name in the same request\. For information on creating a security group, see [CreateSecurityGroup]
+
 If you specify a network interface, you must configure the security group as part of the network interface, and not in the Security Groups section of the template.
 (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSecurityGroup.html) in the *Amazon EC2 API Reference*\.   
  *Required*: No  

--- a/doc_source/aws-properties-ec2-launchtemplate-launchtemplatedata.md
+++ b/doc_source/aws-properties-ec2-launchtemplate-launchtemplatedata.md
@@ -170,16 +170,14 @@ We recommend that you use PV\-GRUB instead of kernels and RAM disks\. For more i
 
 `SecurityGroups`  <a name="cfn-ec2-launchtemplate-launchtemplatedata-securitygroups"></a>
 \[EC2\-Classic, default VPC\] One or more security group names\. For a nondefault VPC, you must use SecurityGroupIds instead\. You cannot specify both a security group ID and security name in the same request\. 
-
-If you specify a network interface, you must configure the security group as part of the network interface, and not in the Security Groups section of the template.
+If you specify a network interface, you must configure the security group as part of the network interface, and not in the Security Groups section of the template\.
  *Required*: No  
  *Type*: List of String values  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `SecurityGroupIds`  <a name="cfn-ec2-launchtemplate-launchtemplatedata-securitygroupids"></a>
-One or more security group IDs\. You cannot specify both a security group ID and security name in the same request\. For information on creating a security group, see [CreateSecurityGroup]
-
-If you specify a network interface, you must configure the security group as part of the network interface, and not in the Security Groups section of the template.
+One or more security group IDs\. You cannot specify both a security group ID and security name in the same request\. For information on creating a security group, see [CreateSecurityGroup]\.
+If you specify a network interface, you must configure the security group as part of the network interface, and not in the Security Groups section of the template\.
 (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSecurityGroup.html) in the *Amazon EC2 API Reference*\.   
  *Required*: No  
  *Type*: List of String values  

--- a/doc_source/aws-properties-ec2-launchtemplate-launchtemplatedata.md
+++ b/doc_source/aws-properties-ec2-launchtemplate-launchtemplatedata.md
@@ -150,7 +150,7 @@ The monitoring for the instance\.
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `NetworkInterfaces`  <a name="cfn-ec2-launchtemplate-launchtemplatedata-networkinterfaces"></a>
-One or more network interfaces\.  
+One or more network interfaces\. 
  *Required*: No  
  *Type*: List of [NetworkInterface](aws-properties-ec2-launchtemplate-networkinterface.md)  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
@@ -169,13 +169,16 @@ We recommend that you use PV\-GRUB instead of kernels and RAM disks\. For more i
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `SecurityGroups`  <a name="cfn-ec2-launchtemplate-launchtemplatedata-securitygroups"></a>
-\[EC2\-Classic, default VPC\] One or more security group names\. For a nondefault VPC, you must use SecurityGroupIds instead\. You cannot specify both a security group ID and security name in the same request\.  
+\[EC2\-Classic, default VPC\] One or more security group names\. For a nondefault VPC, you must use SecurityGroupIds instead\. You cannot specify both a security group ID and security name in the same request\. 
+If you specify a network interface, you must configure the security group as part of the network interface, and not in the Security Groups section of the template.
  *Required*: No  
  *Type*: List of String values  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `SecurityGroupIds`  <a name="cfn-ec2-launchtemplate-launchtemplatedata-securitygroupids"></a>
-One or more security group IDs\. You cannot specify both a security group ID and security name in the same request\. For information on creating a security group, see [CreateSecurityGroup](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSecurityGroup.html) in the *Amazon EC2 API Reference*\.   
+One or more security group IDs\. You cannot specify both a security group ID and security name in the same request\. For information on creating a security group, see [CreateSecurityGroup]
+If you specify a network interface, you must configure the security group as part of the network interface, and not in the Security Groups section of the template.
+(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSecurityGroup.html) in the *Amazon EC2 API Reference*\.   
  *Required*: No  
  *Type*: List of String values  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 

--- a/doc_source/aws-properties-ec2-launchtemplate-launchtemplatedata.md
+++ b/doc_source/aws-properties-ec2-launchtemplate-launchtemplatedata.md
@@ -150,7 +150,7 @@ The monitoring for the instance\.
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `NetworkInterfaces`  <a name="cfn-ec2-launchtemplate-launchtemplatedata-networkinterfaces"></a>
-One or more network interfaces\. 
+One or more network interfaces\.  
  *Required*: No  
  *Type*: List of [NetworkInterface](aws-properties-ec2-launchtemplate-networkinterface.md)  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
@@ -170,13 +170,13 @@ We recommend that you use PV\-GRUB instead of kernels and RAM disks\. For more i
 
 `SecurityGroups`  <a name="cfn-ec2-launchtemplate-launchtemplatedata-securitygroups"></a>
 \[EC2\-Classic, default VPC\] One or more security group names\. For a nondefault VPC, you must use SecurityGroupIds instead\. You cannot specify both a security group ID and security name in the same request\. 
-If you specify a network interface, you must configure the security group as part of the network interface, and not in the Security Groups section of the template\.
+If you specify a network interface, you must configure the security group as part of the network interface, and not in the Security Groups section of the template\.  
  *Required*: No  
  *Type*: List of String values  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 
 
 `SecurityGroupIds`  <a name="cfn-ec2-launchtemplate-launchtemplatedata-securitygroupids"></a>
-One or more security group IDs\. You cannot specify both a security group ID and security name in the same request\. For information on creating a security group, see [CreateSecurityGroup]\.
+One or more security group IDs\. You cannot specify both a security group ID and security name in the same request\. For information on creating a security group, see [CreateSecurityGroup]\.  
 If you specify a network interface, you must configure the security group as part of the network interface, and not in the Security Groups section of the template\.
 (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSecurityGroup.html) in the *Amazon EC2 API Reference*\.   
  *Required*: No  


### PR DESCRIPTION
Cloudformation fails, if Network interface is used, and you have a security group on your launch Template, this was not really easy to find, so thought it would be nice if it were in the docs.