### PR TITLE
AWS::IoTEvents::DetectorModel roleArn and detectorModelDefinition required

### DIFF
--- a/doc_source/aws-resource-iotevents-detectormodel.md
+++ b/doc_source/aws-resource-iotevents-detectormodel.md
@@ -47,7 +47,7 @@ Properties:
 
 `DetectorModelDefinition`  <a name="cfn-iotevents-detectormodel-detectormodeldefinition"></a>
 Information that defines how a detector operates\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: [DetectorModelDefinition](aws-properties-iotevents-detectormodel-detectormodeldefinition.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -78,7 +78,7 @@ The input attribute key used to identify a device or system to create a detector
 
 `RoleArn`  <a name="cfn-iotevents-detectormodel-rolearn"></a>
 The ARN of the role that grants permission to AWS IoT Events to perform its operations\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Minimum*: `1`  
 *Maximum*: `2048`  


### PR DESCRIPTION
```
2 validation errors detected: Value null at 'roleArn' failed to satisfy constraint: Member must not be null; Value null at 'detectorModelDefinition' failed to satisfy constraint: Member must not be null (Service: AWSIoTEvents; Status Code: 400; Error Code: InvalidRequestException; Request ID: REDACTED)
```
```yaml
Resources:
  Resource:
    Type: AWS::IoTEvents::DetectorModel
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
