### PR TITLE
Marking DeploymentId a required filed

### DIFF
--- a/doc_source/aws-resource-apigateway-stage.md
+++ b/doc_source/aws-resource-apigateway-stage.md
@@ -90,7 +90,7 @@ The ID of the client certificate that API Gateway uses to call your integration 
 
 `DeploymentId`  <a name="cfn-apigateway-stage-deploymentid"></a>
 The ID of the deployment that the stage is associated with\. This parameter is required\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
Page https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html mention `DeploymentId` field as not required. But according to api specification it is a required field. Correcting the field's documentation.