### PR TITLE
Correct allowed values for SSEType

### DIFF
--- a/doc_source/aws-properties-dynamodb-table-ssespecification.md
+++ b/doc_source/aws-properties-dynamodb-table-ssespecification.md
@@ -43,5 +43,5 @@ Server\-side encryption type\. The only supported value is:
 +  `KMS` \- Server\-side encryption that uses AWS Key Management Service\. The key is stored in your account and is managed by AWS KMS \(AWS KMS charges apply\)\.
 *Required*: No  
 *Type*: String  
-*Allowed Values*: `AES256 | KMS`  
+*Allowed Values*: `KMS`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
Only allowed value for SSEType in SSESpecification is KMS.
Using AES256 that was indicated as an allowed values cause creation to fail.

*Issue #, if available:*

*Description of changes:*
Change the allowed values from AES256 | KMS to only KMS


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
