### PR TITLE
Fix example SAML template: email capitalization

### DIFF
--- a/doc_source/aws-resource-cognito-userpoolidentityprovider.md
+++ b/doc_source/aws-resource-cognito-userpoolidentityprovider.md
@@ -380,7 +380,7 @@ The following example creates a SAML identity provider "YourProviderName" in the
          },
          "ProviderType": "SAML",
          "AttributeMapping": {
-            "Email": "Attribute"
+            "email": "Attribute"
          },
          "IdpIdentifiers": [
             "IdpIdentifier"
@@ -402,7 +402,7 @@ UserPoolIdentityProvider:
       MetadataURL: "YourMetadataURL"
     ProviderType: "SAML"
     AttributeMapping:
-      Email: "Attribute"
+      email: "Attribute"
     IdpIdentifiers:
       - "IdpIdentifier"
 ```


### PR DESCRIPTION
Just confirmed on my project that the `email` attribute mapping for a SAML IdP should be lowercase (like every other example), not uppercase. Using `Email` causes the stack for fail: "missing require attribute `email`"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
