### PR TITLE
Fixing the YAML indentation in the AWS::ApiGateway::Account examples

### DIFF
--- a/doc_source/aws-resource-apigateway-account.md
+++ b/doc_source/aws-resource-apigateway-account.md
@@ -84,25 +84,25 @@ The following example creates an IAM role that API Gateway can assume to push lo
 ### YAML<a name="aws-resource-apigateway-account-examples.yaml"></a>
 
 ```
-CloudWatchRole: 
+CloudWatchRole:
  Type: AWS::IAM::Role
- Properties: 
-  AssumeRolePolicyDocument: 
-   Version: "2012-10-17"
-   Statement: 
+ Properties:
+  AssumeRolePolicyDocument:
+    Version: "2012-10-17"
+    Statement:
     - Effect: Allow
-      Principal: 
-       Service: 
+      Principal:
+       Service:
         - "apigateway.amazonaws.com"
       Action: "sts:AssumeRole"
   Path: "/"
-  ManagedPolicyArns: 
-   - "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+  ManagedPolicyArns:
+  - "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 Account: 
  Type: AWS::ApiGateway::Account
  Properties: 
   CloudWatchRoleArn: 
-   "Fn::GetAtt": 
+    "Fn::GetAtt": 
     - CloudWatchRole
     - Arn
 ```


### PR DESCRIPTION
*Issue #, if available:*

Copying and pasting the example YAML provided on the page results in an incorrect YAML structure that causes deploys to fail.

*Description of changes:*

Added indentation where necessary, and also stripped some trailing spaces in the YAML example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
