### PR TITLE
Update Required to true for DeploymentId.

### DIFF
--- a/doc_source/aws-resource-apigateway-stage.md
+++ b/doc_source/aws-resource-apigateway-stage.md
@@ -90,7 +90,7 @@ The ID of the client certificate that API Gateway uses to call your integration 
 
 `DeploymentId`  <a name="cfn-apigateway-stage-deploymentid"></a>
 The ID of the deployment that the stage is associated with\. This parameter is required\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fix misleading section stating that `DeploymentId` is both required, and not required. Validated that it is in fact required via test deployment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
