### PR TITLE
Fix inner link

### DIFF
--- a/doc_source/aws-resource-iam-role.md
+++ b/doc_source/aws-resource-iam-role.md
@@ -47,7 +47,7 @@ Properties:
 ## Properties<a name="aws-resource-iam-role-properties"></a>
 
 `AssumeRolePolicyDocument`  <a name="cfn-iam-role-assumerolepolicydocument"></a>
-The trust policy that is associated with this role\. Trust policies define which entities can assume the role\. You can associate only one trust policy with a role\. For an example of a policy that can be used to assume a role, see [Template Examples](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-templateexamples)\. For more information about the elements that you can use in an IAM policy, see [IAM Policy Elements Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html) in the *IAM User Guide*\.  
+The trust policy that is associated with this role\. Trust policies define which entities can assume the role\. You can associate only one trust policy with a role\. For an example of a policy that can be used to assume a role, see [Template Examples](#aws-resource-iam-role--examples)\. For more information about the elements that you can use in an IAM policy, see [IAM Policy Elements Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html) in the *IAM User Guide*\.  
 *Required*: Yes  
 *Type*: Json  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*

One of the _internal_ links in the text is broken (probably outdated).

*Description of changes:*

Since it’s an internal link, I’ve cut it down to the anchor name: from `https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-templateexamples` to `#aws-resource-iam-role--examples`, which seems less code to maintain; I hope that’s alright.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
