### PR TITLE
The code S3Bucket and S3Key are no longer used

### DIFF
--- a/doc_source/aws-resource-codestar-githubrepository.md
+++ b/doc_source/aws-resource-codestar-githubrepository.md
@@ -109,8 +109,8 @@ When passing secret parameters, do not enter the value directly into the templat
         "Properties": {
             "Code": {
                 "S3": {
-                    "S3Bucket": "my-bucket",
-                    "S3Key": "sourcecode.zip",
+                    "Bucket": "my-bucket",
+                    "Key": "sourcecode.zip",
                     "ObjectVersion": "1"
                 }
             },
@@ -133,8 +133,8 @@ MyRepo:
   Properties:
     Code:
       S3:
-        S3Bucket: "my-bucket" 
-        S3Key: "sourcecode.zip" 
+        Bucket: "my-bucket" 
+        Key: "sourcecode.zip" 
         ObjectVersion: "1"
     EnableIssues: true
     IsPrivate: true


### PR DESCRIPTION
The code S3Bucket and S3Key are no longer used

*Issue #, if available:* N/A

*Description of changes:* Removed the S3Bucket and S3Key and replaced them with Bucket and Key in the examples. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
