### PR TITLE
Fix formatting error In YAML version of example

### DIFF
--- a/doc_source/aws-resource-dynamodb-table.md
+++ b/doc_source/aws-resource-dynamodb-table.md
@@ -494,7 +494,7 @@ mySecondDDBTable:
             Ref: "WriteCapacityUnits"
     Tags:
       - Key: foo
-Value: bar
+        Value: bar
 ```
 
 ### DynamoDB Table with Application Auto Scaling<a name="aws-resource-dynamodb-table--examples--DynamoDB_Table_with_Application_Auto_Scaling"></a>


### PR DESCRIPTION
*Issue #, if available:*

The tags 'Value' attribute should have the same indentation as the 'Key' to which it relates, see the JSON version of the example immediately above in the doc to see that they should both be in the same array nested within the tags array. :)

*Description of changes:*

Added the necessary indentation to make it part of the correct tag, and **not** a top level resource in the Cloud Formation template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
