### PR TITLE
Service Domain EBSOptions: add sc1 volume type

### DIFF
--- a/doc_source/aws-properties-elasticsearch-domain-ebsoptions.md
+++ b/doc_source/aws-properties-elasticsearch-domain-ebsoptions.md
@@ -42,6 +42,6 @@ The size of the EBS volume for each data node\. The minimum and maximum size of 
 *Type*: Integer
 
 `VolumeType`  <a name="cfn-elasticsearch-domain-ebsoptions-volumetype"></a>
-The EBS volume type to use with the Amazon ES domain, such as `standard`, `gp2`, or `io1`\. For more information about each type, see [Amazon EBS Volume Types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) in the *Amazon EC2 User Guide for Linux Instances*\.  
+The EBS volume type to use with the Amazon ES domain, such as `standard`, `gp2`, `io1` or `sc1`\. For more information about each type, see [Amazon EBS Volume Types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) in the *Amazon EC2 User Guide for Linux Instances*\.  
 *Required*: No  
 *Type*: String


### PR DESCRIPTION
*Description of changes:*
`sc1` is a valid type of storage; add it to the example list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
