### PR TITLE
Make documentation clearer around dependency

### DIFF
--- a/doc_source/aws-resource-config-deliverychannel.md
+++ b/doc_source/aws-resource-config-deliverychannel.md
@@ -3,6 +3,7 @@
 Specifies a delivery channel object to deliver configuration information to an Amazon S3 bucket and Amazon SNS topic\.
 
 Before you can create a delivery channel, you must create a configuration recorder\.
+This does not imply a `DependsOn` reference in the CloudFormation script though. The AWS Config service will resolve the dependency natively.
 
 You can use this action to change the Amazon S3 bucket or an Amazon SNS topic of the existing delivery channel\. To change the Amazon S3 bucket or an Amazon SNS topic, call this action and specify the changed values for the S3 bucket and the SNS topic\. If you specify a different value for either the S3 bucket or the SNS topic, this action will keep the existing value for the parameter that is not changed\.
 


### PR DESCRIPTION
This has cost us quite a bit of time.
The documentation as it is states that there is a dependency from the delivery channel to the Configuration Recorder. Once we added a `DependsOn` to the delivery channel resource the creation of the Configuration Recorder was stuck and eventually timed out because there was no delivery channel, so the recorder wouldn't start.
The documentation must be clearer that this sentence does not mean to add a `DependsOn` to the resource.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
