### PR TITLE
Update aws-properties-ecs-taskdefinition-tmpfs.md

### DIFF
--- a/doc_source/aws-properties-ecs-taskdefinition-tmpfs.md
+++ b/doc_source/aws-properties-ecs-taskdefinition-tmpfs.md
@@ -44,7 +44,7 @@ Duplicate values are not allowed\.
 
 `Size`  <a name="cfn-ecs-taskdefinition-tmpfs-size"></a>
 The size \(in MiB\) of the tmpfs volume\.  
- *Required*: No  
+ *Required*: Yes  
  *Type*: Integer  
  *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement) 
 


### PR DESCRIPTION
Change required to Yes for tmpfs size, since without the Size parameter it will fail. Note that the API (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Tmpfs.html) has required Yes for size as well.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
