### PR TITLE
Update aws-resource-servicecatalog-portfolioshare.md

### DIFF
--- a/doc_source/aws-resource-servicecatalog-portfolioshare.md
+++ b/doc_source/aws-resource-servicecatalog-portfolioshare.md
@@ -1,6 +1,6 @@
 # AWS::ServiceCatalog::PortfolioShare<a name="aws-resource-servicecatalog-portfolioshare"></a>
 
-Shares the specified portfolio with the specified account or organization node\. Shares to an organization node can only be created by the master account of an Organization\. AWSOrganizationsAccess must be enabled in order to create a portfolio share to an organization node\.
+Shares the specified portfolio with the specified AWS account.
 
 ## Syntax<a name="aws-resource-servicecatalog-portfolioshare-syntax"></a>
 


### PR DESCRIPTION


*Issue #, if available:* 
Currently, CloudFormation does not support the OrganizationNode property within the AWS::ServiceCatalog::PortfolioShare resource. Hence, this document is misleading and confusing.

*Description of changes:*  Removed the Organization node related information from the document as it is misleading.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
