### PR TITLE
Fixed typo "WriteCapacityUnis" correctly

### DIFF
--- a/doc_source/resource-import-existing-stack.md
+++ b/doc_source/resource-import-existing-stack.md
@@ -52,7 +52,7 @@ In this walkthrough, we provide the following example template, called `template
                 ],
                 "ProvisionedThroughput": {
                     "ReadCapacityUnits": 5,
-                    "WriteCapacityUnis": 1
+                    "WriteCapacityUnits": 1
                 }
             }
         }

--- a/doc_source/resource-import-new-stack.md
+++ b/doc_source/resource-import-new-stack.md
@@ -53,7 +53,7 @@ In this walkthrough, we provide the following example template, called `template
                 ],
                 "ProvisionedThroughput": {
                     "ReadCapacityUnits": 5,
-                    "WriteCapacityUnis": 1
+                    "WriteCapacityUnits": 1
                 }
             }
         }

--- a/doc_source/resource-import-revert.md
+++ b/doc_source/resource-import-revert.md
@@ -53,7 +53,7 @@ To revert an import operation, specify a `Retain` deletion policy for the resour
                    ],
                    "ProvisionedThroughput": {
                        "ReadCapacityUnits": 5,
-                       "WriteCapacityUnis": 1
+                       "WriteCapacityUnits": 1
                    }
                }
            }
@@ -164,7 +164,7 @@ To revert an import operation, specify a `Retain` deletion policy for the resour
                    ],
                    "ProvisionedThroughput": {
                        "ReadCapacityUnits": 5,
-                       "WriteCapacityUnis": 1
+                       "WriteCapacityUnits": 1
                    }
                }
            }


### PR DESCRIPTION
# What

Hi, I found typo `WriteCapacityUnis` in some documents.
I updated it.

- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-existing-stack.html
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-new-stack.html
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-revert.html

I understand it 👍

>By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Thanks.