### PR TITLE
Fix docs: Uploading Local Artifacts to an S3 Bucket

### DIFF
--- a/doc_source/using-cfn-cli-package.md
+++ b/doc_source/using-cfn-cli-package.md
@@ -21,7 +21,7 @@ Resources:
     Properties:
       Handler: index.handler
       Runtime: nodejs8.10
-      CodeUri: /home/user/code/lambdafunction
+      Code: /home/user/code/lambdafunction
 ```
 
 The following command creates a \.zip file containing the function's source code folder, and then uploads the \.zip file to the root folder of the `my-bucket` bucket\.
@@ -29,10 +29,10 @@ The following command creates a \.zip file containing the function's source code
 **Package Command**
 
 ```
-aws cloudformation package --template /path_to_template/template.json --s3-bucket mybucket --output json > packaged-template.json
+aws cloudformation package --template /path_to_template/template.json --s3-bucket mybucket --use-json > packaged-template.json
 ```
 
-The command saves the template that it generates to the path specified by the `--output` option\. The command replaces the artifact with the S3 location, as shown in the following example:
+The command saves the template that it generates to the path specified by the `--output-template-file` option\. The command replaces the artifact with the S3 location, as shown in the following example:
 
 **Resulting Template**
 
@@ -45,5 +45,5 @@ Resources:
     Properties:
       Handler: index.handler
       Runtime: nodejs8.10
-      CodeUri: s3://mybucket/lambdafunction.zip
+      Code: s3://mybucket/lambdafunction.zip
 ```

--- a/doc_source/using-cfn-cli-package.md
+++ b/doc_source/using-cfn-cli-package.md
@@ -14,10 +14,10 @@ The following template specifies the local artifact for a Lambda function's sour
 
 ```
 AWSTemplateFormatVersion: '2010-09-09'
-Transform: 'AWS::Serverless-2016-10-31'
+Transform: 'AWS::Lambda-2016-10-31'
 Resources:
   MyFunction:
-    Type: 'AWS::Serverless::Function'
+    Type: 'AWS::Lambda::Function'
     Properties:
       Handler: index.handler
       Runtime: nodejs8.10
@@ -38,10 +38,10 @@ The command saves the template that it generates to the path specified by the `-
 
 ```
 AWSTemplateFormatVersion: '2010-09-09'
-Transform: 'AWS::Serverless-2016-10-31'
+Transform: 'AWS::Lambda-2016-10-31'
 Resources:
   MyFunction:
-    Type: 'AWS::Serverless::Function'
+    Type: 'AWS::Lambda::Function'
     Properties:
       Handler: index.handler
       Runtime: nodejs8.10


### PR DESCRIPTION
*Description of changes:*

1. Fixed the property name for `AWS::Serverless::Function` resource:  from `CodeUri` to `Code`.

2. Fixed the `aws cloudformation package` command arguments: from `--output json` to `--use-json`, and another instance from ` --output` to `--output-template-file`.

3. Fixed the resource name: from `AWS::Serverless::Function` to `AWS::Lambda::Function`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
