### PR TITLE
Document interruption for DBInstanceClass

### DIFF
--- a/doc_source/aws-properties-rds-database-instance.md
+++ b/doc_source/aws-properties-rds-database-instance.md
@@ -214,10 +214,11 @@ The identifier of the DB cluster that the instance will belong to\.
 
 `DBInstanceClass`  <a name="cfn-rds-dbinstance-dbinstanceclass"></a>
 The compute and memory capacity of the DB Instance\.  
+If you change this option, the instance will be restarted\.  
  Valid Values: `db.t1.micro | db.m1.small | db.m1.medium | db.m1.large | db.m1.xlarge | db.m2.xlarge |db.m2.2xlarge | db.m2.4xlarge`   
 *Required*: Yes  
 *Type*: String  
-*Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+*Update requires*: [Some interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt)
 
 `DBInstanceIdentifier`  <a name="cfn-rds-dbinstance-dbinstanceidentifier"></a>
 A name for the DB instance\. If you specify a name, AWS CloudFormation converts it to lowercase\. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the DB instance\. For more information, see [Name Type](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-name.html)\.  


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* I don't know the specifics here, but there is definitely some interruption during a change in instance class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
