### PR TITLE
Fixed indentation on CreateTestDBPolicy YAML example in aws-resource-…

### DIFF
--- a/doc_source/aws-resource-iam-managedpolicy.md
+++ b/doc_source/aws-resource-iam-managedpolicy.md
@@ -210,8 +210,8 @@ The following example creates a managed policy and associates it with the `TestD
                         Condition:
                           StringEquals:
                             rds:DatabaseClass: "db.t2.micro"
-           Groups:
-             - "TestDBGroup"
+              Groups:
+                - "TestDBGroup"
 ```
 
 ## See Also<a name="aws-resource-iam-managedpolicy--seealso"></a>


### PR DESCRIPTION
…iam-managedpolicy.md

*Issue #, if available:*
N.A.

*Description of changes:*
Fixed indentation on lines 213,214 of doc_source/aws-resource-iam-managedpolicy.md. They were out of alignment. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
Yes
