### PR TITLE
Update example snippet

### DIFF
--- a/doc_source/aws-properties-apitgateway-method-integration.md
+++ b/doc_source/aws-properties-apitgateway-method-integration.md
@@ -115,7 +115,7 @@ The source must be an existing method request parameter or a static value\. You 
 A map of Apache Velocity templates that are applied on the request payload\. The template that API Gateway uses is based on the value of the Content\-Type header that's sent by the client\. The content type value is the key, and the template is the value \(specified as a string\), such as the following snippet:  
 
 ```
-"application/json": "{\n    \"statusCode\": \"200\"\n}"
+"application/json": "{\n    \"statusCode\": 200\n}"
 ```
 For more information about templates, see [API Gateway API Request and Response Payload\-Mapping Template Reference](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html) in the *API Gateway Developer Guide*\.  
 *Required*: No  


### PR DESCRIPTION
*Description of changes:*
Updated the example snippet, in the current form it doesn't work, the `statusCode` should be an integer. With the current template, this will be the error:

`Execution failed due to configuration error: statusCode should be an integer which defined in request template`

Also, that error sentence is missing a word (`which [is] defined`), might want to have that checked as well...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.