### PR TITLE
Remove Allowed Values from ObjectLockEnabled

### DIFF
--- a/doc_source/aws-properties-s3-bucket.md
+++ b/doc_source/aws-properties-s3-bucket.md
@@ -158,8 +158,7 @@ Places an object lock configuration on the specified bucket\. The rule specified
 `ObjectLockEnabled`  <a name="cfn-s3-bucket-objectlockenabled"></a>
 Indicates whether this bucket has an object lock configuration enabled\.  
 *Required*: No  
-*Type*: Boolean  
-*Allowed Values*: `Enabled`  
+*Type*: Boolean    
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `PublicAccessBlockConfiguration`  <a name="cfn-s3-bucket-publicaccessblockconfiguration"></a>


### PR DESCRIPTION
ObjectLockEnabled is a Boolean and the Allowed Values: Enabled is not valid. Presumably this property has been confused with the one of the same name under ObjectLockConfiguration.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
