### PR TITLE
ServiceRole requires an Arn

### DIFF
--- a/doc_source/aws-resource-codebuild-project.md
+++ b/doc_source/aws-resource-codebuild-project.md
@@ -273,9 +273,7 @@ The following example creates a project that caches build dependencies in Amazon
     "CodeBuildProject": {
       "Type": "AWS::CodeBuild::Project",
       "Properties": {
-        "ServiceRole": {
-          "Ref": "CodeBuildRole"
-        },
+        "ServiceRole": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
         "Artifacts": {
           "Type": "CODEPIPELINE"
         },
@@ -416,7 +414,7 @@ Resources:
   CodeBuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
-      ServiceRole: !Ref CodeBuildRole
+      ServiceRole: !GetAtt ServiceRole.Arn
       Artifacts:
         Type: CODEPIPELINE
       Environment:

--- a/doc_source/aws-resource-codebuild-project.md
+++ b/doc_source/aws-resource-codebuild-project.md
@@ -273,7 +273,7 @@ The following example creates a project that caches build dependencies in Amazon
     "CodeBuildProject": {
       "Type": "AWS::CodeBuild::Project",
       "Properties": {
-        "ServiceRole": { "Fn::GetAtt": [ "ServiceRole", "Arn" ] },
+        "ServiceRole": { "Fn::GetAtt": [ "CodeBuildRole", "Arn" ] },
         "Artifacts": {
           "Type": "CODEPIPELINE"
         },
@@ -414,7 +414,7 @@ Resources:
   CodeBuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
-      ServiceRole: !GetAtt ServiceRole.Arn
+      ServiceRole: !GetAtt CodeBuildRole.Arn
       Artifacts:
         Type: CODEPIPELINE
       Environment:


### PR DESCRIPTION
ServiceRole requires an Arn, and while Ref to a Role works it's technically incorrect. It doesn't work if the path is NOT '/'.

*Issue #, if available:*

*Description of changes:*

Use FnGetAtt(GetAtt) and not Ref in the last example to retrieve the ARN.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
