### PR TITLE
`RepositoryUrl` must not cointain an username

### DIFF
--- a/doc_source/aws-properties-sagemaker-coderepository-gitconfig.md
+++ b/doc_source/aws-properties-sagemaker-coderepository-gitconfig.md
@@ -36,7 +36,7 @@ The default branch for the Git repository\.
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `RepositoryUrl`  <a name="cfn-sagemaker-coderepository-gitconfig-repositoryurl"></a>
-The URL where the Git repository is located\.  
+The URL where the Git repository is located\. The URL must not contain an username\.  
 *Required*: Yes  
 *Type*: String  
 *Pattern*: `^https://([^/]+)/?(.*)$`  


### PR DESCRIPTION
By default, Bitbucket, and likely others, give the HTTPS URL for a repository together with the username. Such as `https://myusername@bitbucket.org/mycompany/myrepository.git`

While `AWS::SageMaker::CodeRepository` seems accepts this format, `AWS::SageMaker::NotebookInstance` fails when referencing the added `CodeRepository` in ` DefaultCodeRepository` (probably the same applies when referencing it in `AdditionalCodeRepositories`).

As the Secret used by `AWS::SageMaker::CodeRepository` has `username` defined in it anyway, I removed the username from the Git repository URL and this way `AWS::SageMaker::NotebookInstance` did not fail anymore when attaching the git repository.

Interestingly, failure reasons were different yesterday from what they are today. However, removing the username from Git repository URL has solved the problems for now.

*Issue #, if available:*

*Description of changes:*
Sidenote in the documentation that RepositoryUrl must not contain the username.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
