### PR TITLE
AWS::ElasticLoadBalancingV2::TargetGroup -- Protocol is required

### DIFF
--- a/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
@@ -139,7 +139,7 @@ The port on which the targets receive traffic\. This port is used unless you spe
 
 `Protocol`  <a name="cfn-elasticloadbalancingv2-targetgroup-protocol"></a>
 The protocol to use for routing traffic to the targets\. For Application Load Balancers, the supported protocols are HTTP and HTTPS\. For Network Load Balancers, the supported protocols are TCP and TLS\. If the target is a Lambda function, this parameter does not apply\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Allowed Values*: `HTTP | HTTPS | TCP | TLS`  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
For `AWS::ElasticLoadBalancingV2::TargetGroup`, protocol is required; otherwise CloudFormation returns:

```
A protocol must be specified (Service: AmazonElasticLoadBalancingV2; Status Code: 400; Error Code: ValidationError
```

*Description of changes:*

Simple change:

```diff
- *Required*: No
+ *Required*: Yes
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
