### PR TITLE
AWS::MediaLive::InputSecurityGroup WhitelistRules required

### DIFF
--- a/doc_source/aws-resource-medialive-inputsecuritygroup.md
+++ b/doc_source/aws-resource-medialive-inputsecuritygroup.md
@@ -40,7 +40,7 @@ A collection of tags for this input security group\. Each tag is a key\-value pa
 
 `WhitelistRules`  <a name="cfn-medialive-inputsecuritygroup-whitelistrules"></a>
 The list of IPv4 CIDR addresses to include in the input security group as "allowed" addresses\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: List of [InputWhitelistRuleCidr](aws-properties-medialive-inputsecuritygroup-inputwhitelistrulecidr.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
```
Must specify at least one whitelist (Service: AWSMediaLive; Status Code: 400; Error Code: BadRequestException; Request ID: REDACTED)
```
```yaml
Resources:
  Resource:
    Type: AWS::MediaLive::InputSecurityGroup
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
