### PR TITLE
Update aws-properties-s3-bucket.md

### DIFF
--- a/doc_source/aws-properties-s3-bucket.md
+++ b/doc_source/aws-properties-s3-bucket.md
@@ -159,7 +159,6 @@ Amazon S3 can store replicated objects in only one destination bucket\. The dest
 
 `Tags`  <a name="cfn-s3-bucket-tags"></a>
 An arbitrary set of tags \(key\-value pairs\) for this S3 bucket\.  
- We recommend limiting the number of tags to seven\. Applying more than seven tags prevents the AWS CLI and the AWS CloudFormation console and API actions from listing the tags for the bucket\. 
 *Required*: No  
 *Type*: List of [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
Remove recommendation for limiting S3 buckets to seven tags, since as far as I can tell S3 and Cloudformation can now successfully deal with far more than seven tags.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
