### PR TITLE
Describe valid values for Amplify redirect/rewrite status

### DIFF
--- a/doc_source/aws-properties-amplify-app-customrule.md
+++ b/doc_source/aws-properties-amplify-app-customrule.md
@@ -42,6 +42,15 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 `Status`  <a name="cfn-amplify-app-customrule-status"></a>
  The status code for a URL rewrite or redirect rule\.   
+ 
+|Value    |Represents                |
+|---------|--------------------------|
+|`200`    |200 (Rewrite)             |
+|`301`    |301 (Redirect - Permanent)|
+|`302`    |302 (Redirect - Temporary)|
+|`404`    |404 (Redirect)            |
+|`404-200`|404 (Rewrite)             |
+
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
The Amplify redirect/rewrite status value "404-200" isn't at all obvious and needs to be documented so that users who want to create a "404 rewrite" rule (common for React apps) can do so.

*Issue #, if available:* N/A

*Description of changes:* Added a table listing the valid values that `Status` can have when declaring a redirect/rewrite rule on an Amplify app. This is because the value for a 404 rewrite rule is not at all obvious, nor documented anywhere that I could find.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
