### PR TITLE
Update aws-resource-apigateway-account.md

### DIFF
--- a/doc_source/aws-resource-apigateway-account.md
+++ b/doc_source/aws-resource-apigateway-account.md
@@ -5,6 +5,7 @@ The `AWS::ApiGateway::Account` resource specifies the IAM role that Amazon API G
 **Important**  
 If an API Gateway resource has never been created in your AWS account, you must add a dependency on another API Gateway resource, such as an [AWS::ApiGateway::RestApi](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html) or [AWS::ApiGateway::ApiKey](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html) resource\.  
 If an API Gateway resource has been created in your AWS account, no dependency is required \(even if the resource was deleted\)\.
+The `AWS::ApiGateway::Account` resources is an account-level resource meaning that you should not create multiple stacks in the same AWS account containing this resource otherwise one stack may overwrite the Api Gateway account configuration set by another stack.
 
 ## Syntax<a name="aws-resource-apigateway-account-syntax"></a>
 


### PR DESCRIPTION
The ApiGateway::Account resource configures an account-level setting, and launching multiple stacks containing this resource in the same account may lead to undesirable behavior.

*Issue #, if available:*

The ApiGateway::Account resource is different from most other resources in that it manages configuration at an account-level. This behavior should be emphasized in the documentation because it can lead to unexpected results if the resource is used incorrectly. In our case it lead to the failure of Api Gateway logging and limited our troubleshooting of a production problem.

*Description of changes:*

This change makes clear that the ApiGateway::Account resource manages an account-level configuration setting and that users should not create multiple stacks in the same account containing this resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
