### PR TITLE
Remove DEEP_ARCHIVE StorageClass

### DIFF
--- a/doc_source/aws-properties-s3-bucket-lifecycleconfig-rule-transition.md
+++ b/doc_source/aws-properties-s3-bucket-lifecycleconfig-rule-transition.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 The storage class to which you want the object to transition\.  
 *Required*: Yes  
 *Type*: String  
-*Allowed Values*: `DEEP_ARCHIVE | GLACIER | INTELLIGENT_TIERING | ONEZONE_IA | STANDARD_IA`  
+*Allowed Values*: ` GLACIER | INTELLIGENT_TIERING | ONEZONE_IA | STANDARD_IA`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `TransitionDate`  <a name="cfn-s3-bucket-lifecycleconfig-rule-transition-transitiondate"></a>


### PR DESCRIPTION
DEEP_ARCHIVE is not yet supported by cloudformation per AWS support

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
