### PR TITLE
Fixed S3 Template Snippets for static websites with custom domains

### DIFF
--- a/doc_source/quickref-s3.md
+++ b/doc_source/quickref-s3.md
@@ -233,7 +233,7 @@ For more information about using a custom domain, see [Setting Up a Static Websi
                         "Type": "CNAME",
                         "TTL" : "900",
                         "ResourceRecords" : [
-                            {"Fn::GetAtt":["WWWBucket", "DomainName"]}
+                          { "Fn::Join": [".", ["www", { "Ref": "RootDomainName"}, { "Fn::FindInMap": [ "RegionMap", { "Ref": "AWS::Region"}, "websiteendpoint" ]} ]}
                         ]
                     }
                 ]
@@ -321,8 +321,11 @@ Resources:
             - Domain: !Ref RootDomainName
         Type: CNAME
         TTL: 900
-        ResourceRecords:
-        - !GetAtt WWWBucket.DomainName
+        ResourceRecords: 
+        - !Sub
+          - www.${BucketDomain}.${RegionEndpoint}
+          - BucketDomain: !Ref RootDomainName
+            RegionEndpoint: !FindInMap [ RegionMap, !Ref 'AWS::Region', websiteendpoint]
 Outputs:
   WebsiteURL:
     Value: !GetAtt RootBucket.WebsiteURL


### PR DESCRIPTION
*Description of changes:*
The current S3 Template Snippert for static websites with a custom domain assaigns the Bucket's DomainName to the CNAME Record. However, for the redirect to work, the value needs to be the Bucket's Website-Endpoint.

As there is no attribute in the S3::Bucket-Ressource, I built the Website-Endpoint with intrinsic functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
