### PR TITLE
Update aws-resource-wafregional-ratebasedrule.md

### DIFF
--- a/doc_source/aws-resource-wafregional-ratebasedrule.md
+++ b/doc_source/aws-resource-wafregional-ratebasedrule.md
@@ -120,7 +120,7 @@ MyIPSetRateBasedRule:
     MetricName: "MyIPSetRateBasedRule"
     RateKey : "IP"
     RateLimit : 8000
-    Predicates: 
+    MatchPredicates: 
       - 
         DataId: 
           Ref: "MyIPSetBlacklist"


### PR DESCRIPTION
The Yaml example is incorrect, 'Predicates' should be 'MatchPredicates' as showed in the Resource definition and the JSON example.