### PR TITLE
AWS::DirectoryService::*AD - Note on how to change Administrator Password

### DIFF
--- a/doc_source/aws-resource-directoryservice-microsoftad.md
+++ b/doc_source/aws-resource-directoryservice-microsoftad.md
@@ -66,6 +66,7 @@ The fully qualified name for the Microsoft Active Directory in AWS, such as `cor
 
 `Password`  <a name="cfn-directoryservice-microsoftad-password"></a>
 The password for the default administrative user, `Admin`\.  
+If you need to change the password for the administrative user without replacing the directory you can use the [ResetUserPassword](https://docs.aws.amazon.com/directoryservice/latest/devguide/API_ResetUserPassword.html) API call to change it\.  
 *Required*: Yes  
 *Type*: String  
 *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement)

--- a/doc_source/aws-resource-directoryservice-simplead.md
+++ b/doc_source/aws-resource-directoryservice-simplead.md
@@ -68,6 +68,7 @@ The fully qualified name for the directory, such as `corp.example.com`\.
 
 `Password`  <a name="cfn-directoryservice-simplead-password"></a>
 The password for the directory administrator\. AWS Directory Service creates a directory administrator account with the user name `Administrator` and this password\.  
+If you need to change the password for the administrative user without replacing the directory you can use the [ResetUserPassword](https://docs.aws.amazon.com/directoryservice/latest/devguide/API_ResetUserPassword.html) API call to change it\.  
 *Required*: Yes  
 *Type*: String  
 *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement)


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* This adds a note after the `Password` property for the `AWS::DirectoryService::*AD` resources to let the user know how they can change the Administrator Password should they go about changing it using the `ResetUserPassword` API call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
