### PR TITLE
Fix the example in `AWS::EC2::NatGateway`'s document

### DIFF
--- a/doc_source/aws-resource-ec2-natgateway.md
+++ b/doc_source/aws-resource-ec2-natgateway.md
@@ -75,7 +75,6 @@ The following example creates a NAT gateway and a route that associates the NAT 
 
 ```
 "NAT" : {
-  "DependsOn" : "VPCGatewayAttach",
   "Type" : "AWS::EC2::NatGateway",
   "Properties" : {
     "AllocationId" : { "Fn::GetAtt" : ["EIP", "AllocationId"]},
@@ -84,6 +83,7 @@ The following example creates a NAT gateway and a route that associates the NAT 
   }
 },
 "EIP" : {
+  "DependsOn" : "VPCGatewayAttach",
   "Type" : "AWS::EC2::EIP",
   "Properties" : {
     "Domain" : "vpc"
@@ -103,7 +103,6 @@ The following example creates a NAT gateway and a route that associates the NAT 
 
 ```
 NAT:
-  DependsOn: VPCGatewayAttach
   Type: AWS::EC2::NatGateway
   Properties:
     AllocationId:
@@ -116,6 +115,7 @@ NAT:
       - Key: foo
         Value: bar
 EIP:
+  DependsOn: VPCGatewayAttach
   Type: AWS::EC2::EIP
   Properties:
     Domain: vpc


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
The `AWS::EC2::EIP` resource document
(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip.html)
says that

> If you define an Elastic IP address and associate it with a VPC that is
> defined in the same template, you must declare a dependency on the
> VPC-gateway attachment by using the DependsOn attribute on this resource.

And the `DependsOn` attribute document
(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html)
also says that Elastic IP addresses depends on a VPC-gateway attachment.

This pull request fixes the example in `AWS::EC2::NatGateway`'s document to
follow the above constraint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
