### PR TITLE
Update Ref return value

### DIFF
--- a/doc_source/aws-resource-transfer-server.md
+++ b/doc_source/aws-resource-transfer-server.md
@@ -84,7 +84,7 @@ Key\-value pairs that can be used to group and search for servers\.
 
 ### Ref<a name="aws-resource-transfer-server-return-values-ref"></a>
 
- When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the ServerId, such as `s-01234567890abcdef`, and the server ARN, such as `arn:aws:transfer:us-east-1:123456789012:server/s-01234567890abcdef`\. 
+ When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the server ARN, such as `arn:aws:transfer:us-east-1:123456789012:server/s-01234567890abcdef`\. 
 
 ### Fn::GetAtt<a name="aws-resource-transfer-server-return-values-fn--getatt"></a>
 


### PR DESCRIPTION
`Ref` LogicalId returns only the ARN of the server.

*Issue #, if available:*
`Ref` only returns a single value not multiple.

*Description of changes:*
Remove of wording that suggests `Ref` returns ServerId and ARN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
