### PR TITLE
Make it clear to use CustomOrigin when sourcing a distribution from a static S3 website

### DIFF
--- a/doc_source/aws-properties-cloudfront-distribution-origin.md
+++ b/doc_source/aws-properties-cloudfront-distribution-origin.md
@@ -41,13 +41,14 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-cloudfront-distribution-origin-properties"></a>
 
 `CustomOriginConfig`  <a name="cfn-cloudfront-distribution-origin-customoriginconfig"></a>
-A complex type that contains information about a custom origin\. If the origin is an Amazon S3 bucket, use the `S3OriginConfig` element instead\.  
+A complex type that contains information about a custom origin\. If the origin is an Amazon S3 bucket (but not configured as a static website), use the `S3OriginConfig` element instead\.  
 *Required*: Conditional  
 *Type*: [CustomOriginConfig](aws-properties-cloudfront-distribution-customoriginconfig.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `DomainName`  <a name="cfn-cloudfront-distribution-origin-domainname"></a>
- **Amazon S3 origins**: The DNS name of the Amazon S3 bucket from which you want CloudFront to get objects for this origin, for example, `myawsbucket.s3.amazonaws.com`\. If you set up your bucket to be configured as a website endpoint, enter the Amazon S3 static website hosting endpoint for the bucket\.  
+ **Amazon S3 origins**: The DNS name of the Amazon S3 bucket from which you want CloudFront to get objects for this origin, for example, `myawsbucket.s3.amazonaws.com`\. 
+Please note, if you set up your bucket to be configured as a website endpoint, you need to use `CustomOriginConfig` and enter the Amazon S3 static website hosting endpoint for the bucket without the leading `http://`\.  
 For more information about specifying this value for different types of origins, see [Origin Domain Name](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesDomainName) in the *Amazon CloudFront Developer Guide*\.  
 Constraints for Amazon S3 origins:   
 + If you configured Amazon S3 Transfer Acceleration for your bucket, don't specify the `s3-accelerate` endpoint for `DomainName`\.
@@ -88,7 +89,7 @@ When a user enters `example.com/acme/index.html` in a browser, CloudFront sends 
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `S3OriginConfig`  <a name="cfn-cloudfront-distribution-origin-s3originconfig"></a>
-A complex type that contains information about the Amazon S3 origin\. If the origin is a custom origin, use the `CustomOriginConfig` element instead\.  
+A complex type that contains information about the Amazon S3 origin\. If the origin is a custom origin or an S3 bucket set up as a website endpoint, use the `CustomOriginConfig` element instead\.  
 *Required*: Conditional  
 *Type*: [S3OriginConfig](aws-properties-cloudfront-distribution-s3originconfig.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
It is a quite common mistake of trying to use `S3OriginConfig` to source a CF distribution from an S3 bucket configured as a static website:
- https://stackoverflow.com/questions/54097734/why-am-i-getting-a-customoriginconfig-instead-of-s3originconfig
- https://github.com/aws/aws-sdk-js/issues/2368
- https://github.com/terraform-providers/terraform-provider-aws/issues/78470
- https://stackoverflow.com/questions/42841607/cloudfront-cant-use-s3-website-origin-only-rest-origin-cloudformation

There is a note in the CloudFront user guide https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistS3AndCustomOrigins.html#concept_S3Origin_website, but the CloudFormation docs fail to mention this. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
