### PR TITLE
Fixed inaccuracy of Engine property in RDS instance resource

### DIFF
--- a/doc_source/aws-properties-rds-database-instance.md
+++ b/doc_source/aws-properties-rds-database-instance.md
@@ -352,8 +352,7 @@ For more information, see [Using Amazon Performance Insights](https://docs.aws.a
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Engine`  <a name="cfn-rds-dbinstance-engine"></a>
-The name of the database engine that you want to use for this DB cluster\. For valid values, see the `Engine` parameter of the [CreateDBCluster](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBCluster.html) action in the *Amazon RDS API Reference*\.  
-If you don't specify a value for the `DBClusterParameterGroupName` property and `default.aurora5.6` is used, specifying `aurora.mysql` or `aurora-postgresql` for this property might result in an error\.
+The name of the database engine to be used for this instance\. For valid values, see the `Engine` parameter of the [CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html) action in the *Amazon RDS API Reference*\.   
 *Required*: No  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
**Resolved Issue #374**

The `Engine` property of `AWS::RDS::DBInstance` is incorrectly linked to RDS Cluster API. Please see the following source code line for details. The given link, property name (e.g., `DBClusterParameterGroupName`) and sample values (e.g., `aurora.mysql`) there are not applicable to the creation of DB instance in that context.

> **aws-properties-rds-databsae-instance.md as of commit 06f1a219aa82f2dfc76cf7eec1ce93384ee6b977**
https://github.com/awsdocs/aws-cloudformation-user-guide/blame/06f1a219aa82f2dfc76cf7eec1ce93384ee6b977/doc_source/aws-properties-rds-database-instance.md#L355


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
