### PR TITLE
Fix EC2 NetworkInterface AssociatePublicIpAddress

### DIFF
--- a/doc_source/aws-properties-ec2-network-iface-embedded.md
+++ b/doc_source/aws-properties-ec2-network-iface-embedded.md
@@ -50,7 +50,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-ec2-network-iface-embedded-properties"></a>
 
 `AssociatePublicIpAddress`  <a name="aws-properties-ec2-network-iface-embedded-associatepubip"></a>
-One or more IPv6 addresses to assign to the network interface\. You cannot specify this option and the option to assign a number of IPv6 addresses in the same request\. You cannot specify this option if you've specified a minimum number of instances to launch\.  
+Whether or not to associates a public IPv4 address with eth0\.
 *Required*: No  
 *Type*: Boolean  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Description of changes:*

The description was some copypasta from ipv6 addresses. Updated to a description adapted from the same property on launch templates: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-networkinterface.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
