### PR TITLE
Missing type and properties on AWS::Route53::HostedZone

### DIFF
--- a/doc_source/aws-resource-route53-hostedzone-hostedzonevpcs.md
+++ b/doc_source/aws-resource-route53-hostedzone-hostedzonevpcs.md
@@ -10,8 +10,10 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 ```
 {
-  "[VPCId](#cfn-route53-hostedzone-hostedzonevpcs-vpcid)" : String,
-  "[VPCRegion](#cfn-route53-hostedzone-hostedzonevpcs-vpcregion)" : String
+  "Type" : "AWS::Route53::HostedZone",
+  "Properties" : {  
+    "[VPCId](#cfn-route53-hostedzone-hostedzonevpcs-vpcid)" : String,
+    "[VPCRegion](#cfn-route53-hostedzone-hostedzonevpcs-vpcregion)" : String
 }
 ```
 

--- a/doc_source/aws-resource-route53-hostedzone-hostedzonevpcs.md
+++ b/doc_source/aws-resource-route53-hostedzone-hostedzonevpcs.md
@@ -18,8 +18,10 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-resource-route53-hostedzone-hostedzonevpcs-syntax.yaml"></a>
 
 ```
-﻿  [VPCId](#cfn-route53-hostedzone-hostedzonevpcs-vpcid) : String
-﻿  [VPCRegion](#cfn-route53-hostedzone-hostedzonevpcs-vpcregion) : String
+  Type: "AWS::Route53::HostedZone"
+  Properties: 
+    [VPCId](#cfn-route53-hostedzone-hostedzonevpcs-vpcid) : String
+    [VPCRegion](#cfn-route53-hostedzone-hostedzonevpcs-vpcregion) : String
 ```
 
 ## Properties<a name="aws-resource-route53-hostedzone-hostedzonevpcs-properties"></a>


### PR DESCRIPTION
*Issue #, if available:*

Description of changes:
Documentations was missing type and properties on  AWS::Route53::HostedZone

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
