### PR TITLE
Fix VpnGatewayId reference for AWS::EC2::VPNGatewayRoutePropagation

### DIFF
--- a/doc_source/aws-resource-ec2-vpn-gatewayrouteprop.md
+++ b/doc_source/aws-resource-ec2-vpn-gatewayrouteprop.md
@@ -78,8 +78,7 @@ Type: AWS::EC2::VPNGatewayRoutePropagation
    Properties:
        RouteTableIds: 
         - !Ref PrivateRouteTable
-       VpnGatewayId: 
-        - !Ref VPNGateway
+       VpnGatewayId: !Ref VPNGateway
 ```
 
 ## See Also<a name="aws-resource-ec2-vpn-gatewayrouteprop--seealso"></a>


### PR DESCRIPTION
*Description of changes:* VpnGatewayId is not a list but a String. Also a new line was automatically added by GitHub at the end of the file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
