### PR TITLE
Made TriggerName required

### DIFF
--- a/doc_source/aws-properties-codedeploy-deploymentgroup-triggerconfig.md
+++ b/doc_source/aws-properties-codedeploy-deploymentgroup-triggerconfig.md
@@ -35,7 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 `TriggerName`  <a name="cfn-codedeploy-deploymentgroup-triggerconfig-triggername"></a>
 The name of the notification trigger\.  
-*Required*: No  
+*Required*: Yes
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
Received an error from CloudFormation that TriggerName was not set when I didn't included it. Everything worked well when it was included. Kindly confirm with the CloudFormation product team and accept change to docs if this change is accurate.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
