### PR TITLE
Update aws-properties-ec2-launchtemplate-tagspecification.md

### DIFF
--- a/doc_source/aws-properties-ec2-launchtemplate-tagspecification.md
+++ b/doc_source/aws-properties-ec2-launchtemplate-tagspecification.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-ec2-launchtemplate-tagspecification-properties"></a>
 
 `ResourceType`  <a name="cfn-ec2-launchtemplate-tagspecification-resourcetype"></a>
-The type of resource to tag\.  
+The type of resource to tag. Currently, the resource types that support tagging on creation are instance and volume. To tag a resource after it has been created, see CreateTags.\.  
 *Required*: No  
 *Type*: String  
 *Allowed Values*: `client-vpn-endpoint | customer-gateway | dedicated-host | dhcp-options | elastic-ip | fleet | fpga-image | host-reservation | image | instance | internet-gateway | key-pair | launch-template | natgateway | network-acl | network-interface | placement-group | reserved-instances | route-table | security-group | snapshot | spot-fleet-request | spot-instances-request | subnet | traffic-mirror-filter | traffic-mirror-session | traffic-mirror-target | transit-gateway | transit-gateway-attachment | transit-gateway-multicast-domain | transit-gateway-route-table | volume | vpc | vpc-flow-log | vpc-peering-connection | vpn-connection | vpn-gateway`  


### PR DESCRIPTION
*Issue #, if available:* Customers are confused on adding values other than volume and instance.

*Description of changes:* 
Even though allowed values are as specfied only ones that are allowed are - You can only tag instances and volumes on launch. The specified tags are applied to all instances or volumes that are created during launch.

While the EC2 documentation clearly specifies that -
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateTagSpecificationRequest.html

CloudFormation document does not -
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html

Therefore this needs an edit to add the same line that is there in EC2 document to make this consistent with EC2 API description for ResourceType

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
