### PR TITLE
FIX indentation in examples section's YAML for AWS::ElastiCache::ParameterGroup

### DIFF
--- a/doc_source/aws-properties-elasticache-cache-cluster.md
+++ b/doc_source/aws-properties-elasticache-cache-cluster.md
@@ -385,16 +385,16 @@ The following example launches a cache cluster with three nodes, where two nodes
 
 ```
 myCacheCluster:
-            Type: AWS::ElastiCache::CacheCluster
-            Properties:
-            AZMode: "cross-az"
-            CacheNodeType: "cache.m3.medium"
-            Engine: "memcached"
-            NumCacheNodes: "3"
-            PreferredAvailabilityZones:
-            - "us-west-2a"
-            - "us-west-2a"
-            - "us-west-2b"
+  Type: AWS::ElastiCache::CacheCluster
+  Properties:
+    AZMode: "cross-az"
+    CacheNodeType: "cache.m3.medium"
+    Engine: "memcached"
+    NumCacheNodes: "3"
+    PreferredAvailabilityZones:
+      - "us-west-2a"
+      - "us-west-2a"
+      - "us-west-2b"
 ```
 
 ## See Also<a name="aws-properties-elasticache-cache-cluster--seealso"></a>

--- a/doc_source/aws-properties-elasticache-cache-cluster.md
+++ b/doc_source/aws-properties-elasticache-cache-cluster.md
@@ -338,26 +338,26 @@ For the cache cluster, the `VpcSecurityGroupIds` property is used to associate t
 
 ```
 ElasticacheSecurityGroup:
-            Type: AWS::EC2::SecurityGroup
-            Properties:
-            GroupDescription: "Elasticache Security Group"
-            SecurityGroupIngress:
-            -
-            IpProtocol: "tcp"
-            FromPort: "11211"
-            ToPort: "11211"
-            SourceSecurityGroupName:
+  Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "Elasticache Security Group"
+      SecurityGroupIngress:
+        -
+          IpProtocol: "tcp"
+          FromPort: "11211"
+          ToPort: "11211"
+          SourceSecurityGroupName:
             Ref: "InstanceSecurityGroup"
-            ElasticacheCluster:
-            Type: AWS::ElastiCache::CacheCluster
-            Properties:
-            AutoMinorVersionUpgrade: "true"
-            Engine: "memcached"
-            CacheNodeType: "cache.t2.micro"
-            NumCacheNodes: "1"
-            VpcSecurityGroupIds:
-            -
-            Fn::GetAtt:
+ElasticacheCluster:
+  Type: AWS::ElastiCache::CacheCluster
+    Properties:
+      AutoMinorVersionUpgrade: "true"
+      Engine: "memcached"
+      CacheNodeType: "cache.t2.micro"
+      NumCacheNodes: "1"
+      VpcSecurityGroupIds:
+        -
+          Fn::GetAtt:
             - "ElasticacheSecurityGroup"
             - "GroupId"
 ```

--- a/doc_source/aws-properties-elasticache-parameter-group.md
+++ b/doc_source/aws-properties-elasticache-parameter-group.md
@@ -94,13 +94,13 @@ For more information about using the `Ref` function, see [Ref](https://docs.aws.
 
 ```
 MyParameterGroup: 
-            Type: AWS::ElastiCache::ParameterGroup
-            Properties: 
-            Description: "MyNewParameterGroup"
-            CacheParameterGroupFamily: "memcached1.4"
-            Properties: 
-            cas_disabled: "1"
-            chunk_size_growth_factor: "1.02"
+   Type: AWS::ElastiCache::ParameterGroup
+   Properties: 
+      Description: "MyNewParameterGroup"
+      CacheParameterGroupFamily: "memcached1.4"
+      Properties: 
+         cas_disabled: "1"
+         chunk_size_growth_factor: "1.02"
 ```
 
 ## See Also<a name="aws-properties-elasticache-parameter-group--seealso"></a>


### PR DESCRIPTION
*Issue #, if available:*
Wrong indentation in the examples section in AWS::ElastiCache::ParameterGroup

*Description of changes:*
Fixing the YAML's indentation in the examples section in AWS::ElastiCache::ParameterGroup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
