### PR TITLE
Fix mistake in security-group docs

### DIFF
--- a/doc_source/aws-properties-ec2-security-group-rule-1.md
+++ b/doc_source/aws-properties-ec2-security-group-rule-1.md
@@ -95,7 +95,7 @@ The ID of the security group\. You must specify either the security group ID or 
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `SourceSecurityGroupOwnerId`  <a name="cfn-ec2-security-group-rule-sourcesecuritygroupownerid"></a>
-\[nondefault VPC\] The AWS account ID for the source security group, if the source security group is in a different account\. You can't specify this parameter in combination with the following parameters: the CIDR IP address range, the IP protocol, the start of the port range, and the end of the port range\. Creates rules that grant full ICMP, UDP, and TCP access\.  
+\[EC2\-Classic, nondefault VPC\] The AWS account ID for the source security group, if the source security group is in a different account\. You can't specify this parameter in combination with the following parameters: the CIDR IP address range, the IP protocol, the start of the port range, and the end of the port range\. Creates rules that grant full ICMP, UDP, and TCP access\.  
 If you specify `SourceSecurityGroupName` or `SourceSecurityGroupId` and that security group is owned by a different account than the account creating the stack, you must specify the `SourceSecurityGroupOwnerId`; otherwise, this property is optional\.  
 *Required*: Conditional  
 *Type*: String  


### PR DESCRIPTION
Property SourceSecurityGroupOwnerId is only available in EC2 classic so the documentation should reflect this fact.

*Issue #, if available:*

*Description of changes:* Changes to documentation markdown file.

The SourceSecurityGroupOwnerId property in Ingress resources is only applicable for EC2-Classic. See screenshot from the AWS Console:
![image](https://user-images.githubusercontent.com/19572253/79191034-05ab4e00-7e69-11ea-9a3e-19bebbe7ace5.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
