### PR TITLE
Fix typo `worklfows` -> `workflows` in documentation

### DIFF
--- a/doc_source/aws-resource-stepfunctions-statemachine.md
+++ b/doc_source/aws-resource-stepfunctions-statemachine.md
@@ -73,7 +73,7 @@ If you specify a name, you cannot perform updates that require replacement of th
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `StateMachineType`  <a name="cfn-stepfunctions-statemachine-statemachinetype"></a>
-Determines whether a `STANDARD` or `EXPRESS` state machine is created\. The default is `STANDARD`\. You cannot update the `type` of a state machine once it has been created\. For more information on `STANDARD` and `EXPRESS` worklfows, see [Standard Versus Express Workflows](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-standard-vs-express.html) in the AWS Step Functions Developer Guide\.  
+Determines whether a `STANDARD` or `EXPRESS` state machine is created\. The default is `STANDARD`\. You cannot update the `type` of a state machine once it has been created\. For more information on `STANDARD` and `EXPRESS` workflows, see [Standard Versus Express Workflows](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-standard-vs-express.html) in the AWS Step Functions Developer Guide\.  
 *Required*: No  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Typo in the Step Functions documentation in the section where the `StateMachineType` property is explained.