### PR TITLE
AWS::SageMaker::Workteam Description required

### DIFF
--- a/doc_source/aws-resource-sagemaker-workteam.md
+++ b/doc_source/aws-resource-sagemaker-workteam.md
@@ -42,7 +42,7 @@ Properties:
 
 `Description`  <a name="cfn-sagemaker-workteam-description"></a>
 A description of the work team\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Minimum*: `1`  
 *Maximum*: `200`  


### PR DESCRIPTION
`Workteam description cannot be empty`

```yaml
Resources:
  Resource:
    Type: AWS::SageMaker::Workteam
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
