### PR TITLE
wafv2 Rule Name required

### DIFF
--- a/doc_source/aws-properties-wafv2-webacl-rule.md
+++ b/doc_source/aws-properties-wafv2-webacl-rule.md
@@ -47,7 +47,7 @@ The action that AWS WAF should take on a web request when it matches the rule's 
 
 `Name`  <a name="cfn-wafv2-webacl-rule-name"></a>
 A friendly name of the rule\. You can't change the name of a `Rule` after you create it\.   
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Minimum*: `1`  
 *Maximum*: `128`  


### PR DESCRIPTION
If you do not include a Name for the rule, rather than auto-generate, CFT returns the following error: 
"1 validation error detected: Value null at 'rules.1.member.name' failed to satisfy constraint: Member must not be null (Service: Wafv2, Status Code: 400,"

Therefore Name should be marked as required

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
