### PR TITLE
removed 'AT_TIMESTAMP' from event source mapping

### DIFF
--- a/doc_source/aws-resource-lambda-eventsourcemapping.md
+++ b/doc_source/aws-resource-lambda-eventsourcemapping.md
@@ -78,8 +78,8 @@ The name of the Lambda function\.
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)
 
 `StartingPosition`  <a name="cfn-lambda-eventsourcemapping-startingposition"></a>
-The position in a stream from which to start reading\. Required for Amazon Kinesis and Amazon DynamoDB Streams sources\. `AT_TIMESTAMP` is only supported for Kinesis streams\.   
-Valid Values: `TRIM_HORIZON` \| `LATEST` \| `AT_TIMESTAMP`  
+The position in a stream from which to start reading\. Required for Amazon Kinesis and Amazon DynamoDB Streams sources\.  
+Valid Values: `TRIM_HORIZON` \| `LATEST`   
 *Required*: No  
 *Type*: String  
 *Update requires*: [Replacement](using-cfn-updating-stacks-update-behaviors.md#update-replacement)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Cloudformation document says that 'AT_TIMESTAMP' is supported value for 'StartingPosition' but if I pass that value, Cloudformation gives me an error that 'Need to specify a timestamp (Service: AWSLambda; Status Code: 400; Error Code: InvalidParameterValueException'. I created case for AWS because Cloudformation does not support 'StartingPositionTimestamp' parameter yet. This is confusing to users and we should not allow 'AT_TIMESTAMP' value until 'StartingPositionTimestamp' is supported. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
