### PR TITLE
Fix examples

### DIFF
--- a/doc_source/aws-resource-eks-cluster.md
+++ b/doc_source/aws-resource-eks-cluster.md
@@ -115,12 +115,12 @@ The following example creates an Amazon EKS cluster called prod\.
                 "ResourcesVpcConfig": {
                     "SecurityGroupIds": [
                         "sg-6979fe18"
+                    ],
+                    "SubnetIds": [
+                        "subnet-6782e71e",
+                        "subnet-e7e761ac"
                     ]
-                },
-                "SubnetIds": [
-                    "subnet-6782e71e",
-                    "subnet-e7e761ac"
-                ]
+                } 
             }
         }
     }
@@ -141,9 +141,9 @@ Resources:
       ResourcesVpcConfig:
         SecurityGroupIds:
           - sg-6979fe18
-      SubnetIds:
-        - subnet-6782e71e
-        - subnet-e7e761ac
+        SubnetIds:
+          - subnet-6782e71e
+          - subnet-e7e761ac
 ```
 
 ## See Also<a name="aws-resource-eks-cluster--seealso"></a>


### PR DESCRIPTION
Seems like SubnetIds should be a list in  ResourcesVpcConfig property

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
