### PR TITLE
Update aws-properties-ec2-launchtemplate-spotoptions.md

### DIFF
--- a/doc_source/aws-properties-ec2-launchtemplate-spotoptions.md
+++ b/doc_source/aws-properties-ec2-launchtemplate-spotoptions.md
@@ -43,7 +43,7 @@ The maximum hourly price you're willing to pay for the Spot Instances\.
 
 `SpotInstanceType`  <a name="cfn-ec2-launchtemplate-spotoptions-spotinstancetype"></a>
 The Spot Instance request type\.  
-Valid values include: `one-time` and `persistent`\.  
+Valid values include: `one-time` and `persistent`\.  Can only be `one-time` when used with an AutoScale Group.
  *Required*: No  
  *Type*: String  
  *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt) 


### PR DESCRIPTION
Added useful informtion about persistent vs one-time

*Issue #, if available:*

Adding some essential information to know before using this with an autoscaling group

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
