### PR TITLE
Fix node require() path for cfn-response

### DIFF
--- a/doc_source/cfn-lambda-function-code-cfnresponsemodule.md
+++ b/doc_source/cfn-lambda-function-code-cfnresponsemodule.md
@@ -12,7 +12,7 @@ The `cfn-response` module is available only when you use the `ZipFile` property 
 For Node\.js functions, use the `require()` function to load the `cfn-response` module\. For example, the following code example creates a `cfn-response` object with the name `response`:
 
 ```
-var response = require('cfn-response');
+var response = require('./cfn-response');
 ```
 
 For Python, use the `import` statement to load the `cfnresponse` module, as shown in the following example:
@@ -56,7 +56,7 @@ In the following Node\.js example, the inline Lambda function takes an input val
 
 ```
 "ZipFile": { "Fn::Join": ["", [
-  "var response = require('cfn-response');",
+  "var response = require('./cfn-response');",
   "exports.handler = function(event, context) {",
   "  var input = parseInt(event.ResourceProperties.Input);",
   "  var responseData = {Value: input * 5};",
@@ -69,7 +69,7 @@ In the following Node\.js example, the inline Lambda function takes an input val
 
 ```
 ZipFile: >
-  var response = require('cfn-response');
+  var response = require('./cfn-response');
   exports.handler = function(event, context) {
     var input = parseInt(event.ResourceProperties.Input);
     var responseData = {Value: input * 5};

--- a/doc_source/quickref-lambda.md
+++ b/doc_source/quickref-lambda.md
@@ -80,7 +80,7 @@ In the example, when AWS CloudFormation creates the `AllSecurityGroups` custom r
         "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
         "Code": {
           "ZipFile":  { "Fn::Join": ["", [
-            "var response = require('cfn-response');",
+            "var response = require('./cfn-response');",
             "exports.handler = function(event, context) {",
             "   var responseData = {Value: event.ResourceProperties.List};",
             "   responseData.Value.push(event.ResourceProperties.AppendedItem);",
@@ -215,7 +215,7 @@ Resources:
       Role: !GetAtt LambdaExecutionRole.Arn
       Code:
         ZipFile: !Sub |
-          var response = require('cfn-response');
+          var response = require('./cfn-response');
           exports.handler = function(event, context) {
              var responseData = {Value: event.ResourceProperties.List};
              responseData.Value.push(event.ResourceProperties.AppendedItem);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current code `require('cfn-response')` produces a `Cannot find module` error. A relative path needs to be used because Cloudformation places the `cfn-response.js` file at the root level with the code from the `ZipFile` parameter.

The bug will leave your Cloudformation stack in a broken state because the custom resource cannot be successfully created (causing a rollback) nor deleted (leaving the stack in a rollback cleanup state until timed out, etc.).

![image](https://user-images.githubusercontent.com/3052593/68427423-eba16d00-015e-11ea-8b1c-e31a31ebcdd5.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
