### PR TITLE
Add note about response size for Custom Resources

### DIFF
--- a/doc_source/crpg-ref-responses.md
+++ b/doc_source/crpg-ref-responses.md
@@ -4,6 +4,8 @@
 
 The following are properties that the custom resource provider includes when it sends the JSON file to the presigned URL\. For more information about uploading objects by using presigned URLs, see the related [topic](https://docs.aws.amazon.com/AmazonS3/latest/dev/PresignedUrlUploadObject.html) in the *Amazon Simple Storage Service Developer Guide*\.
 
+**Note:** The total size of the response body cannot exceed 4096 bytes. If the resonse size would exceed this, the resource will go into the `CREATE_FAILED` state with the status reason "Response object is too long."
+
 Status  <a name="crpg-ref-responses-status"></a>
 The status value sent by the custom resource provider in response to an AWS CloudFormation\-generated request\.  
 Must be either `SUCCESS` or `FAILED`\.  


### PR DESCRIPTION
*Description of changes:*

This adds a note about response size for Custom Resources.

My coworker ran into this, and found that the limit was around 4k, I used trial and error to verify that the exact limit is 4096 (inclusive).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
