### PR TITLE
Fix: awscli change sets require StackName or ARN

### DIFF
--- a/doc_source/resource-import-existing-stack.md
+++ b/doc_source/resource-import-existing-stack.md
@@ -141,13 +141,13 @@ The import operation fails if you modify existing parameters that trigger a crea
 1. Review the change set to make sure the correct resources will be imported\.
 
    ```
-   > aws cloudformation describe-change-set --change-set-name ImportChangeSet
+   > aws cloudformation describe-change-set --change-set-name ImportChangeSet --stack-name TargetStack
    ```
 
 1. Run the change set to import the resources\. Any [stack\-level tags](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html) are applied to imported resources at this time\. On successful completion of the operation `(IMPORT_COMPLETE)`, the resources are successfully imported\.
 
    ```
-   > aws cloudformation execute-change-set --change-set-name ImportChangeSet
+   > aws cloudformation execute-change-set --change-set-name ImportChangeSet --stack-name TargetStack
    ```
 
 1. \(Optional\) Run drift detection on the `IMPORT_COMPLETE` stack to make sure the template and actual configuration of the imported resources match\. For more information about detecting drift, see [Detect Drift on an Entire CloudFormation Stack](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/detect-drift-stack.html)\. 

--- a/doc_source/resource-import-new-stack.md
+++ b/doc_source/resource-import-new-stack.md
@@ -149,13 +149,13 @@ The import operation fails if you modify existing parameters that trigger a crea
 1. Review the change set to make sure the correct resources will be imported\.
 
    ```
-   > aws cloudformation describe-change-set --change-set-name ImportChangeSet
+   > aws cloudformation describe-change-set --change-set-name ImportChangeSet --stack-name TargetStack
    ```
 
 1. Run the change set to import the resources\. On successful completion of the operation `(IMPORT_COMPLETE)`, the resources are successfully imported\.
 
    ```
-   > aws cloudformation execute-change-set --change-set-name ImportChangeSet
+   > aws cloudformation execute-change-set --change-set-name ImportChangeSet --stack-name TargetStack
    ```
 
 1. \(Optional\) Run drift detection on the `IMPORT_COMPLETE` stack to make sure the template and actual configuration of the imported resources match\. For more information on detecting drift, see [Detect Drift on an Entire CloudFormation Stack](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/detect-drift-stack.html)\.


### PR DESCRIPTION
*Issue #, if available:*
fixes #597

*Description of changes:*
awscli describe-change-set and execute-change-set require passing the change set ARN or change set name and stack name/stack ARN. Updated import CF doc examples to reflect this.


![Validated requirements in awscli docs](https://user-images.githubusercontent.com/11020780/74595817-d49ad280-500b-11ea-850a-31ebfea30619.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
