### PR TITLE
Update the format version of the ResourcePolicy example

### DIFF
--- a/doc_source/aws-resource-secretsmanager-resourcepolicy.md
+++ b/doc_source/aws-resource-secretsmanager-resourcepolicy.md
@@ -73,7 +73,7 @@ The following examples shows how to attach a resource\-based policy to the speci
                            "Ref" : "MySecret"
                          },
                         "ResourcePolicy" : {
-                           "Version" : "2019-10-19",
+                           "Version" : "2012-10-17",
                            "Statement" : [
                               {
                                    "Resource" : "*",


### PR DESCRIPTION
*Description of changes:*
Set the correct format version of the ResourcePolicy to "2012-10-17" in the JSON example. The '2019-10-19' returned 'This policy has invalid syntax. (Service: AWSSecretsManager; Status Code: 400; Error Code: MalformedPolicyDocumentException;)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
