### PR TITLE
fix: Predicate.Type indentation

### DIFF
--- a/doc_source/aws-resource-waf-rule.md
+++ b/doc_source/aws-resource-waf-rule.md
@@ -102,5 +102,5 @@ MyIPSetRule:
         DataId: 
           Ref: "MyIPSetBlacklist"
         Negated: false
-Type: "IPMatch"
+        Type: "IPMatch"
 ```


### PR DESCRIPTION
`Predicate.Type` should have same indentation as other predicate attributes, namely, `DataId` and `Negated`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.