### PR TITLE
Update aws-properties-wafv2-webacl-visibilityconfig.md

### DIFF
--- a/doc_source/aws-properties-wafv2-webacl-visibilityconfig.md
+++ b/doc_source/aws-properties-wafv2-webacl-visibilityconfig.md
@@ -46,6 +46,6 @@ A friendly name of the CloudWatch metric\. The name can contain only alphanumeri
 
 `SampledRequestsEnabled`  <a name="cfn-wafv2-webacl-visibilityconfig-sampledrequestsenabled"></a>
 A boolean indicating whether AWS WAF should store a sampling of the web requests that match the rules\. You can view the sampled requests through the AWS WAF console\.   
-*Required*: No  
+*Required*: Yes  
 *Type*: Boolean  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
SampledRequestsEnabled attribute is required as per recent change in the WAFv2 WebACL model.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
