### PR TITLE
correct wrong word in sagemaker notebook doc

### DIFF
--- a/doc_source/aws-resource-sagemaker-notebookinstance.md
+++ b/doc_source/aws-resource-sagemaker-notebookinstance.md
@@ -103,7 +103,7 @@ The Amazon Resource Name \(ARN\) of a AWS Key Management Service key that Amazon
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `LifecycleConfigName`  <a name="cfn-sagemaker-notebookinstance-lifecycleconfigname"></a>
-The name of a lifecycle configuration to associate with the notebook instance\. For information about lifestyle configurations, see [Customize a Notebook Instance](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html) in the *Amazon SageMaker Developer Guide*\.  
+The name of a lifecycle configuration to associate with the notebook instance\. For information about lifecycle configurations, see [Customize a Notebook Instance](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html) in the *Amazon SageMaker Developer Guide*\.  
 *Required*: No  
 *Type*: String  
 *Maximum*: `63`  


### PR DESCRIPTION
*Description of changes:*

Errata: 
* The name of a lifecycle configuration to associate with the notebook instance. For information about **lifestyle** configurations, see

Corrige:
* The name of a lifecycle configuration to associate with the notebook instance. For information about **lifecycle** configurations, see

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
