### PR TITLE
Create-Stack on CLI does not upload to S3

### DIFF
--- a/doc_source/using-cfn-cli-creating-stack.md
+++ b/doc_source/using-cfn-cli-creating-stack.md
@@ -4,10 +4,6 @@ To create a stack you run the `[aws cloudformation create\-stack](https://docs.a
 
 Parameters are separated with a space and the key names are case sensitive\. If you mistype a parameter key name when you run `aws cloudformation create-stack`, AWS CloudFormation doesn't create the stack and reports that the template doesn't contain that parameter\.
 
-**Note**  
-If you specify a local template file, AWS CloudFormation uploads it to an Amazon S3 bucket in your AWS account\. AWS CloudFormation creates a unique bucket for each region in which you upload a template file\. The buckets are accessible to anyone with Amazon S3 permissions in your AWS account\. If an AWS CloudFormation\-created bucket already exists, the template is added to that bucket\.  
-You can use your own bucket and manage its permissions by manually uploading templates to Amazon S3\. Then whenever you create or update a stack, specify the Amazon S3 URL of a template file\.
-
 By default, `aws cloudformation describe-stacks` returns parameter values\. To prevent sensitive parameter values such as passwords from being returned, include a `NoEcho` property set to `TRUE` in your AWS CloudFormation template\.
 
 **Important**  


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The documentation currently claims that templates uploaded via the CLI will be duplicated into an S3 bucket in the customers account. This is not true, and _only_ applies to uploads using the Web Console. Therefore having this note on this page is misleading.

Removing the note.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
