### PR TITLE
Fix incorrect description of AWS::EC2::VPCCidrBlock

### DIFF
--- a/doc_source/aws-resource-ec2-vpccidrblock.md
+++ b/doc_source/aws-resource-ec2-vpccidrblock.md
@@ -1,6 +1,6 @@
 # AWS::EC2::VPCCidrBlock<a name="aws-resource-ec2-vpccidrblock"></a>
 
-Associates a CIDR block with your subnet\. You can only associate a single IPv6 CIDR block with your subnet\. An IPv6 CIDR block must have a prefix length of /64\.
+Associates a CIDR block with your VPC\. You can only associate a single IPv6 CIDR block with your VPC\. An IPv6 CIDR block must have a prefix length of /64\.
 
 For more information about associating CIDR blocks with your VPC and applicable restrictions, see [VPC and Subnet Sizing](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#VPC_Sizing) in the *Amazon Virtual Private Cloud User Guide*\.
 


### PR DESCRIPTION
*Issue #, if available:* None.

*Description of changes:*
The description of AWS::EC2::VPCCidrBlock incorrectly states that it is for associating CIDR blocks with a subnet.  The description should read that it is for associating CIDR blocks with a VPC.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
