### PR TITLE
Denoting AuthorizationType as Required as per SDK

### DIFF
--- a/doc_source/aws-resource-apigateway-method.md
+++ b/doc_source/aws-resource-apigateway-method.md
@@ -71,7 +71,7 @@ A list of authorization scopes configured on the method\. The scopes are used wi
 `AuthorizationType`  <a name="cfn-apigateway-method-authorizationtype"></a>
 The method's authorization type\. For valid values, see [Method](https://docs.aws.amazon.com/apigateway/api-reference/resource/method/) in the *API Gateway API Reference*\.  
 If you specify the `AuthorizerId` property, specify `CUSTOM` for this property\.
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
When you try to create an APIGateway::Method resource without an authorizationType set, the underlying SDK will fail with error:

```json
...
"ResourceStatusReason": "1 validation error detected: Value null at 'putMethodInput.authorizationType' failed to satisfy constraint: Member must not be null (Service: AmazonApiGateway; Status Code: 400; Error Code: ValidationException; Request ID: b0c6d8f2-0554-4b21-9f02-ea42d28e78b4)",
...
```

yet the documentation here says that it is not required.  This change updates that mistake so that the field is required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
