### PR TITLE
DeploymentId is required when defining stage resource

### DIFF
--- a/doc_source/aws-resource-apigateway-stage.md
+++ b/doc_source/aws-resource-apigateway-stage.md
@@ -90,7 +90,7 @@ The ID of the client certificate that API Gateway uses to call your integration 
 
 `DeploymentId`  <a name="cfn-apigateway-stage-deploymentid"></a>
 The ID of the deployment that the stage is associated with\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
DeploymentId is labelled as not required however this (as far as I can tell), is not the case.

From `aws apigateway create-stage help`

```
NAME
       create-stage -

DESCRIPTION
       Creates  a  new  Stage resource that references a pre-existing  Deploy-
       ment for the API.

       See also: AWS API Documentation

       See 'aws help' for descriptions of global parameters.

SYNOPSIS
            create-stage
          --rest-api-id <value>
          --stage-name <value>
          --deployment-id <value>
          [--description <value>]
          [--cache-cluster-enabled | --no-cache-cluster-enabled]
          [--cache-cluster-size <value>]
          [--variables <value>]
          [--documentation-version <value>]
          [--canary-settings <value>]
          [--tracing-enabled | --no-tracing-enabled]
          [--tags <value>]
          [--cli-input-json <value>]
          [--generate-cli-skeleton <value>]

OPTIONS
       --rest-api-id (string)
          [Required] The string identifier of the associated  RestApi .

       --stage-name (string)
          [Required] The name for the  Stage resource. Stage  names  can  only
          contain  alphanumeric  characters, hyphens, and underscores. Maximum
          length is 128 characters.

       --deployment-id (string)
          [Required] The identifier of the  Deployment resource for the  Stage
          resource.
...
```

The CLI states that this is not an optional field. Furthermore, when omitting this field, Cloudformation fails.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
