### PR TITLE
Correcting how to reference the Configuration resource

### DIFF
--- a/doc_source/aws-resource-amazonmq-broker.md
+++ b/doc_source/aws-resource-amazonmq-broker.md
@@ -355,7 +355,7 @@ Resources:
       AutoMinorVersionUpgrade: "false"
       BrokerName: MyComplexBroker
       Configuration: 
-        Id: !GetAtt Configuration1.Id
+        Id: !Ref Configuration1
         Revision: !GetAtt Configuration1.Revision
       DeploymentMode: SINGLE_INSTANCE
       EngineType: ActiveMQ


### PR DESCRIPTION
Correcting how to reference the Configuration resource in the yaml sample for the complex broker at the end of the doc.  The json example is correct but the yaml is not.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
