### PR TITLE
Update aws-resource-codestarnotifications-notificationrule.md

### DIFF
--- a/doc_source/aws-resource-codestarnotifications-notificationrule.md
+++ b/doc_source/aws-resource-codestarnotifications-notificationrule.md
@@ -64,7 +64,7 @@ The name for the notification rule\. Notification rule names must be unique in y
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Resource`  <a name="cfn-codestarnotifications-notificationrule-resource"></a>
-The Amazon Resource Name \(ARN\) of the resource to associate with the notification rule\. Supported resources include pipelines in AWS CodePipeline, repositories in AWS CodeCommit, and build projects in AWS CodeBuild\.  
+The Amazon Resource Name \(ARN\) of the resource to associate with the notification rule\. Supported resources include pipelines in AWS CodePipeline, repositories in AWS CodeCommit, build projects in AWS CodeBuild, and Deployment Applications in AWS CodeDeploy\.  
 *Required*: Yes  
 *Type*: String  
 *Pattern*: `^arn:aws[^:\s]*:[^:\s]*:[^:\s]*:[0-9]{12}:[^\s]+$`  


### PR DESCRIPTION
Added this change, as CodeStar Notification also supports creation of Notification Rule for CodeDeploy Application.

*Issue #, if available:*


*Description of changes:*
The CloudFormation Documentation for creation for CodeStar Notification Rule mentions only creation of Notification Rule for CodeBuild and CodePipeline, while the creation of Notification Rule is also supported for CodeDeploy Application, but was not mentioned in the Documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
