### PR TITLE
set type 'Schedule' for schedules

### DIFF
--- a/doc_source/aws-resource-datapipeline-pipeline.md
+++ b/doc_source/aws-resource-datapipeline-pipeline.md
@@ -264,7 +264,7 @@ The following data pipeline backs up data from an Amazon DynamoDB \(DynamoDB\) t
           },
           {
             "Key": "type",
-            "StringValue": "Default"
+            "StringValue": "Schedule"
           },
           {
             "Key": "period",
@@ -459,7 +459,7 @@ DynamoDBInputS3OutputHive:
             StringValue: "FIRST_ACTIVATION_DATE_TIME"
           - 
             Key: "type"
-            StringValue: "Default"
+            StringValue: "Schedule"
           - 
             Key: "period"
             StringValue: "1 Day"


### PR DESCRIPTION
*Issue #, if available:*
N/A - minor change

*Description of changes:*
The example Cloudformation stack uses a schedule of type `Default`. This results in:

```
'schedule' values must be of type 'Schedule'. Found values of type 'Default'
```

Changing this to be of type `Schedule` resolves the issue - https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-schedule.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
