### PR TITLE
Fix invalid reference to security group

### DIFF
--- a/doc_source/aws-properties-ec2-security-group-ingress.md
+++ b/doc_source/aws-properties-ec2-security-group-ingress.md
@@ -198,7 +198,7 @@ SGBaseIngress:
       IpProtocol: tcp
       FromPort: 80
       ToPort: 80
-      SourceSecurityGroupId: !Ref SGBase
+      SourceSecurityGroupId: !GetAtt SGBase.GroupId
 ```
 
 ### Allow Traffic from a Security Group in a Peered VPC<a name="aws-properties-ec2-security-group-ingress--examples--Allow_Traffic_from_a_Security_Group_in_a_Peered_VPC"></a>


### PR DESCRIPTION
It seems most of the page was updated, but this example is invalid and fails because GroupId: requires an Id to be extracted from the object first.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
