### PR TITLE
Proposed change to make it more clear that the policy is an object

### DIFF
--- a/doc_source/aws-resource-iot-policy.md
+++ b/doc_source/aws-resource-iot-policy.md
@@ -12,7 +12,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
   "Type" : "AWS::IoT::Policy",
   "Properties" : {
-      "[PolicyDocument](#cfn-iot-policy-policydocument)" : Json,
+      "[PolicyDocument](#cfn-iot-policy-policydocument)" : Object,
       "[PolicyName](#cfn-iot-policy-policyname)" : String
     }
 }
@@ -23,7 +23,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ```
 Type: AWS::IoT::Policy
 Properties: 
-  [PolicyDocument](#cfn-iot-policy-policydocument): Json
+  [PolicyDocument](#cfn-iot-policy-policydocument): Object
   [PolicyName](#cfn-iot-policy-policyname): String
 ```
 
@@ -32,7 +32,7 @@ Properties:
 `PolicyDocument`  <a name="cfn-iot-policy-policydocument"></a>
 The JSON document that describes the policy\.  
 *Required*: Yes  
-*Type*: Json  
+*Type*: Object  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `PolicyName`  <a name="cfn-iot-policy-policyname"></a>


### PR DESCRIPTION
This PR illustrates an area where the CloudFormation documentation could use some work to make it more clear when adding inline policies. The documentation references "Json" in both the JSON and YAML areas which has led some of my customers to believe that this value needs to be a long JSON string.

This shows up in the IAM documentation and likely other places as well.

Instead of referencing Json we should call out that the value is actually an object in whichever syntax the customer is using. This would help if we later add an additional syntax as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
