### PR TITLE
Flag LogGroup parameter as required for AWS::MSK::Cluster CloudWatchLogs

### DIFF
--- a/doc_source/aws-properties-msk-cluster-cloudwatchlogs.md
+++ b/doc_source/aws-properties-msk-cluster-cloudwatchlogs.md
@@ -32,6 +32,6 @@ Specifies whether broker logs get sent to the specified CloudWatch Logs destinat
 
 `LogGroup`  <a name="cfn-msk-cluster-cloudwatchlogs-loggroup"></a>
 The CloudWatch log group that is the destination for broker logs\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Description of changes:*

Flag LogGroup parameter as required.
Got the following error from CloudFormation when trying to omit it:
"To use CloudWatch Logs as a destination for broker logs, you must specify a CloudWatch log group."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
