### PR TITLE
Fixed wrong case of AWS::ECS::Service AwsVpcConfiguration resource name.

### DIFF
--- a/doc_source/aws-properties-ecs-service-awsvpcconfiguration.md
+++ b/doc_source/aws-properties-ecs-service-awsvpcconfiguration.md
@@ -1,6 +1,6 @@
-# AWS::ECS::Service AwsVpcConfiguration<a name="aws-properties-ecs-service-awsvpcconfiguration"></a>
+# AWS::ECS::Service AwsvpcConfiguration<a name="aws-properties-ecs-service-awsvpcconfiguration"></a>
 
-The `AwsVpcConfiguration` property specifies an object representing the networking details for a task or service\.
+The `AwsvpcConfiguration` property specifies an object representing the networking details for a task or service\.
 
 ## Syntax<a name="aws-properties-ecs-service-awsvpcconfiguration-syntax"></a>
 
@@ -36,14 +36,14 @@ Whether the task's elastic network interface receives a public IP address\. The 
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `SecurityGroups`  <a name="cfn-ecs-service-awsvpcconfiguration-securitygroups"></a>
-The security groups associated with the task or service\. If you do not specify a security group, the default security group for the VPC is used\. There is a limit of 5 security groups that can be specified per `AwsVpcConfiguration`\.  
+The security groups associated with the task or service\. If you do not specify a security group, the default security group for the VPC is used\. There is a limit of 5 security groups that can be specified per `AwsvpcConfiguration`\.  
 All specified security groups must be from the same VPC\.
 *Required*: No  
 *Type*: List of String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Subnets`  <a name="cfn-ecs-service-awsvpcconfiguration-subnets"></a>
-The subnets associated with the task or service\. There is a limit of 16 subnets that can be specified per `AwsVpcConfiguration`\.  
+The subnets associated with the task or service\. There is a limit of 16 subnets that can be specified per `AwsvpcConfiguration`\.  
 All specified subnets must be from the same VPC\.
 *Required*: Yes  
 *Type*: List of String  

--- a/doc_source/aws-properties-ecs-service-networkconfiguration.md
+++ b/doc_source/aws-properties-ecs-service-networkconfiguration.md
@@ -10,7 +10,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 ```
 {
-  "[AwsvpcConfiguration](#cfn-ecs-service-networkconfiguration-awsvpcconfiguration)" : [AwsVpcConfiguration](aws-properties-ecs-service-awsvpcconfiguration.md)
+  "[AwsvpcConfiguration](#cfn-ecs-service-networkconfiguration-awsvpcconfiguration)" : [AwsvpcConfiguration](aws-properties-ecs-service-awsvpcconfiguration.md)
 }
 ```
 
@@ -18,7 +18,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 ```
 ﻿  [AwsvpcConfiguration](#cfn-ecs-service-networkconfiguration-awsvpcconfiguration) : 
-    [AwsVpcConfiguration](aws-properties-ecs-service-awsvpcconfiguration.md)
+    [AwsvpcConfiguration](aws-properties-ecs-service-awsvpcconfiguration.md)
 ```
 
 ## Properties<a name="aws-properties-ecs-service-networkconfiguration-properties"></a>
@@ -27,5 +27,5 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 The VPC subnets and security groups associated with a task\.  
 All specified subnets and security groups must be from the same VPC\.
 *Required*: No  
-*Type*: [AwsVpcConfiguration](aws-properties-ecs-service-awsvpcconfiguration.md)  
+*Type*: [AwsvpcConfiguration](aws-properties-ecs-service-awsvpcconfiguration.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* fixed resource name of `AwsvpcConfiguration`.

In CloudFormation `AWS::ECS::Service AwsVpcConfiguration` is not accepted cause of one case.

I tried to update using following template, but it failed.
```
  ECSService:
    Type: "AWS::ECS::Service"
    Properties:
      ServiceName: service
      Cluster: ecs-cluster
      DesiredCount: 1
      LaunchType: FARGATE
      TaskDefinition: !Ref ECSTask
      LoadBalancers:
        -
          ContainerName: service
          ContainerPort: 80
          TargetGroupArn: !Ref TargetGroup
      NetworkConfiguration:
        AwsVpcConfiguration:
          AssignPublicIp: ENABLED
          Subnets: !Ref PublicSubnetIds
          SecurityGroups:
            - !Ref ServiceSecurityGroup
```
![2019-11-21_19-30-0_No-00](https://user-images.githubusercontent.com/1398565/69329932-59888100-0c95-11ea-85f2-e9a0ad0b9ee7.png)


`AWS::Events::Rule AwsVpcConfiguration` is right cases in CloudFormation, also [API Documentation](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AwsVpcConfiguration.html).

Only CloudFormation `AWS::ECS::Service AwsVpcConfiguration` is wrong case

<br>
Related #279 .

<br><br>
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
