### PR TITLE
Removing reference to Id being returned

### DIFF
--- a/doc_source/aws-resource-amazonmq-configuration.md
+++ b/doc_source/aws-resource-amazonmq-configuration.md
@@ -94,10 +94,6 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 The Amazon Resource Name \(ARN\) of the Amazon MQ configuration\.  
  `arn:aws:mq:us-east-2:123456789012:configuration:MyConfigurationDevelopment:c-1234a5b6-78cd-901e-2fgh-3i45j6k178l9` 
 
-`Id`  <a name="Id-fn::getatt"></a>
-The ID of the Amazon MQ configuration\.  
- `c-1234a5b6-78cd-901e-2fgh-3i45j6k178l9` 
-
 `Revision`  <a name="Revision-fn::getatt"></a>
 The revision number of the configuration\.  
  `1` 


### PR DESCRIPTION
The Id is not retrievable directly with GetAtt.  Removing the reference here.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
