### PR TITLE
Add pythonshell to Valid values of AWS::Glue::Job

### DIFF
--- a/doc_source/aws-properties-glue-job-jobcommand.md
+++ b/doc_source/aws-properties-glue-job-jobcommand.md
@@ -38,5 +38,5 @@ The location of a script that executes a job\.
 The name of the job command\.  
  *Required*: Yes  
  *Type*: String  
- *Valid values*: `glueetl`  
+ *Valid values*: `glueetl`, `pythonshell`  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 


### PR DESCRIPTION
Description of changes:
Updated the Valid Values to include pythonshell in addition to the existing glueetl.  pythonshell was released Jan 22 and this resource supports the parameter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
