### PR TITLE
Quote the map keys in the example so that they are parsed as strings and not as numbers

### DIFF
--- a/doc_source/aws-resource-opsworks-instance.md
+++ b/doc_source/aws-resource-opsworks-instance.md
@@ -341,20 +341,20 @@ DBInstance:
     InstanceType: "m1.small"
     TimeBasedAutoScaling: 
       Friday: 
-        12: "on"
-        13: "on"
-        14: "on"
-        15: "on"
+        "12": "on"
+        "13": "on"
+        "14": "on"
+        "15": "on"
       Saturday: 
-        12: "on"
-        13: "on"
-        14: "on"
-        15: "on"
+        "12": "on"
+        "13": "on"
+        "14": "on"
+        "15": "on"
       Sunday: 
-        12: "on"
-        13: "on"
-        14: "on"
-        15: "on"
+        "12": "on"
+        "13": "on"
+        "14": "on"
+        "15": "on"
 ```
 
 ## See Also<a name="aws-resource-opsworks-instance--seealso"></a>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The map keys under the TimeBasedAutoScaling property in the given example are not quoted and hence will be parsed as numbers. If we follow this example in an actual template, the CloudFormation run fails with the below template validation error.
Template format error: [/Resources/Instance/Properties/TimeBasedAutoScaling/Monday] map keys must be strings; received numeric [1] instead

This commit quotes the map keys in the given example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
