### PR TITLE
Fixed contradiction in API Gateway CloudFormation docs

### DIFF
--- a/doc_source/aws-resource-apigateway-stage.md
+++ b/doc_source/aws-resource-apigateway-stage.md
@@ -89,8 +89,8 @@ The ID of the client certificate that API Gateway uses to call your integration 
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `DeploymentId`  <a name="cfn-apigateway-stage-deploymentid"></a>
-The ID of the deployment that the stage is associated with\. This parameter is required\.  
-*Required*: No  
+The ID of the deployment that the stage is associated with\.  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION

*Description of changes:*

The [API Gateway Stage docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html) currently have conflicting information about the `DeploymentId` parameter. The description contains the text `This parameter is required.` and 'Required: No`. I have seen, from CloudFormation errors, that the parameter is required...in this PR I propose changing the documentation to reflect that.

I'm sorry that additional lines were touched by this PR (the `Resources:` examples). Looks like  it may be related to line endings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.