### PR TITLE
Updated clientvpnauthorizationrule to state when certain fields are required

### DIFF
--- a/doc_source/aws-resource-ec2-clientvpnauthorizationrule.md
+++ b/doc_source/aws-resource-ec2-clientvpnauthorizationrule.md
@@ -36,14 +36,14 @@ Properties:
 ## Properties<a name="aws-resource-ec2-clientvpnauthorizationrule-properties"></a>
 
 `AccessGroupId`  <a name="cfn-ec2-clientvpnauthorizationrule-accessgroupid"></a>
-The ID of the Active Directory group to grant access\.  
-*Required*: Required only when AuthorizeAllGroups is not specified.
+The ID of the Active Directory group to grant access\. Required when `AuthorizeAllGroups` is `false` or not specified\.  
+*Required*: No  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `AuthorizeAllGroups`  <a name="cfn-ec2-clientvpnauthorizationrule-authorizeallgroups"></a>
-Indicates whether to grant access to all clients\. Use `true` to grant all clients who successfully establish a VPN connection access to the network\.  
-*Required*: Required only when AccessGroupId is not specified.  
+Indicates whether to grant access to all clients\. Use `true` to grant all clients who successfully establish a VPN connection access to the network\. Must be specified as `true` when no `AccessGroupId` is specified\.  
+*Required*: No  
 *Type*: Boolean  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/doc_source/aws-resource-ec2-clientvpnauthorizationrule.md
+++ b/doc_source/aws-resource-ec2-clientvpnauthorizationrule.md
@@ -37,13 +37,13 @@ Properties:
 
 `AccessGroupId`  <a name="cfn-ec2-clientvpnauthorizationrule-accessgroupid"></a>
 The ID of the Active Directory group to grant access\.  
-*Required*: No  
+*Required*: Required only when AuthorizeAllGroups is not specified.
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `AuthorizeAllGroups`  <a name="cfn-ec2-clientvpnauthorizationrule-authorizeallgroups"></a>
 Indicates whether to grant access to all clients\. Use `true` to grant all clients who successfully establish a VPN connection access to the network\.  
-*Required*: No  
+*Required*: Required only when AccessGroupId is not specified.  
 *Type*: Boolean  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/doc_source/aws-resource-ec2-clientvpnauthorizationrule.md
+++ b/doc_source/aws-resource-ec2-clientvpnauthorizationrule.md
@@ -42,7 +42,7 @@ The ID of the Active Directory group to grant access\. Required when `AuthorizeA
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `AuthorizeAllGroups`  <a name="cfn-ec2-clientvpnauthorizationrule-authorizeallgroups"></a>
-Indicates whether to grant access to all clients\. Use `true` to grant all clients who successfully establish a VPN connection access to the network\. Must be specified as `true` when no `AccessGroupId` is specified\.  
+Indicates whether to grant access to all clients\. Use `true` to grant all clients who successfully establish a VPN connection access to the network\. Must be set to `true` if `AccessGroupId` is not specified\.  
 *Required*: No  
 *Type*: Boolean  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
When deploying resources without AuthorizeAllGroups or AccessGroupId an error is thrown. This is likely an implementation error on cloudformation but it's worth documenting. Error: `You must specify either access-group-id or authorize-all-groups (Service: AmazonEC2; Status Code: 400; Error Code: MissingParameter`

*Issue #, if available:*

* No issue created.

*Description of changes:*

* Modified the required status of fields that are conditionally required

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
