### PR TITLE
Adds note about tag restrictions. Fixes issue #371

### DIFF
--- a/doc_source/aws-properties-resource-tags.md
+++ b/doc_source/aws-properties-resource-tags.md
@@ -31,6 +31,8 @@ All stack\-level tags, including automatically created tags, are propagated to r
 ```
 
 ## Properties<a name="w4784ab1c21c10d190c13c15"></a>
+**Note**  
+Don't use `aws:`, `AWS:`, or any upper or lowercase combination of such as a prefix for either keys or values as it is reserved for AWS use\. You can't edit or delete tag keys or values with this prefix\. Tags with this prefix do not count against your tags per resource limit\.
 
 `Key`  <a name="cfn-resource-tags-key"></a>
 The key name of the tag\. You can specify a value that is 1 to 127 Unicode characters in length and cannot be prefixed with `aws:`\. You can use any of the following characters: the set of Unicode letters, digits, whitespace, `_`, `.`, `/`, `=`, `+`, and `-`\.  


### PR DESCRIPTION
Fixes issue #371 by adding a note instructing to not use aws: or AWS: as a prefix for tag name or value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
