### PR TITLE
Update aws-resource-elasticsearch-domain.md

### DIFF
--- a/doc_source/aws-resource-elasticsearch-domain.md
+++ b/doc_source/aws-resource-elasticsearch-domain.md
@@ -112,7 +112,8 @@ Whether the domain should encrypt data at rest, and if so, the AWS Key Managemen
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `LogPublishingOptions`  <a name="cfn-elasticsearch-domain-logpublishingoptions"></a>
-Key\-value pairs to configure slow log publishing\.  This should be a object where keys are from the following `[SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS, INDEX_SLOW_LOGS]`, and value formatted in the form of `LogPublishingOption`. 
+Key\-value pairs to configure slow log publishing\.  
+This should be a object where keys are from the following `[SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS, INDEX_SLOW_LOGS]`, depending on the types of logs needed to publish. Each of the keys should have a valid `LogPublishingOption` value.
 *Required*: No  
 *Type*: Map of [LogPublishingOption](aws-properties-elasticsearch-domain-logpublishingoption.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
@@ -311,6 +312,16 @@ The following example creates a domain with VPC options\.
             "Resource": "*"
           }]
         },
+        "LogPublishingOptions":{
+          "SEARCH_SLOW_LOGS": {
+            "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs",
+            "Enabled": "true"
+          },
+          "INDEX_SLOW_LOGS": {
+            "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs",
+            "Enabled": "true"
+          }
+        },
         "AdvancedOptions": {
           "rest.action.multi.allow_explicit_index": "true"
         },
@@ -432,6 +443,13 @@ Resources:
             Resource: '*'
       AdvancedOptions:
         rest.action.multi.allow_explicit_index: 'true'
+      LogPublishingOptions:
+        SEARCH_SLOW_LOGS:
+          CloudWatchLogsLogGroupArn: arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs
+          Enabled: 'true'
+        INDEX_SLOW_LOGS:
+          CloudWatchLogsLogGroupArn: arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs
+          Enabled: 'true'
       Tags:
         - Key: foo
           Value: bar

--- a/doc_source/aws-resource-elasticsearch-domain.md
+++ b/doc_source/aws-resource-elasticsearch-domain.md
@@ -112,7 +112,7 @@ Whether the domain should encrypt data at rest, and if so, the AWS Key Managemen
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `LogPublishingOptions`  <a name="cfn-elasticsearch-domain-logpublishingoptions"></a>
-Key\-value pairs to configure slow log publishing\.  
+Key\-value pairs to configure slow log publishing\.  This should be a object where keys are from the following `[SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS, INDEX_SLOW_LOGS]`, and value formatted in the form of `LogPublishingOption`. 
 *Required*: No  
 *Type*: Map of [LogPublishingOption](aws-properties-elasticsearch-domain-logpublishingoption.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding clarity to the use of `LogPublishingOptions` in `AWS::Elasticsearch::Domain`. Currently, it doesn't explain the full details on how to provide its proper values, other than "map of LogPublishingOptions"



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
