### PR TITLE
Update aws-resource-apigateway-basepathmapping.md

### DIFF
--- a/doc_source/aws-resource-apigateway-basepathmapping.md
+++ b/doc_source/aws-resource-apigateway-basepathmapping.md
@@ -46,7 +46,7 @@ The `DomainName` of an [AWS::ApiGateway::DomainName](https://docs.aws.amazon.com
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `RestApiId`  <a name="cfn-apigateway-basepathmapping-restapiid"></a>
-The name of the API\.  
+The ARN of the API\.  
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
Name of the API doesn't work, need to use ARN e.g. RestApiId: !Ref API

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
