### PR TITLE
Fix typo in example: !Ref

### DIFF
--- a/doc_source/quickref-general.md
+++ b/doc_source/quickref-general.md
@@ -358,9 +358,9 @@ This example shows an Outputs section with two output assignments\. One is based
 ```
 1. Outputs:
 2.   SNSTopic:
-3.     Value: Ref: MyNotificationTopic
+3.     Value: !Ref MyNotificationTopic
 4.   StackName:
-5.     Value: Ref: AWS::StackName
+5.     Value: !Ref AWS::StackName
 ```
 
 ## Outputs Section with an Output Based on a Function, a Literal String, a Reference, and a Pseudo Parameter<a name="scenario-output-with-complex-spec"></a>


### PR DESCRIPTION

I think this is a typo:
```
Value: Ref: MyNotificationTopic
```
and should be:
```
Value: !Ref MyNotificationTopic
```