### PR TITLE
change 'name' property of Ulimit to be required

### DIFF
--- a/doc_source/aws-properties-ecs-taskdefinition-containerdefinitions-ulimit.md
+++ b/doc_source/aws-properties-ecs-taskdefinition-containerdefinitions-ulimit.md
@@ -31,7 +31,7 @@ The hard limit for the ulimit type\.
 
 `Name`  <a name="cfn-ecs-taskdefinition-containerdefinition-ulimit-name"></a>
 The type of ulimit\. For valid values, see the `name` content for the [Ulimit](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html) data type in the *Amazon Elastic Container Service API Reference*\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String
 
 `SoftLimit`  <a name="cfn-ecs-taskdefinition-containerdefinition-ulimit-softlimit"></a>


### PR DESCRIPTION
Description of changes: 'Name' property in Ulimit section for task definition is required property. When I did not pass 'Name', cloudformation gave me an error. I found that it's required parameter from API reference page: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
