### PR TITLE
Typofix MinimumProtocolVerison.

### DIFF
--- a/doc_source/aws-properties-cloudfront-distribution-viewercertificate.md
+++ b/doc_source/aws-properties-cloudfront-distribution-viewercertificate.md
@@ -47,7 +47,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 `AcmCertificateArn`  <a name="cfn-cloudfront-distribution-viewercertificate-acmcertificatearn"></a>
 If the distribution uses `Aliases` \(alternate domain names or CNAMEs\) and the SSL/TLS certificate is stored in [AWS Certificate Manager \(ACM\)](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html), provide the Amazon Resource Name \(ARN\) of the ACM certificate\. CloudFront only supports ACM certificates in the US East \(N\. Virginia\) Region \(`us-east-1`\)\.  
-If you specify an ACM certificate ARN, you must also specify values for `MinimumProtocolVerison` and `SslSupportMethod`\.   
+If you specify an ACM certificate ARN, you must also specify values for `MinimumProtocolVersion` and `SslSupportMethod`\.   
 *Required*: Conditional  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
In section about AcmCertificateArn is a typo: MinimumProtocolVerison

*Description of changes: Typo fix*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
