### PR TITLE
Update aws-resource-ec2-route-table.md

### DIFF
--- a/doc_source/aws-resource-ec2-route-table.md
+++ b/doc_source/aws-resource-ec2-route-table.md
@@ -84,7 +84,7 @@ The following example uses the VPC ID from a VPC named myVPC that was declared e
 ```
 
 ## See Also<a name="aws-resource-ec2-route-table--seealso"></a>
-+  [AWS::EC2::Route](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-route-table.html)
++  [AWS::EC2::Route](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-route.html)
 +  [CreateRouteTable](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateRouteTable.html) in the *Amazon EC2 API Reference*
 +  [Route Tables](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html) in the *Amazon VPC User Guide*
 +  [Using Tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) in the *Amazon Elastic Compute Cloud User Guide*


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Under See Also, fix `AWS::EC2::Route` link to refer to route documentation (not circular reference back to self/route table)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
