### PR TITLE
EnableIAMDatabaseAuthentication supported by Postgres

### DIFF
--- a/doc_source/aws-properties-rds-database-instance.md
+++ b/doc_source/aws-properties-rds-database-instance.md
@@ -340,6 +340,10 @@ Not applicable\. Mapping AWS IAM accounts to database accounts is managed by the
  **MySQL**   
 + For MySQL 5\.6, minor version 5\.6\.34 or higher
 + For MySQL 5\.7, minor version 5\.7\.16 or higher
+ **Postgres**
++ For Postgres 9\.5, minor version 9\.5\.13 or higher
++ For Postgres 9\.6, minor version 9\.6\.9 or higher
++ For Postgres 10\.4 and higher
 *Required*: No  
 *Type*: Boolean  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
Per https://aws.amazon.com/about-aws/whats-new/2018/09/amazon-rds-postgresql-now-supports-iam-authentication/ Postgres supports IAM Database Authentication.

*Issue #, if available:*

*Description of changes:*

Adding in Postgres support for IAM Authentication aligned with other AWS notices and documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
