### PR TITLE
Update aws-resource-rds-dbcluster.md

### DIFF
--- a/doc_source/aws-resource-rds-dbcluster.md
+++ b/doc_source/aws-resource-rds-dbcluster.md
@@ -189,7 +189,7 @@ The master user name for the DB instance\.
 The password for the master database user\.  
 *Required*: Conditional\. You must specify this property unless you specify the `SnapshotIdentifier` property\. In that case, do not specify this property\.  
 *Type*: String  
-*Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)
+*Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt). The password is updated in the upcoming maintenance window.
 
 `Port`  <a name="cfn-rds-dbcluster-port"></a>
 The port number on which the DB instances in the cluster can accept connections\. If this argument is omitted, `3306` is used\.  


### PR DESCRIPTION
Add information to MasterUserPassword property that changes are not applied immediately but in the upcoming maintenance window.

*Issue #, if available:*
CASE 5811100811

*Description of changes:*
For Aurora, when modifying a DB cluster, only changes to the DB cluster identifier, IAM DB authentication, and New master password settings are affected by the Apply Immediately setting [1].
Currently CloudFormation does not have property for DB cluster by which  'Apply Immediately' flag can be set and hence the password gets updated during upcoming maintenance window (not immediately).

Resources:
[1] https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Modifying.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
