### PR TITLE
Removing invalid Allowed Values from ObjectLockEnabled

### DIFF
--- a/doc_source/aws-properties-s3-bucket.md
+++ b/doc_source/aws-properties-s3-bucket.md
@@ -159,7 +159,6 @@ Places an object lock configuration on the specified bucket\. The rule specified
 Indicates whether this bucket has an object lock configuration enabled\.  
 *Required*: No  
 *Type*: Boolean  
-*Allowed Values*: `Enabled`  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `PublicAccessBlockConfiguration`  <a name="cfn-s3-bucket-publicaccessblockconfiguration"></a>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `Allowed Values` in `ObjectLockEnabled` is not a valid Boolean and when used causes CloudFormation to fail. Removing `Allowed Values` as it is incorrect and not consistent with the rest of the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
