### PR TITLE
Fixing typo in CloudMap ARN, service-discovery -> servicediscovery

### DIFF
--- a/doc_source/aws-resource-servicediscovery-httpnamespace.md
+++ b/doc_source/aws-resource-servicediscovery-httpnamespace.md
@@ -62,7 +62,7 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 #### <a name="aws-resource-servicediscovery-httpnamespace-return-values-fn--getatt-fn--getatt"></a>
 
 `Arn`  <a name="Arn-fn::getatt"></a>
-The Amazon Resource Name \(ARN\) of the namespace, such as `arn:aws:service-discovery:us-east-1:123456789012:http-namespace/http-namespace-a1bzhi`\.
+The Amazon Resource Name \(ARN\) of the namespace, such as `arn:aws:servicediscovery:us-east-1:123456789012:http-namespace/http-namespace-a1bzhi`\.
 
 `Id`  <a name="Id-fn::getatt"></a>
 The ID of the namespace\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed service-discovery to servicediscovery

According to the CloudMap IAM docs, the correct prefix format is servicediscovery.
https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awscloudmap.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
