### PR TITLE
AWS::ElasticLoadBalancingV2::LoadBalancer Subnets or SubnetMappings required

### DIFF
--- a/doc_source/aws-resource-elasticloadbalancingv2-loadbalancer.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-loadbalancer.md
@@ -88,7 +88,7 @@ The default is an Internet\-facing load balancer\.
 The IDs of the public subnets\. You can specify only one subnet per Availability Zone\. You must specify either subnets or subnet mappings\.  
 \[Application Load Balancers\] You must specify subnets from at least two Availability Zones\. You cannot specify Elastic IP addresses for your subnets\.  
 \[Network Load Balancers\] You can specify subnets from one or more Availability Zones\. You can specify one Elastic IP address per subnet\.  
-*Required*: No  
+*Required*: Conditional  
 *Type*: List of [SubnetMapping](aws-properties-elasticloadbalancingv2-loadbalancer-subnetmapping.md)  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
@@ -96,7 +96,7 @@ The IDs of the public subnets\. You can specify only one subnet per Availability
 The IDs of the public subnets\. You can specify only one subnet per Availability Zone\. You must specify either subnets or subnet mappings\.  
 \[Application Load Balancers\] You must specify subnets from at least two Availability Zones\. When you specify subnets for an existing Application Load Balancer, they replace the previously enabled subnets\.  
 \[Network Load Balancers\] You can specify subnets from one or more Availability Zones when you create the load balancer\. You can't change the subnets for an existing Network Load Balancer\.  
-*Required*: No  
+*Required*: Conditional  
 *Type*: List of String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
`You must specify either subnets or subnet mappings.`

```yaml
Resources:
  Resource:
    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
