### PR TITLE
Correct `Parameters` property, add info and example

### DIFF
--- a/doc_source/aws-properties-ssm-maintenancewindowtask-maintenancewindowruncommandparameters.md
+++ b/doc_source/aws-properties-ssm-maintenancewindowtask-maintenancewindowruncommandparameters.md
@@ -86,8 +86,22 @@ The Amazon S3 bucket subfolder\.
 `Parameters`  <a name="cfn-ssm-maintenancewindowtask-maintenancewindowruncommandparameters-parameters"></a>
 The parameters for the `RUN_COMMAND` task execution\.  
 *Required*: No  
-*Type*: Json  
+*Type*: Object with properties that represent the parameters for the `RUN_COMMAND` task
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+This is an object that defines the items like `executionTimeout` and `commands` for the `RUN_COMMAND` task.
+YAML example:
+```YAML
+          Parameters:
+            executionTimeout:
+              - "3600"
+            commands:
+              - |
+                Get-Service myImportantService | Restart-Service
+                Get-ExecutionPolicy -List
+                Set-ExecutionPolicy -Scope Process AllSigned
+                ## .. do the other important things here
+```
 
 `ServiceRoleArn`  <a name="cfn-ssm-maintenancewindowtask-maintenancewindowruncommandparameters-servicerolearn"></a>
 The ARN of the IAM service role to use to publish Amazon Simple Notification Service \(Amazon SNS\) notifications for maintenance window Run Command tasks\.  


### PR DESCRIPTION
The previous value for *Type* that was `JSON` is incorrect.  This can lead to quite a bit of wasted time for users trying to craft a proper value for the `Parameters` property. This file change adds a few clarifying statements about the value for `Parameters`, and adds a YAML example of the syntax for the sub-properties of the `Parameters` property

*Issue #, if available:*  none

*Description of changes:*  add detail and example for the `Parameters` property of this `MaintenanceWindowRunCommandParameters` property type, in order to help others quickly and easily add such a section to their CloudFormation template (the current documentation contents that said "JSON" as the value type was misleading, and there was no example)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
