### PR TITLE
Fix typo in resource Type in example

### DIFF
--- a/doc_source/aws-resource-transfer-user.md
+++ b/doc_source/aws-resource-transfer-user.md
@@ -162,7 +162,7 @@ The following example associates a user with an SFTP server\.
 ```
 {
   "sftp_user": {
-    "Type": "AWS::Transfer::Server",
+    "Type": "AWS::Transfer::User",
     "Properties": {
       "HomeDirectoryMappings": [
         {
@@ -201,7 +201,7 @@ The following example associates a user with an SFTP server\.
 
 ```
 sftp_user:
-  Type : AWS::Transfer::Server
+  Type : AWS::Transfer::User
   Properties :
     HomeDirectoryMappings: 
       - Entry: our-personal-report.pdf


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated incorrect resource type in the SFTP/Transfer User example docs, from "Server" to "User".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
