### PR TITLE
"You must specify USERPOOL" for AWS::AppStream::User AuthenticationType

### DIFF
--- a/doc_source/aws-resource-appstream-user.md
+++ b/doc_source/aws-resource-appstream-user.md
@@ -39,7 +39,7 @@ Properties:
 The authentication type for the user\. You must specify USERPOOL\.   
 *Required*: Yes  
 *Type*: String  
-*Allowed Values*: `API | SAML | USERPOOL`  
+*Allowed Values*: `USERPOOL`  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `FirstName`  <a name="cfn-appstream-user-firstname"></a>


### PR DESCRIPTION
```yaml
Resources:
  User:
    Type: AWS::AppStream::User
    Properties:
      UserName: UserName@UserName.com
      AuthenticationType: API
```
`Cannot create a user with 'API' authentication type (Service: AmazonAppStream; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: )`
```yaml
Resources:
  User:
    Type: AWS::AppStream::User
    Properties:
      UserName: UserName@UserName.com
      AuthenticationType: SAML
```
`Cannot create a user with 'SAML' authentication type (Service: AmazonAppStream; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: )`

[`AWS::AppStream::User`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appstream-user.html#cfn-appstream-user-authenticationtype)