### PR TITLE
AWS::EC2::LaunchTemplate LaunchTemplateData required

### DIFF
--- a/doc_source/aws-resource-ec2-launchtemplate.md
+++ b/doc_source/aws-resource-ec2-launchtemplate.md
@@ -32,7 +32,7 @@ Properties:
 
 `LaunchTemplateData`  <a name="cfn-ec2-launchtemplate-launchtemplatedata"></a>
 The information for the launch template\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: [LaunchTemplateData](aws-properties-ec2-launchtemplate-launchtemplatedata.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
```
No launch template data was provided. Launch template data is required to create a launch template. (Service: AmazonEC2; Status Code: 400; Error Code: MissingParameter; Request ID: REDACTED)
```
```yaml
Resources:
  Resource:
    Type: AWS::EC2::LaunchTemplate
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
