### PR TITLE
Examples are not formatted correctly in AWS::SecurityHub::Hub

### DIFF
--- a/doc_source/aws-resource-securityhub-hub.md
+++ b/doc_source/aws-resource-securityhub-hub.md
@@ -51,24 +51,23 @@ The following example shows how to declare a Security Hub `Hub` resource:
 
 ```
 {
-    "Description": "Example Hub with Tags",
-        "Resources" : {
-            "ExampleHubWithTags" : {
-                "Type" : "AWS::SecurityHub::Hub",
-                    "Properties" : {
-                        "Tags" : {
-                            "key1" : "value1",
-                            "key2" : "value2"
-                        }
-                    }
-            }
-        },
-        "Outputs" : {
-            "HubArn" : {
-                "Value" : {"Ref" : "ExampleHubWithTags"}
-            }
+  "Description": "Example Hub with Tags",
+  "Resources" : {
+      "ExampleHubWithTags" : {
+          "Type" : "AWS::SecurityHub::Hub",
+          "Properties" : {
+              "Tags" : {
+                  "key1" : "value1",
+                  "key2" : "value2"
+              }
+          }
+      }
+    },
+    "Outputs" : {
+        "HubArn" : {
+            "Value" : {"Ref" : "ExampleHubWithTags"}
         }
-            
+    }
 }
 ```
 
@@ -76,14 +75,14 @@ The following example shows how to declare a Security Hub `Hub` resource:
 
 ```
 Description: "Example Hub with Tags"
-    Resources:
-        ExampleHubWithTags:
-            Type: "AWS::SecurityHub::Hub"
-            Properties:
-                Tags:
-                    "key1" : "value1"
-                    "key2" : "value2"
-            Outputs:
-                HubArn:
-                    Value: !Ref ExampleHubWithTags
+Resources:
+    ExampleHubWithTags:
+        Type: "AWS::SecurityHub::Hub"
+        Properties:
+            Tags:
+                "key1" : "value1"
+                "key2" : "value2"
+Outputs:
+    HubArn:
+        Value: !Ref ExampleHubWithTags
 ```


### PR DESCRIPTION
The indentation of the Outputs section of the sample YAML in this doc is incorrect and won't work as provided.
The JSON's indentation is also a bit wonky, but will still parse correctly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
