### PR TITLE
Uses correct case in UserName property name

### DIFF
--- a/doc_source/aws-resource-fsx-filesystem.md
+++ b/doc_source/aws-resource-fsx-filesystem.md
@@ -377,7 +377,7 @@ Resources:
             'Fn::ImprtValue': SelfManagedADDomainName
           FileSystemAdministratorsGroup: MyDomainAdminGroup
           OrganizationalUnitDistinguishedName: 'OU=FileSystems,DC=corp,DC=example,DC=com'
-          Username: Admin
+          UserName: Admin
           Password: !Join 
             - ':'
             - - '{{resolve:secretsmanager'


### PR DESCRIPTION
Corrects property name in Self-Managed AD YAML example from Username to UserName.

*Issue #, if available:*
n/a

*Description of changes:*
In the YAML example for creating an FSx file system in a self-managed AD, updates the property name from `Username` (incorrect) to `UserName` (correct, per [CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-windowsconfiguration-selfmanagedactivedirectoryconfiguration.html)).  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
