### PR TITLE
Specify correct syntax for Targets property within the AWS::SSM::MaintenanceWindowTarget resource

### DIFF
--- a/doc_source/aws-resource-ssm-maintenancewindowtarget.md
+++ b/doc_source/aws-resource-ssm-maintenancewindowtarget.md
@@ -75,7 +75,7 @@ The targets, either instances or tags\.
 Specify instances using the following format:  
  `Key=instanceids,Values=<instanceid1>,<instanceid2>`   
 Tags are specified using the following format:  
- `Key=<tag name>,Values=<tag value>`\.  
+ `Key=tag:<tag name>,Values=<tag value>`\.  
 *Required*: Yes  
 *Type*: [List](aws-properties-ssm-maintenancewindowtarget-targets.md) of [Targets](aws-properties-ssm-maintenancewindowtarget-targets.md)  
 *Maximum*: `5`  


### PR DESCRIPTION
*Description of changes:*
The AWS::SSM::MaintenanceWindowTarget documentation points to an incorrect syntax on the use of the 'Targets' property, which requires "Key" to be prefixed with "tag:". The underlying [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ssm-maintenancewindowtarget-targets.html) for the Targets object specifies this correctly, and this change only reflects what is already covered there (and is the correct solution).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
