### PR TITLE
Remove duplicate description in PreferredMaintenanceWindow

### DIFF
--- a/doc_source/aws-properties-elasticache-cache-cluster.md
+++ b/doc_source/aws-properties-elasticache-cache-cluster.md
@@ -211,7 +211,6 @@ Default: System chosen Availability Zones\.
 *Update requires*: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt)
 
 `PreferredMaintenanceWindow`  <a name="cfn-elasticache-cachecluster-preferredmaintenancewindow"></a>
-Specifies the weekly time range during which maintenance on the cluster is performed\. It is specified as a range in the format ddd:hh24:mi\-ddd:hh24:mi \(24H Clock UTC\)\. The minimum maintenance window is a 60 minute period\. Valid values for `ddd` are:  
 Specifies the weekly time range during which maintenance on the cluster is performed\. It is specified as a range in the format ddd:hh24:mi\-ddd:hh24:mi \(24H Clock UTC\)\. The minimum maintenance window is a 60 minute period\.  
 Valid values for `ddd` are:  
 +  `sun` 


### PR DESCRIPTION
The description for `PreferredMaintenanceWindow` parameter under `AWS::ElastiCache::CacheCluster` has a duplicated paragraph. This commit simply cleans it up.

*Issue #, if available:*

*Description of changes:*
Remove duplicated line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
