### PR TITLE
AWS::Elasticsearch::Domain EBSOptions conditionally required

### DIFF
--- a/doc_source/aws-resource-elasticsearch-domain.md
+++ b/doc_source/aws-resource-elasticsearch-domain.md
@@ -76,7 +76,7 @@ If you specify a name, you cannot perform updates that require replacement of th
 
 `EBSOptions`  <a name="cfn-elasticsearch-domain-ebsoptions"></a>
 The configurations of Amazon Elastic Block Store \(Amazon EBS\) volumes that are attached to data nodes in the Amazon ES domain\. For more information, see [Configuring EBS\-based Storage](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-ebs) in the *Amazon Elasticsearch Service Developer Guide*\.  
-*Required*: No  
+*Required*: Conditional  
 *Type*: [EBSOptions](aws-properties-elasticsearch-domain-ebsoptions.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
```
EBS storage must be selected for m4.large.elasticsearch (Service: AWSElasticsearch; Status Code: 400; Error Code: ValidationException; Request ID: REDACTED)
```
```yaml
Resources:
  Resource:
    Type: AWS::Elasticsearch::Domain
```
["Amazon EBS storage (if you choose this option)"](https://aws.amazon.com/elasticsearch-service/pricing/)

This template succeeds without `EBSOptions`:

```yaml
Resources:
  Resource:
    Type: AWS::Elasticsearch::Domain
    Properties:
      ElasticsearchClusterConfig:
        InstanceType: 'r3.large.elasticsearch'
```

[`AWS::Elasticsearch::Domain`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html)

[`create-elasticsearch-domain`](https://docs.aws.amazon.com/cli/latest/reference/es/create-elasticsearch-domain.html)