### PR TITLE
Update aws-resource-codestarnotifications-notificationrule.md

### DIFF
--- a/doc_source/aws-resource-codestarnotifications-notificationrule.md
+++ b/doc_source/aws-resource-codestarnotifications-notificationrule.md
@@ -108,11 +108,13 @@ The following example creates a notification rule with a name of My Notification
 {
     "Type": "AWS::CodeStarNotifications::NotificationRule",
     "Properties": {
-        "Name": "My Notification Rule for Comments on Commits",
+        "Name": "My Notification Rule for Comments on Deploys",
         "DetailType": "FULL",
         "Resource": "arn:aws:codecommit:us-east-2:123456789012:MyDemoRepo",
         "EventTypeIds": [
-            "codecommit-repository-comments-on-commits"
+            "codedeploy-application-deployment-failed"
+            "codedeploy-application-deployment-succeeded"
+            "codedeploy-application-deployment-started"
         ],
         "Targets": [
             {
@@ -134,11 +136,13 @@ The following example creates a notification rule with a name of My Notification
 ```
 Type: 'AWS::CodeStarNotifications::NotificationRule'
 Properties:
-        Name: 'My Notification Rule for Comments on Commits'
+        Name: 'My Notification Rule for Comments on Deploys'
         DetailType: FULL
         Resource: 'arn:aws:codecommit:us-east-2:123456789012:MyDemoRepo'
         EventTypeIds: 
-            - codecommit-repository-comments-on-commits
+            - codedeploy-application-deployment-failed
+            - codedeploy-application-deployment-succeeded
+            - codedeploy-application-deployment-started
         Targets: 
             - TargetType: SNS, 
               TargetAddress: 'Fn::Sub': 'arn:aws:sns:us-east-2:123456789012:MyNotificationTopic'


### PR DESCRIPTION
The examples seem to be for the code commits and the EventTypeIds are not correct, which I updated with the correct examples.  Added all the EventTypeIds so it's easy to refer for someone later.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
