### PR TITLE
Fixed inaccuracy in EC2 network interface YAML snippet

### DIFF
--- a/doc_source/aws-resource-ec2-network-interface.md
+++ b/doc_source/aws-resource-ec2-network-interface.md
@@ -225,7 +225,7 @@ Ec2Instance:
       NetworkInterfaces:
       - NetworkInterfaceId:
          Ref: controlXface
-         DeviceIndex: '1'
+        DeviceIndex: '0'
       Tags:
       - Key: Role
         Value: Test Instance


### PR DESCRIPTION
### Description of changes:
1. `DeviceIndex` has extra indent and it is actually passing hash instead of string value to `NetworkInterfaceId ` property. This will result in following CloudFormation error:

    > Value of property NetworkInterfaceId must be of type String

2. Primary network interface begins with device index 0. The snippet is using device index `1` but there is only one interface. This will result in following CloudFormation error:

    > When specifying network interfaces, you must include a device at index 0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
