### PR TITLE
AWS::MediaLive::Input Name required

### DIFF
--- a/doc_source/aws-resource-medialive-input.md
+++ b/doc_source/aws-resource-medialive-input.md
@@ -70,7 +70,7 @@ Settings that apply only if the input is a MediaConnect input\.
 
 `Name`  <a name="cfn-medialive-input-name"></a>
 A name for the input\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
```
Non-empty input name required (Service: AWSMediaLive; Status Code: 400; Error Code: BadRequestException; Request ID: REDACTED)
```
```yaml
Resources:
  Resource:
    Type: AWS::MediaLive::Input
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
