### PR TITLE
Improve S3 WebsiteConfiguration documentation

### DIFF
--- a/doc_source/aws-properties-s3-websiteconfiguration.md
+++ b/doc_source/aws-properties-s3-websiteconfiguration.md
@@ -22,23 +22,23 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ```
 ﻿  [ErrorDocument](#cfn-s3-websiteconfiguration-errordocument) : String
 ﻿  [IndexDocument](#cfn-s3-websiteconfiguration-indexdocument) : String
-﻿  [RedirectAllRequestsTo](#cfn-s3-websiteconfiguration-redirectallrequeststo) : 
+﻿  [RedirectAllRequestsTo](#cfn-s3-websiteconfiguration-redirectallrequeststo) :
     [RedirectAllRequestsTo](aws-properties-s3-websiteconfiguration-redirectallrequeststo.md)
-﻿  [RoutingRules](#cfn-s3-websiteconfiguration-routingrules) : 
+﻿  [RoutingRules](#cfn-s3-websiteconfiguration-routingrules) :
     - [RoutingRule](aws-properties-s3-websiteconfiguration-routingrules.md)
 ```
 
 ## Properties<a name="aws-properties-s3-websiteconfiguration-properties"></a>
 
 `ErrorDocument`  <a name="cfn-s3-websiteconfiguration-errordocument"></a>
-The name of the error document for the website\.  
+The name of the error document for the website\. Should not be specified if `RedirectAllRequestsTo` is specified\.   
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `IndexDocument`  <a name="cfn-s3-websiteconfiguration-indexdocument"></a>
-The name of the index document for the website\.  
-*Required*: No  
+The name of the index document for the website\. Should not be specified if `RedirectAllRequestsTo` is specified\.
+*Required*: Conditional\. If you don't specify the `RedirectAllRequestsTo` property, you must specify this property\.  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -50,7 +50,7 @@ If you specify this property, you can't specify any other property\.
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `RoutingRules`  <a name="cfn-s3-websiteconfiguration-routingrules"></a>
-Rules that define when a redirect is applied and the redirect behavior\.  
+Rules that define when a redirect is applied and the redirect behavior\. Should not be specified if `RedirectAllRequestsTo` is specified\.   
 *Required*: No  
 *Type*: List of [RoutingRule](aws-properties-s3-websiteconfiguration-routingrules.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
The `IndexDocument` is not mandatory. See the Screenshot from a Stack deployment:

![image](https://user-images.githubusercontent.com/35613489/51062111-ed111000-15f5-11e9-81fe-8e238606eff8.png)

Updated the documentation to reflect this:

* Made the Required of the IndexDocument `Conditional`
* Added description that IndexDocument, ErrorDocument and RoutingRules are not allowed to be specified if `RedirectAllRequestsTo` is specified (already mentioned at the `RedirectAllRequestsTo`, but this makes it a bit more explicit

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
