### PR TITLE
AWS::ServiceDiscovery::Service NamespaceId required

### DIFF
--- a/doc_source/aws-resource-servicediscovery-service.md
+++ b/doc_source/aws-resource-servicediscovery-service.md
@@ -83,7 +83,7 @@ The name of the service\.
 
 `NamespaceId`  <a name="cfn-servicediscovery-service-namespaceid"></a>
 The ID of the namespace that was used to create the service\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Maximum*: `64`  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
```
Service namespace id cannot be null (Service: AWSServiceDiscovery; Status Code: 400; Error Code: InvalidInput; Request ID: REDACTED)
```
```yaml
Resources:
  Resource:
    Type: AWS::ServiceDiscovery::Service
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
