### PR TITLE
Correct property types Double -> Number

### DIFF
--- a/doc_source/aws-properties-backup-backupplan-backupruleresourcetype.md
+++ b/doc_source/aws-properties-backup-backupplan-backupruleresourcetype.md
@@ -10,12 +10,12 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 ```
 {
-  "[CompletionWindowMinutes](#cfn-backup-backupplan-backupruleresourcetype-completionwindowminutes)" : Double,
+  "[CompletionWindowMinutes](#cfn-backup-backupplan-backupruleresourcetype-completionwindowminutes)" : Number,
   "[Lifecycle](#cfn-backup-backupplan-backupruleresourcetype-lifecycle)" : [LifecycleResourceType](aws-properties-backup-backupplan-lifecycleresourcetype.md),
   "[RecoveryPointTags](#cfn-backup-backupplan-backupruleresourcetype-recoverypointtags)" : Json,
   "[RuleName](#cfn-backup-backupplan-backupruleresourcetype-rulename)" : String,
   "[ScheduleExpression](#cfn-backup-backupplan-backupruleresourcetype-scheduleexpression)" : String,
-  "[StartWindowMinutes](#cfn-backup-backupplan-backupruleresourcetype-startwindowminutes)" : Double,
+  "[StartWindowMinutes](#cfn-backup-backupplan-backupruleresourcetype-startwindowminutes)" : Number,
   "[TargetBackupVault](#cfn-backup-backupplan-backupruleresourcetype-targetbackupvault)" : String
 }
 ```
@@ -23,13 +23,13 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-properties-backup-backupplan-backupruleresourcetype-syntax.yaml"></a>
 
 ```
-  [CompletionWindowMinutes](#cfn-backup-backupplan-backupruleresourcetype-completionwindowminutes): Double
+  [CompletionWindowMinutes](#cfn-backup-backupplan-backupruleresourcetype-completionwindowminutes): Number
   [Lifecycle](#cfn-backup-backupplan-backupruleresourcetype-lifecycle): 
     [LifecycleResourceType](aws-properties-backup-backupplan-lifecycleresourcetype.md)
   [RecoveryPointTags](#cfn-backup-backupplan-backupruleresourcetype-recoverypointtags): Json
   [RuleName](#cfn-backup-backupplan-backupruleresourcetype-rulename): String
   [ScheduleExpression](#cfn-backup-backupplan-backupruleresourcetype-scheduleexpression): String
-  [StartWindowMinutes](#cfn-backup-backupplan-backupruleresourcetype-startwindowminutes): Double
+  [StartWindowMinutes](#cfn-backup-backupplan-backupruleresourcetype-startwindowminutes): Number
   [TargetBackupVault](#cfn-backup-backupplan-backupruleresourcetype-targetbackupvault): String
 ```
 


### PR DESCRIPTION
This change is based on API docs here: https://docs.aws.amazon.com/aws-backup/latest/devguide/API_CreateBackupPlan.html

I tested it and confirmed that using an integer in the template works, while using decimal syntax results in `Failed to parse template, one or more fields are invalid`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
