### PR TITLE
[kms] Fix maximum PendingWindowInDays

### DIFF
--- a/doc_source/aws-resource-kms-key.md
+++ b/doc_source/aws-resource-kms-key.md
@@ -93,7 +93,7 @@ For information about the `PendingDeletion` key state, see [How Key State Affect
 *Required*: No  
 *Type*: Integer  
 *Minimum*: `1`  
-*Maximum*: `365`  
+*Maximum*: `30`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Tags`  <a name="cfn-kms-key-tags"></a>


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* In the console and all other resources, the maximum `PendingWindowInDays` for KMS Keys is 30, not 365.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
