### PR TITLE
correct allowed value for ec2fleet ondemand and spot allocation strategy, lowest-price to lowestPrice

### DIFF
--- a/doc_source/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.md
+++ b/doc_source/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.md
@@ -25,10 +25,10 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-ec2-ec2fleet-ondemandoptionsrequest-properties"></a>
 
 `AllocationStrategy`  <a name="cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy"></a>
-The order of the launch template overrides to use in fulfilling On\-Demand capacity\. If you specify `lowest-price`, EC2 Fleet uses price to determine the order, launching the lowest price first\. If you specify `prioritized`, EC2 Fleet uses the priority that you assigned to each launch template override, launching the highest priority first\. If you do not specify a value, EC2 Fleet defaults to `lowest-price`\.  
+The order of the launch template overrides to use in fulfilling On\-Demand capacity\. If you specify `lowestPrice`, EC2 Fleet uses price to determine the order, launching the lowest price first\. If you specify `prioritized`, EC2 Fleet uses the priority that you assigned to each launch template override, launching the highest priority first\. If you do not specify a value, EC2 Fleet defaults to `lowestPrice`\.  
 *Required*: No  
 *Type*: String  
-*Allowed Values*: `lowest-price | prioritized`  
+*Allowed Values*: `lowestPrice | prioritized`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 ## See Also<a name="aws-properties-ec2-ec2fleet-ondemandoptionsrequest--seealso"></a>

--- a/doc_source/aws-properties-ec2-ec2fleet-spotoptionsrequest.md
+++ b/doc_source/aws-properties-ec2-ec2fleet-spotoptionsrequest.md
@@ -32,7 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 Indicates how to allocate the target capacity across the Spot pools specified by the Spot Fleet request\. The default is `lowestPrice`\.  
 *Required*: No  
 *Type*: String  
-*Allowed Values*: `diversified | lowest-price`  
+*Allowed Values*: `diversified | lowestPrice`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `InstanceInterruptionBehavior`  <a name="cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior"></a>
@@ -43,7 +43,7 @@ The behavior when a Spot Instance is interrupted\. The default is `terminate`\.
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `InstancePoolsToUseCount`  <a name="cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount"></a>
-The number of Spot pools across which to allocate your target Spot capacity\. Valid only when Spot **AllocationStrategy** is set to `lowest-price`\. EC2 Fleet selects the cheapest Spot pools and evenly allocates your target Spot capacity across the number of Spot pools that you specify\.  
+The number of Spot pools across which to allocate your target Spot capacity\. Valid only when Spot **AllocationStrategy** is set to `lowestPrice`\. EC2 Fleet selects the cheapest Spot pools and evenly allocates your target Spot capacity across the number of Spot pools that you specify\.  
 *Required*: No  
 *Type*: Integer  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cloudformation create of AWS::EC2::Fleet resource fails with the following errors

```
OnDemandAllocationStrategy must be "lowestPrice" or "prioritized" (Service: AmazonEC2; Status Code: 400; Error Code: InvalidParameter; Request ID: xxx)
```

```
AllocationStrategy must be "lowestPrice" or "diversified" (Service: AmazonEC2; Status Code: 400; Error Code: InvalidParameter; Request ID: xxx)
``` 

This PR corrects the allowed values for ec2fleet ondemand and spot allocation strategy from `lowest-price` to `lowestPrice`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
