### PR TITLE
fixed code snippet for custom resource section, example3.yaml

### DIFF
--- a/doc_source/aws-resource-cfn-customresource.md
+++ b/doc_source/aws-resource-cfn-customresource.md
@@ -153,8 +153,7 @@ MyCustomResource:
   Type: "Custom::TestLambdaCrossStackRef"
   Properties: 
     ServiceToken:
-      !Sub |
-        arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${LambdaFunctionName}
+      !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${LambdaFunctionName}
     StackName: 
       Ref: "NetworkStackName"
 ```


### PR DESCRIPTION
Changed the example 3 yaml section for the file "aws-resource-cfn-customresource.md" from this:
```
    ServiceToken:
      !Sub |
        arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${LambdaFunctionName}
```
To this:
```
    ServiceToken:
      !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${LambdaFunctionName}
```

The character "|" is adding a "\n" to the end of the service token, which is causing stacks to fail.
