### PR TITLE
AWS::ElasticLoadBalancingV2::TargetGroup Port, Protocol, VpcId conditionally required

### DIFF
--- a/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
@@ -139,7 +139,7 @@ The port on which the targets receive traffic\. This port is used unless you spe
 
 `Protocol`  <a name="cfn-elasticloadbalancingv2-targetgroup-protocol"></a>
 The protocol to use for routing traffic to the targets\. For Application Load Balancers, the supported protocols are HTTP and HTTPS\. For Network Load Balancers, the supported protocols are TCP and TLS\. If the target is a Lambda function, this parameter does not apply\.  
-*Required*: No  
+*Required*: Conditional  
 *Type*: String  
 *Allowed Values*: `HTTP | HTTPS | TCP | TLS`  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)

--- a/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
@@ -131,7 +131,7 @@ This name must be unique per region per account, can have a maximum of 32 charac
 
 `Port`  <a name="cfn-elasticloadbalancingv2-targetgroup-port"></a>
 The port on which the targets receive traffic\. This port is used unless you specify a port override when registering the target\. If the target is a Lambda function, this parameter does not apply\.  
-*Required*: No  
+*Required*: Conditional  
 *Type*: Integer  
 *Minimum*: `1`  
 *Maximum*: `65535`  


### PR DESCRIPTION
```
A port must be specified (Service: AmazonElasticLoadBalancingV2; Status Code: 400; Error Code: ValidationError; Request ID: REDACTED)
```
```
A protocol must be specified (Service: AmazonElasticLoadBalancingV2; Status Code: 400; Error Code: ValidationError; Request ID: REDACTED)
```
```
A VPC ID must be specified (Service: AmazonElasticLoadBalancingV2; Status Code: 400; Error Code: ValidationError; Request ID: REDACTED)
```
```yaml
Resources:
  Resource:
    Type: AWS::ElasticLoadBalancingV2::TargetGroup
```

[`AWS::ElasticLoadBalancingV2::TargetGroup`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html)
