### PR TITLE
Fixed dead link to ENI snippets page

### DIFF
--- a/doc_source/aws-resource-ec2-network-interface.md
+++ b/doc_source/aws-resource-ec2-network-interface.md
@@ -144,7 +144,7 @@ Returns the secondary private IP addresses of the network interface\. For exampl
 
  *Tip* 
 
-For more `NetworkInterface` template examples, see [Elastic Network Interface \(ENI\) Template Snippets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-template-snippets-eni.html)\.
+For more `NetworkInterface` template examples, see [Elastic Network Interface \(ENI\) Template Snippets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-ec2.html#cfn-template-snippets-eni)\.
 
 ### Simple Standalone ENI<a name="aws-resource-ec2-network-interface--examples--Simple_Standalone_ENI"></a>
 


### PR DESCRIPTION
On [AWS::EC2:NetworkInterface](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html#aws-resource-ec2-network-interface--examples) page, the link to **`Elastic Network Interface (ENI) Template Snippets`** is no longer valid and user will be redirected to welcome page. This PR is to fix the link target and point it to correct new URL (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-ec2.html#cfn-template-snippets-eni).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
