### PR TITLE
Changed required option of AuthorizerResultTtlInSeconds

### DIFF
--- a/doc_source/aws-resource-apigateway-authorizer.md
+++ b/doc_source/aws-resource-apigateway-authorizer.md
@@ -53,8 +53,8 @@ The credentials that are required for the authorizer\. To specify an IAM role th
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `AuthorizerResultTtlInSeconds`  <a name="cfn-apigateway-authorizer-authorizerresultttlinseconds"></a>
-The time\-to\-live \(TTL\) period, in seconds, that specifies how long API Gateway caches authorizer results\. If you specify a value greater than 0, API Gateway caches the authorizer responses\. By default, API Gateway sets this property to 300\. The maximum value is 3600, or 1 hour\.  
-*Required*: No  
+The time\-to\-live \(TTL\) period, in seconds, that specifies how long API Gateway caches authorizer results\. If you specify a value greater than 0, API Gateway caches the authorizer responses\. By default, API Gateway sets this property to 300\. The maximum value is 3600, or 1 hour\.  If you do not set any cache, specify this property to 0\.
+*Required*: Yes  
 *Type*: Integer  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
The property AuthorizerResultTtlInSeconds is required. If you do not set this property CloudFormation return the following error: Invalid request input (Service: AmazonApiGateway; Status Code: 400; Error Code: BadRequestException)

*Issue #, if available:*

*Description of changes:*
Changed required attribute of _AuthorizerResultTtlInSeconds_ from **No** to **Yes** and added description how to set this attribute if no cache is set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
