### PR TITLE
Update aws-properties-ec2-security-group.md

### DIFF
--- a/doc_source/aws-properties-ec2-security-group.md
+++ b/doc_source/aws-properties-ec2-security-group.md
@@ -189,8 +189,8 @@ sgwithoutegress:
     SecurityGroupEgress:
     - CidrIp: 127.0.0.1/32
       IpProtocol: "-1"
-      VpcId:
-         Ref: myVPC
+    VpcId:
+      Ref: myVPC
 ```
 
 ## See Also<a name="aws-properties-ec2-security-group--seealso"></a>


### PR DESCRIPTION
Correct indention in yaml example code for removing default protocol.

*Description of changes:*
Corrected indention of VPC in YAML example for removing defaults.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.