### PR TITLE
Update aws-resource-ecs-service.md

### DIFF
--- a/doc_source/aws-resource-ecs-service.md
+++ b/doc_source/aws-resource-ecs-service.md
@@ -156,7 +156,7 @@ Service discovery is supported for Fargate tasks if you are using platform versi
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `TaskDefinition`  <a name="cfn-ecs-service-taskdefinition"></a>
-The `family` and `revision` \(`family:revision`\) or full ARN of the task definition to run in your service\. If a `revision` is not specified, the latest `ACTIVE` revision is used\.  
+The `family` and `revision` \(`family:revision`\) or full ARN of the task definition to run in your service\. The `revision` is required in order for the resource to stabilize\.  
 A task definition must be specified if the service is using the `ECS` deployment controller\.  
 *Required*: Yes  
 *Type*: String  


### PR DESCRIPTION
Updated documentation to avoid customer confusion. If Task definition revision is not specified, service will create correctly BUT CFN ECS service resource will NOT stabilize, causing stack creation to fail.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
