### PR TITLE
AWS::DynamoDB::Table AttributeDefinitions required

### DIFF
--- a/doc_source/aws-resource-dynamodb-table.md
+++ b/doc_source/aws-resource-dynamodb-table.md
@@ -65,7 +65,7 @@ Properties:
 `AttributeDefinitions`  <a name="cfn-dynamodb-table-attributedef"></a>
 A list of attributes that describe the key schema for the table and indexes\. Duplicates are allowed\.   
 Update requires: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt)\. Replacement if you edit an existing AttributeDefinition\.   
-*Required*: No  
+*Required*: Yes  
 *Type*: List of [AttributeDefinition](aws-properties-dynamodb-attributedef.md)
 
 `BillingMode`  <a name="cfn-dynamodb-table-billingmode"></a>


### PR DESCRIPTION
This template will produce this error:

```yaml
Resources:
  dynamoDBTable:
    Type: AWS::DynamoDB::Table
    Properties:
      KeySchema:
        - AttributeName: "Album"
          KeyType: "HASH"
        - AttributeName: "Artist"
          KeyType: "RANGE"
      ProvisionedThroughput:
        ReadCapacityUnits: 5
        WriteCapacityUnits: 5
```
`You must specify the AttributeDefinitions property.`

<img width="1405" alt="Screen Shot 2019-07-20 at 1 15 42 PM" src="https://user-images.githubusercontent.com/7014355/61583704-7f87f400-aaf0-11e9-9e75-8ba3687ac086.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
