### PR TITLE
Clarifying the use of (no) prefix in lifeycle rule.

### DIFF
--- a/doc_source/aws-properties-s3-bucket-lifecycleconfig-rule.md
+++ b/doc_source/aws-properties-s3-bucket-lifecycleconfig-rule.md
@@ -99,7 +99,7 @@ You must specify at least one of the following properties: `AbortIncompleteMulti
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Prefix`  <a name="cfn-s3-bucket-lifecycleconfig-rule-prefix"></a>
-Object key prefix that identifies one or more objects to which this rule applies\.  
+Object key prefix that identifies one or more objects to which this rule applies\. When no prefix is specified, the rule will be applied to the entire bucket\.  
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change helps clarify why you would choose to omit prefix from a lifecycle rule. I mistakenly assumed that using ` \ ` for prefix would cause the rule to be applied to the entire bucket, but this does not work (and does not cause an error). If this suggestion was in place I would have saved some time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
