### PR TITLE
Ref RouteTable returns ID not Name

### DIFF
--- a/doc_source/aws-resource-ec2-route-table.md
+++ b/doc_source/aws-resource-ec2-route-table.md
@@ -48,7 +48,7 @@ The ID of the VPC\.
 
 ### Ref<a name="aws-resource-ec2-route-table-return-values-ref"></a>
 
-When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the name of the route table\.
+When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the ID of the route table\.
 
 For more information about using the `Ref` function, see [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html)\.
 


### PR DESCRIPTION
RouteTables don't have a native "Name", just a "Name" tag. Ref on them returns their ID like rtb-00000000 , ready to be passed to e.g. an `AWS::EC2::Route`'s `RouteTableId` propertty like:

```yaml
MyRoute:
  Type: AWS::EC2::Route
  Properties:
    DestinationCidrBlock: 0.0.0.0/0
    NatGatewayId: !Ref MyNatGateway
    RouteTableId: !Ref MyRouteTable
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
