### PR TITLE
ADD vscode auto-generated .history directory to .gitignore as it shouldn't be added to the VCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.history


### PR DESCRIPTION
Signed-off-by: kerolos <kerolos.william@gmail.com>

*Issue #, if available:*

*Description of changes:*
Added the .history directory to the gitignore file since it's auto generated based on the personal environment and can cause un-necessary conflicts 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
