### PR TITLE
Add note regarding StackSet operation concurrency

### DIFF
--- a/doc_source/stackinstances-delete.md
+++ b/doc_source/stackinstances-delete.md
@@ -49,6 +49,9 @@ StackSets also deletes stack instances from any child OUs of the specified targe
 
    Set the failure tolerance and maximum concurrent accounts by setting `FailureToleranceCount` to `0`, and `MaxConcurrentCount` to `1` in the `--operation-preferences` parameter, as shown in the following example\. To apply percentages instead, use `FailureTolerancePercentage` or `MaxConcurrentPercentage`\. For the purposes of this walkthrough, we are using count, not percentage\.
 
+   **Note**
+   The concurrency of the StackSet instances deployments in the operation is dependent on the value of `FailureToleranceCount-MaxConcurrentCount` and is at most one more than the `FailureToleranceCount`.
+   
    Because `--retain-stacks` is a required parameter of `delete-stack-instances`, if you do not want to retain \(save\) stacks, add `--no-retain-stacks`\. In this walkthrough, we add the `--no-retain-stacks` parameter, because we are not retaining any stacks\.
 
    \[Self\-managed permissions\] Replace *account\_ID* with the accounts you used to create your stack set in [Create a Stack Set](stacksets-getting-started-create.md)\.

--- a/doc_source/stackinstances-override.md
+++ b/doc_source/stackinstances-override.md
@@ -69,6 +69,9 @@ In the example command shown here, we change the default snapshot delivery frequ
 1. Run the following command\. For `--stack-set-name`, specify the stack set name *my\-awsconfig\-stackset*\.
 
    Set the failure tolerance and maximum concurrent accounts by setting `FailureToleranceCount` to `0`, and `MaxConcurrentCount` to `1` in the `--operation-preferences` parameter, as shown in the following example\. To apply percentages instead, use `FailureTolerancePercentage` or `MaxConcurrentPercentage`\. For this walkthrough, we are using count, not percentage\.
+   
+      **Note**
+   The concurrency of the StackSet instances deployments in the operation is dependent on the value of `FailureToleranceCount-MaxConcurrentCount` and is at most one more than the `FailureToleranceCount`.
 
    \[Self\-managed permissions\] Provide the account IDs for which you want to override parameter values on stack instances\.
 

--- a/doc_source/stacksets-getting-started-create.md
+++ b/doc_source/stacksets-getting-started-create.md
@@ -92,6 +92,9 @@ When you create stack sets by using AWS CLI commands, you run two separate comma
 1. Run the `create-stack-instances` AWS CLI command to add stack instances to your stack set\. In this walkthrough, we use `us-west-2` and `us-east-1` as the values of the `--regions` parameter\.
 
    Set the failure tolerance and maximum concurrent accounts by setting `FailureToleranceCount` to `0` and `MaxConcurrentCount` to `1` in the `--operation-preferences` parameter, as shown in the following example\. To apply percentages instead, use `FailureTolerancePercentage` or `MaxConcurrentPercentage`\. For the purposes of this walkthrough, we are using count, not percentage\.
+   
+   **Note**
+   The concurrency of the StackSet instances deployments in the operation is dependent on the value of `FailureToleranceCount-MaxConcurrentCount` and is at most one more than the `FailureToleranceCount`.
 
    ```
    aws cloudformation create-stack-instances --stack-set-name my-awsconfig-stackset --accounts '["account_ID_1","account_ID_2"]' --regions '["region_1","region_2"]' --operation-preferences FailureToleranceCount=0,MaxConcurrentCount=1

--- a/doc_source/stacksets-update.md
+++ b/doc_source/stacksets-update.md
@@ -60,6 +60,10 @@ In the example command shown here, we are updating the stack set by using `--par
 
    Set the failure tolerance and maximum concurrent accounts by setting `FailureToleranceCount` to `0`, and `MaxConcurrentCount` to `1` in the `--operation-preferences` parameter, as shown in the following example\. To apply percentages instead, use `FailureTolerancePercentage` or `MaxConcurrentPercentage`\. For the purposes of this walkthrough, we are using count, not percentage\.
 
+   **Note**
+   The concurrency of the StackSet instances deployments in the operation is dependent on the value of `FailureToleranceCount-MaxConcurrentCount` and is at most one more than the `FailureToleranceCount`.
+
+
    \[Self\-managed permissions\] Provide the account IDs you want your update to target\.
 
    ```


### PR DESCRIPTION
*Description of changes:* Added a note on 4 pages of the User Guide to briefly explain how to set the values of MaxConcurrentCount and FailureToleranceCount to achieve deployment concurrency.
Hit this wall a long time ago and got a customer complaint about the same thing yesterday.

The [API Reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_StackSetOperationPreferences.html) explains it, but this information is buried and difficult to find.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
