### PR TITLE
Updating incorrect allowed values

### DIFF
--- a/doc_source/aws-properties-cw-alarm.md
+++ b/doc_source/aws-properties-cw-alarm.md
@@ -130,8 +130,7 @@ The dimensions for the metric associated with the alarm\. For an alarm based on 
 Used only for alarms based on percentiles\. If `ignore`, the alarm state does not change during periods with too few data points to be statistically significant\. If `evaluate` or this parameter is not used, the alarm is always evaluated and possibly changes state no matter how many data points are available\.  
 *Required*: No  
 *Type*: String  
-*Minimum*: `1`  
-*Maximum*: `255`  
+*Allowed Values*: `evaluate | ignore`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `EvaluationPeriods`  <a name="cfn-cloudwatch-alarms-evaluationperiods"></a>


### PR DESCRIPTION
EvaluateLowSampleCountPercentile was incorrectly misleading to provide values between 1 to 255 whereas it only expects two strings.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
