### PR TITLE
Update aws-properties-cloudwatch-alarm-metric.md

### DIFF
--- a/doc_source/aws-properties-cloudwatch-alarm-metric.md
+++ b/doc_source/aws-properties-cloudwatch-alarm-metric.md
@@ -36,7 +36,7 @@ The dimensions for the metric\.
 
 `MetricName`  <a name="cfn-cloudwatch-alarm-metric-metricname"></a>
 The name of the metric\. This is a required field\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Minimum*: `1`  
 *Maximum*: `255`  


### PR DESCRIPTION
Fix required field documentation for MetricName.

*Issue #, if available:*

N/A

*Description of changes:*

Fixed documentation.  The line above says it is required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
