### PR TITLE
Add ImageId as an attribute and remove OutputResources to Fn::GetAtt …

### DIFF
--- a/doc_source/aws-resource-imagebuilder-image.md
+++ b/doc_source/aws-resource-imagebuilder-image.md
@@ -89,5 +89,6 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 `Arn`  <a name="Arn-fn::getatt"></a>
 Returns the Amazon Resource Name \(ARN\) of the image\. For example, `arn:aws:imagebuilder:us-west-2:123456789012:image/mybasicrecipe/2019.12.03/1`\.
 
-`ImageId`  <a name="OutputResources-fn::getatt"></a>
-Returns the Amazon Machine Images \(AMI\) ID of the image created\. For example, `ami-03757411db9db0bb1`\.
+`ImageId`  <a name="ImageId-fn::getatt"></a>
+Returns the AMI ID of the EC2 AMI in the Region in which you are using Image
+         Builder.\

--- a/doc_source/aws-resource-imagebuilder-image.md
+++ b/doc_source/aws-resource-imagebuilder-image.md
@@ -89,5 +89,5 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 `Arn`  <a name="Arn-fn::getatt"></a>
 Returns the Amazon Resource Name \(ARN\) of the image\. For example, `arn:aws:imagebuilder:us-west-2:123456789012:image/mybasicrecipe/2019.12.03/1`\.
 
-`OutputResources`  <a name="OutputResources-fn::getatt"></a>
-Returns the output resources produced when creating this image, formatted as an array of AMIs\.
+`ImageId`  <a name="OutputResources-fn::getatt"></a>
+Returns the Amazon Machine Images \(AMI\) ID of the image created\. For example, `ami-03757411db9db0bb1`\.


### PR DESCRIPTION
"Return Values" Section

*Issue #, if available:*

*Description of changes:*

Raising this change because of a support case.  https://t.corp.amazon.com/V205217292/communication

The "OutputResources" attribute is not a valid Output as it will never return as a string.
According to the resource schema, the useful attribute for customer should be "ImageId"

https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-imagebuilder/blob/master/image/aws-imagebuilder-image.json#L138

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
