### PR TITLE
Private APIs in APIG don't support custom domains

### DIFF
--- a/doc_source/aws-properties-apigateway-restapi-endpointconfiguration.md
+++ b/doc_source/aws-properties-apigateway-restapi-endpointconfiguration.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 A list of endpoint types of an API or its custom domain name\. Valid values include:  
 + `EDGE`: For an edge\-optimized API and its custom domain name\.
 + `REGIONAL`: For a regional API and its custom domain name\.
-+ `PRIVATE` : For a private API and its custom domain name\.
++ `PRIVATE` : For a private API\.
  *Required*: No  
  *Type*: List of String values  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 


### PR DESCRIPTION
According to the [Private API Development Considerations](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-apis.html?shortFooter=true#apigateway-private-api-design-considerations), the private API Gateway doesn't support custom domain names:
> Custom domain names are not supported for private APIs.

*Issue #, if available:*

*Description of changes:* Removing mention of the custom domains in relation to private API endpoint.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
