### PR TITLE
Fix: AllowedOAuthScopes parameter documentation

### DIFF
--- a/doc_source/aws-resource-cognito-userpoolclient.md
+++ b/doc_source/aws-resource-cognito-userpoolclient.md
@@ -79,7 +79,7 @@ Set to `True` if the client is allowed to follow the OAuth protocol when interac
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `AllowedOAuthScopes`  <a name="cfn-cognito-userpoolclient-allowedoauthscopes"></a>
-A list of allowed `OAuth` scopes\. Currently supported values are `"phone"`, `"email"`, `"openid"`, and `"Cognito"`\.  
+A list of allowed `OAuth` scopes\. Currently supported values are `"phone"`, `"email"`, `"openid"`, `"profile"` and `"aws.cognito.signin.user.admin"`\.  
 *Required*: No  
 *Type*: List of String  
 *Maximum*: `25`  

--- a/doc_source/aws-resource-cognito-userpoolclient.md
+++ b/doc_source/aws-resource-cognito-userpoolclient.md
@@ -65,8 +65,8 @@ Properties:
 ## Properties<a name="aws-resource-cognito-userpoolclient-properties"></a>
 
 `AllowedOAuthFlows`  <a name="cfn-cognito-userpoolclient-allowedoauthflows"></a>
+The allowed OAuth flows\. Possible values are: `code`, `implicit`, and `client_credentials`\.
 Set to `code` to initiate a code grant flow, which provides an authorization code as the response\. This code can be exchanged for access tokens with the token endpoint\.  
-Set to `token` to specify that the client should get the access token \(and, optionally, ID token, based on scopes\) directly\.  
 *Required*: No  
 *Type*: List of String  
 *Maximum*: `3`  
@@ -79,7 +79,7 @@ Set to `True` if the client is allowed to follow the OAuth protocol when interac
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `AllowedOAuthScopes`  <a name="cfn-cognito-userpoolclient-allowedoauthscopes"></a>
-A list of allowed `OAuth` scopes\. Currently supported values are `"phone"`, `"email"`, `"openid"`, `"profile"` and `"aws.cognito.signin.user.admin"`\.  
+The allowed `OAuth` scopes\. Possible values provided by OAuth are: `phone`, `email`, `openid`, and `profile`\. Possible values provided by AWS are: `aws.cognito.signin.user.admin`\. Custom scopes created in Resource Servers are also supported\.
 *Required*: No  
 *Type*: List of String  
 *Maximum*: `25`  


### PR DESCRIPTION
`Invalid scope requested: Cognito (Service: AWSCognitoIdentityProvider; Status Code: 400; Error Code: ScopeDoesNotExistException;`

This should be possible based on the docs stating:
```
AllowedOAuthScopes
A list of allowed OAuth scopes. Currently supported values are "phone", "email", "openid", and "Cognito". In addition to these values, custom scopes created in Resource Servers are also supported.

Required: No

Type: List of String

Maximum: 50

Update requires: No interruption
```

The actual scopes available for creation with CloudFormation (not including custom scopes) are actually:

aws.cognito.signin.user.admin
phone
openid
email
profile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
