### PR TITLE
AWS::IoTEvents::Input inputDefinition required

### DIFF
--- a/doc_source/aws-resource-iotevents-input.md
+++ b/doc_source/aws-resource-iotevents-input.md
@@ -37,7 +37,7 @@ Properties:
 
 `InputDefinition`  <a name="cfn-iotevents-input-inputdefinition"></a>
 The definition of the input\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: [InputDefinition](aws-properties-iotevents-input-inputdefinition.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
```
1 validation error detected: Value null at 'inputDefinition' failed to satisfy constraint: Member must not be null (Service: AWSIoTEvents; Status Code: 400; Error Code: InvalidRequestException; Request ID: REDACTED)
```
```yaml
Resources:
  Resource:
    Type: AWS::IoTEvents::Input
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
