### PR TITLE
RDS instance AllocatedStorage is conditionally required

### DIFF
--- a/doc_source/aws-properties-rds-database-instance.md
+++ b/doc_source/aws-properties-rds-database-instance.md
@@ -161,7 +161,7 @@ Properties:
 `AllocatedStorage`  <a name="cfn-rds-dbinstance-allocatedstorage"></a>
 The amount of storage \(in gigabytes\) to be initially allocated for the database instance\.  
 If any value is set in the `Iops` parameter, `AllocatedStorage` must be at least 100 GB, which corresponds to the minimum Iops value of 1,000\. If you increase the `Iops` value \(in 1,000 IOPS increments\), then you must also increase the `AllocatedStorage` value \(in 100\-GB increments\)\. 
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/doc_source/aws-properties-rds-database-instance.md
+++ b/doc_source/aws-properties-rds-database-instance.md
@@ -161,7 +161,7 @@ Properties:
 `AllocatedStorage`  <a name="cfn-rds-dbinstance-allocatedstorage"></a>
 The amount of storage \(in gigabytes\) to be initially allocated for the database instance\.  
 If any value is set in the `Iops` parameter, `AllocatedStorage` must be at least 100 GB, which corresponds to the minimum Iops value of 1,000\. If you increase the `Iops` value \(in 1,000 IOPS increments\), then you must also increase the `AllocatedStorage` value \(in 100\-GB increments\)\. 
-*Required*: Yes  
+*Required*: Conditional  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
Cloudformation errors out when AllocatedStorage is not specified:
`Property AllocatedStorage cannot be empty.`

This changes `Required: No` to `Required: Yes`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
