### PR TITLE
[BUGFIX] Removed invalid line break in Yaml code sample

### DIFF
--- a/doc_source/quickref-route53.md
+++ b/doc_source/quickref-route53.md
@@ -305,6 +305,5 @@ When you create alias resource record sets, you must specify `Z2FDTNDATAQYW2` fo
  9.       Type: A
 10.       AliasTarget:
 11.         HostedZoneId: Z2FDTNDATAQYW2
-12.         DNSName:
-13.           !GetAtt: myCloudFrontDistribution.DomainName
+12.         DNSName: GetAtt 'myCloudFrontDistribution.DomainName'
 ```


### PR DESCRIPTION
This removed an incorrect use of a line break in the CloudFront
yaml example code snippet. Before the fix the code would result
in a compile(r) error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
