### PR TITLE
Removed -xe from samples

### DIFF
--- a/doc_source/GettingStarted.Walkthrough.md
+++ b/doc_source/GettingStarted.Walkthrough.md
@@ -30,7 +30,7 @@ The Resources section contains the definitions of the AWS resources you want to 
  9.       "SecurityGroups" : [ {"Ref" : "WebServerSecurityGroup"} ],
 10.       "KeyName"        : { "Ref" : "KeyName" },
 11.       "UserData" : { "Fn::Base64" : { "Fn::Join" : ["", [
-12.                      "#!/bin/bash -xe\n",
+12.                      "#!/bin/bash -x\n",
 13.                      "yum update -y aws-cfn-bootstrap\n",
 14. 
 15.                      "/opt/aws/bin/cfn-init -v ",
@@ -79,7 +79,7 @@ The Resources section contains the definitions of the AWS resources you want to 
 12.       - Ref: WebServerSecurityGroup
 13.       UserData:
 14.         Fn::Base64: !Sub |
-15.            #!/bin/bash -xe
+15.            #!/bin/bash -x
 16.            yum update -y aws-cfn-bootstrap
 17.            /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource WebServer --configsets wordpress_install --region ${AWS::Region}
 18.            /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource WebServer --region ${AWS::Region}

--- a/doc_source/aws-attribute-creationpolicy.md
+++ b/doc_source/aws-attribute-creationpolicy.md
@@ -103,7 +103,7 @@ To have instances wait for an Elastic Load Balancing health check before they si
     "UserData": {
       "Fn::Base64": {
         "Fn::Join" : [ "", [
-          "#!/bin/bash -xe\n",
+          "#!/bin/bash -x\n",
           "yum install -y aws-cfn-bootstrap\n",
           "/opt/aws/bin/cfn-signal -e 0 --stack ", { "Ref": "AWS::StackName" },
           " --resource AutoScalingGroup ",
@@ -148,7 +148,7 @@ LaunchConfig:
     UserData:
       "Fn::Base64":
         !Sub |
-          #!/bin/bash -xe
+          #!/bin/bash -x
           yum update -y aws-cfn-bootstrap
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource AutoScalingGroup --region ${AWS::Region}
 ```

--- a/doc_source/aws-properties-ec2-eip-association.md
+++ b/doc_source/aws-properties-ec2-eip-association.md
@@ -244,7 +244,7 @@ Resources:
         Value: Test Instance
 UserData:
   Fn::Base64: !Sub |
-    #!/bin/bash -xe
+    #!/bin/bash -x
     yum install ec2-net-utils -y
     ec2ifup eth1
     service httpd start

--- a/doc_source/aws-properties-ec2-eip-association.md
+++ b/doc_source/aws-properties-ec2-eip-association.md
@@ -157,7 +157,7 @@ For additional examples, see [Assigning an Amazon EC2 Elastic IP Using AWS::EC2:
             "KeyName" : { "Ref" : "KeyName" },
             "NetworkInterfaces" : [ { "NetworkInterfaceId" : {"Ref" : "controlXface"}, "DeviceIndex" : "0" }, { "NetworkInterfaceId" : {"Ref" : "webXface"}, "DeviceIndex" : "1" }],
             "Tags" : [ {"Key" : "Role", "Value" : "Test Instance"}],
-            "UserData" : {"Fn::Base64" : { "Fn::Join" : ["",["#!/bin/bash -ex","\n", "\n","yum install ec2-net-utils -y","\n", "ec2ifup eth1","\n", "service httpd start"]]}}
+            "UserData" : {"Fn::Base64" : { "Fn::Join" : ["",["#!/bin/bash -x","\n", "\n","yum install ec2-net-utils -y","\n", "ec2ifup eth1","\n", "service httpd start"]]}}
         }
     }
 }

--- a/doc_source/cfn-init.md
+++ b/doc_source/cfn-init.md
@@ -64,7 +64,7 @@ For a complete example template, see [Deploying Applications on Amazon EC2 with 
 ```
 "UserData" : { "Fn::Base64" :
   { "Fn::Join" : ["", [
-     "#!/bin/bash -xe\n",
+     "#!/bin/bash -x\n",
      "# Install the files and packages from the metadata\n",
      "/opt/aws/bin/cfn-init -v ",
      "         --stack ", { "Ref" : "AWS::StackName" },
@@ -82,7 +82,7 @@ UserData: !Base64
   'Fn::Join':
     - ''
     - - |
-        #!/bin/bash -xe
+        #!/bin/bash -x
       - |
         # Install the files and packages from the metadata
       - '/opt/aws/bin/cfn-init -v '

--- a/doc_source/deploying.applications.md
+++ b/doc_source/deploying.applications.md
@@ -344,7 +344,7 @@ In the following example, sections marked with an ellipsis \(`...`\) are omitted
         "SecurityGroups" : [ {"Ref" : "WebServerSecurityGroup"} ],
         "KeyName"        : { "Ref" : "KeyName" },
         "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
-             "#!/bin/bash -xe\n",
+             "#!/bin/bash -x\n",
              "yum install -y aws-cfn-bootstrap\n",
 
              "# Install the files and packages from the metadata\n",
@@ -526,7 +526,7 @@ Now that we have a template that installs Linux, Apache, MySQL, and PHP, we'll n
         "SecurityGroups" : [ {"Ref" : "WebServerSecurityGroup"} ],
         "KeyName"        : { "Ref" : "KeyName" },
         "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
-          "#!/bin/bash -xe\n",
+          "#!/bin/bash -x\n",
           "yum install -y aws-cfn-bootstrap\n",
           
           "# Install the files and packages from the metadata\n",
@@ -579,7 +579,7 @@ The following example adds a creation policy to the Amazon EC2 instance to ensur
         "SecurityGroups" : [ {"Ref" : "WebServerSecurityGroup"} ],
         "KeyName"        : { "Ref" : "KeyName" },
         "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
-             "#!/bin/bash -xe\n",
+             "#!/bin/bash -x\n",
              "yum update aws-cfn-bootstrap\n",
 
              "# Install the files and packages from the metadata\n",
@@ -981,7 +981,7 @@ The following example shows final complete template\. You can also view the temp
         "SecurityGroups" : [ {"Ref" : "WebServerSecurityGroup"} ],
         "KeyName"        : { "Ref" : "KeyName" },
         "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
-             "#!/bin/bash -xe\n",
+             "#!/bin/bash -x\n",
              "yum install -y aws-cfn-bootstrap\n",
 
              "# Install the files and packages from the metadata\n",

--- a/doc_source/example-templates-autoscaling.md
+++ b/doc_source/example-templates-autoscaling.md
@@ -346,7 +346,7 @@ You can get the latest version of this sample template at [https://s3\.amazonaws
         "SecurityGroups" : [ { "Ref" : "InstanceSecurityGroup" } ],
         "InstanceType" : { "Ref" : "InstanceType" },
         "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
-             "#!/bin/bash -xe\n",
+             "#!/bin/bash -x\n",
              "yum update -y aws-cfn-bootstrap\n",
 
              "/opt/aws/bin/cfn-init -v ",

--- a/doc_source/intrinsic-function-reference-sub.md
+++ b/doc_source/intrinsic-function-reference-sub.md
@@ -119,7 +119,7 @@ For readability, the JSON example uses the `Fn::Join` function to separate each 
 
 ```
 "UserData": { "Fn::Base64": { "Fn::Join": ["\n", [
-  "#!/bin/bash -xe",
+  "#!/bin/bash -x",
   "yum update -y aws-cfn-bootstrap",
   { "Fn::Sub": "/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LaunchConfig --configsets wordpress_install --region ${AWS::Region}" },
   { "Fn::Sub": "/opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WebServerGroup --region ${AWS::Region}" }]]
@@ -134,7 +134,7 @@ The YAML example uses a literal block to specify the user data script\.
 UserData:
   Fn::Base64:
     !Sub |
-      #!/bin/bash -xe
+      #!/bin/bash -x
       yum update -y aws-cfn-bootstrap
       /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LaunchConfig --configsets wordpress_install --region ${AWS::Region}
       /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WebServerGroup --region ${AWS::Region}

--- a/doc_source/quickref-cloudformation.md
+++ b/doc_source/quickref-cloudformation.md
@@ -212,7 +212,7 @@ This example shows a cfn\-signal command line that signals success to a wait con
     "Fn::Join": [
       "", 
       [
-         "#!/bin/bash -xe\n",
+         "#!/bin/bash -x\n",
          "/opt/aws/bin/cfn-signal --exit-code 0 '", 
          {
            "Ref": "myWaitHandle"
@@ -232,7 +232,7 @@ UserData:
     'Fn::Join':
       - ''
       - - |
-          #!/bin/bash -xe
+          #!/bin/bash -x
         - /opt/aws/bin/cfn-signal --exit-code 0 '
         - Ref: myWaitHandle
         - |

--- a/doc_source/quickref-ec2.md
+++ b/doc_source/quickref-ec2.md
@@ -340,7 +340,7 @@ Resources:
           Value: Test Instance
       UserData:
         Fn::Base64: !Sub |
-          #!/bin/bash -xe
+          #!/bin/bash -x
           yum install ec2-net-utils -y
           ec2ifup eth1
           service httpd start

--- a/doc_source/quickref-ec2.md
+++ b/doc_source/quickref-ec2.md
@@ -246,7 +246,7 @@ Sample template showing how to create an instance with two elastic network inter
 								{ "NetworkInterfaceId" : {"Ref" : "webXface"}, "DeviceIndex" : "1" }],
         "Tags" : [ {"Key" : "Role", "Value" : "Test Instance"}],
         "UserData" : {"Fn::Base64" : { "Fn::Join" : ["",[
-			"#!/bin/bash -ex","\n",
+			"#!/bin/bash -x","\n",
             "\n","yum install ec2-net-utils -y","\n",
 			"ec2ifup eth1","\n",
 			"service httpd start"]]}

--- a/doc_source/quickref-ecs.md
+++ b/doc_source/quickref-ecs.md
@@ -402,7 +402,7 @@ For the latest AMI IDs, see [Amazon ECS\-optimized AMI](https://docs.aws.amazon.
             "Fn::Join":[
               "",
               [
-                "#!/bin/bash -xe\n",
+                "#!/bin/bash -x\n",
                 "echo ECS_CLUSTER=",
                 {
                   "Ref":"ECSCluster"
@@ -915,7 +915,7 @@ Resources:
       KeyName: !Ref 'KeyName'
       UserData:
         Fn::Base64: !Sub |
-          #!/bin/bash -xe
+          #!/bin/bash -x
           echo ECS_CLUSTER=${ECSCluster} >> /etc/ecs/ecs.config
           yum install -y aws-cfn-bootstrap
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource ECSAutoScalingGroup --region ${AWS::Region}

--- a/doc_source/quickref-general.md
+++ b/doc_source/quickref-general.md
@@ -226,7 +226,7 @@ The following example shows commands in the EC2 user data that use the pseudo pa
 
 ```
  1.           "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
- 2.              "#!/bin/bash -xe\n",
+ 2.              "#!/bin/bash -x\n",
  3.              "yum install -y aws-cfn-bootstrap\n",
  4. 
  5.              "/opt/aws/bin/cfn-init -v ",
@@ -247,7 +247,7 @@ The following example shows commands in the EC2 user data that use the pseudo pa
 ```
 1. UserData:
 2.   Fn::Base64: !Sub |
-3.      #!/bin/bash -xe
+3.      #!/bin/bash -x
 4.      yum update -y aws-cfn-bootstrap
 5.      /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LaunchConfig --region ${AWS::Region}
 6.      /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WebServerGroup --region ${AWS::Region}

--- a/doc_source/updating.stacks.walkthrough.md
+++ b/doc_source/updating.stacks.walkthrough.md
@@ -361,7 +361,7 @@ To complete the stack, the template creates an Amazon EC2 security group\.
         "InstanceType"   : { "Ref" : "InstanceType" },
         "SecurityGroups" : [ {"Ref" : "WebServerSecurityGroup"} ],
         "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
-             "#!/bin/bash -xe\n",
+             "#!/bin/bash -x\n",
              "yum install -y aws-cfn-bootstrap\n",
 
              "# Install the files and packages from the metadata\n",
@@ -369,9 +369,6 @@ To complete the stack, the template creates an Amazon EC2 security group\.
              "         --stack ", { "Ref" : "AWS::StackName" },
              "         --resource WebServerInstance ",
              "         --region ", { "Ref" : "AWS::Region" }, "\n",
-
-             "# Start up the cfn-hup daemon to listen for changes to the Web Server metadata\n",
-             "/opt/aws/bin/cfn-hup || error_exit 'Failed to start cfn-hup'\n",  
 
              "# Signal the status from cfn-init\n",
              "/opt/aws/bin/cfn-signal -e $? ",
@@ -1174,7 +1171,7 @@ For reference, the following sample shows the complete template\. If you use thi
         "KeyName"        : { "Ref" : "KeyName" },
         "SecurityGroups" : [ {"Ref" : "WebServerSecurityGroup"} ],
         "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
-             "#!/bin/bash -xe\n",
+             "#!/bin/bash -x\n",
              "yum install -y aws-cfn-bootstrap\n",
 
              "# Install the files and packages from the metadata\n",
@@ -1182,10 +1179,7 @@ For reference, the following sample shows the complete template\. If you use thi
              "         --stack ", { "Ref" : "AWS::StackName" },
              "         --resource LaunchConfig ",
              "         --region ", { "Ref" : "AWS::Region" }, "\n",
-             
-             "# Start up the cfn-hup daemon to listen for changes to the Web Server metadata\n",
-             "/opt/aws/bin/cfn-hup || error_exit 'Failed to start cfn-hup'\n",  
-
+            
              "# Signal the status from cfn-init\n",
              "/opt/aws/bin/cfn-signal -e $? ",
              "         --stack ", { "Ref" : "AWS::StackName" },

--- a/doc_source/working-with-templates-cfn-designer-walkthrough-createbasicwebserver.md
+++ b/doc_source/working-with-templates-cfn-designer-walkthrough-createbasicwebserver.md
@@ -808,7 +808,7 @@ JSON
                "Fn::Join": [
                  "",
                  [
-                   "#!/bin/bash -xe\n",
+                   "#!/bin/bash -x\n",
                    "yum install -y aws-cfn-bootstrap\n",
                    "# Install the files and packages from the metadata\n",
                    "/opt/aws/bin/cfn-init -v ",
@@ -863,7 +863,7 @@ YAML
            'Fn::Join':
              - ''
              - - |
-                 #!/bin/bash -xe
+                 #!/bin/bash -x
                - |
                  yum install -y aws-cfn-bootstrap
                - |

--- a/doc_source/working-with-templates-cfn-designer-walkthrough-updatebasicwebserver.md
+++ b/doc_source/working-with-templates-cfn-designer-walkthrough-updatebasicwebserver.md
@@ -310,7 +310,7 @@ JSON
                   "Fn::Join": [
                     "",
                     [
-                      "#!/bin/bash -xe\n",
+                      "#!/bin/bash -x\n",
                       "yum install -y aws-cfn-bootstrap\n",
                       "# Install the files and packages from the metadata\n",
                       "/opt/aws/bin/cfn-init -v ",
@@ -364,7 +364,7 @@ YAML
               'Fn::Join':
                 - ''
                 - - |
-                    #!/bin/bash -xe
+                    #!/bin/bash -x
                   - |
                     yum install -y aws-cfn-bootstrap
                   - |


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Throughout our documentation we have many examples where we provide usage of `cfn-signal`. However these examples tend to have the bash flags of `-xe`. The `-e` flag means "exit on non-zero status code".

This means that if `cfn-init` fails to execute the script will _not_ signal back to CloudFormation about the failure resulting in a timeout instead. This is not best practice.

I have gone through this repository and found all examples where `-xe` exists and modified the examples to follow best practice. In most cases this is going to just be removing the `-e` flag but in some cases a rewrite of the `UserData` was required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
