### PR TITLE
Update aws-resource-ec2-transitgatewayattachment.md

### DIFF
--- a/doc_source/aws-resource-ec2-transitgatewayattachment.md
+++ b/doc_source/aws-resource-ec2-transitgatewayattachment.md
@@ -67,7 +67,7 @@ The ID of the VPC\.
 
 ### Ref<a name="aws-resource-ec2-transitgatewayattachment-return-values-ref"></a>
 
-When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the Transit Gateway attachment ID\.
+When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the ID of the attachment\.
 
 For more information about using the `Ref` function, see [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html)\.
 

--- a/doc_source/aws-resource-ec2-transitgatewayattachment.md
+++ b/doc_source/aws-resource-ec2-transitgatewayattachment.md
@@ -67,7 +67,7 @@ The ID of the VPC\.
 
 ### Ref<a name="aws-resource-ec2-transitgatewayattachment-return-values-ref"></a>
 
-When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the resource name\.
+When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the Transit Gateway attachment ID\.
 
 For more information about using the `Ref` function, see [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html)\.
 


### PR DESCRIPTION
When I first read the returned value of the Ref function for this resource it made me come to the conclusion I needed to get the attachment ID in a different way. I actually created a CFN custom resource to do that.

I came back to this today and felt that it didn't make sense to return the name so I tested it. I have a cfn stack that creates multiple `AWS::EC2::TransitGatewayAttachment`'s.

The following does return the attachment ID not the name.

```
Outputs:
  LegacyDefaultVpcAttachmentId:
    Description: The ID of the attachment.
    Value: !Ref LegacyDefaultVpcAttachment
```

Please advise.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
