### PR TITLE
Document supported runtimes for lambda zipfile

### DIFF
--- a/doc_source/aws-properties-lambda-function-code.md
+++ b/doc_source/aws-properties-lambda-function-code.md
@@ -57,6 +57,7 @@ For versioned objects, the version of the deployment package object to use\.
 
 `ZipFile`  <a name="cfn-lambda-function-code-zipfile"></a>
 \(Node\.js and Python\) The source code of your Lambda function\. If you include your function source inline with this parameter, AWS CloudFormation places it in a file named `index` and zips it to create a [deployment package](https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html)\. For the `Handler` property, the first part of the handler identifier must be `index`\. For example, `index.handler`\.  
+Only supported for these runtimes: nodejs8.10, nodejs10.x, nodejs12.x, python2.7, python3.6, python3.7.
 Your source code can contain up to 4096 characters\. For JSON, you must escape quotes and special characters such as newline \(`\n`\) with a backslash\.  
 If you specify a function that interacts with an AWS CloudFormation custom resource, you don't have to write your own functions to send responses to the custom resource that invoked the function\. AWS CloudFormation provides a response module \([cfn\-response](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-lambda-function-code-cfnresponsemodule.html)\) that simplifies sending responses\. See [Using AWS Lambda with AWS CloudFormation](https://docs.aws.amazon.com/lambda/latest/dg/services-cloudformation.html) for details\.   
 *Required*: Conditional  


### PR DESCRIPTION
Upgraded a function from 3.7 to 3.8, got this error (CloudFormation event through Ansible):

> AWS::Lambda::Function PythonLambdaFunction UPDATE_FAILED: ZipFile can only be used when Runtime is set to either of nodejs8.10, nodejs10.x, nodejs12.x, python2.7, python3.6, python3.7.

Adding to docs

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
