### PR TITLE
Fix Fn::Join docs example

### DIFF
--- a/doc_source/intrinsic-function-reference-join.md
+++ b/doc_source/intrinsic-function-reference-join.md
@@ -56,7 +56,7 @@ The following example returns: `"a:b:c"`\.
 
 ### Join Using the Ref Function with Parameters<a name="intrinsic-function-reference-join-example2"></a>
 
-The following example uses `Fn::Join` to construct a string value\. It uses the `Ref` function with the `Partition` parameter and the `AWS::AccountId` pseudo parameter\.
+The following example uses `Fn::Join` to construct a string value\. It uses the `Ref` function with the `AWS::Partition` parameter and the `AWS::AccountId` pseudo parameter\.
 
 #### JSON<a name="intrinsic-function-reference-join-example2.json"></a>
 
@@ -66,7 +66,7 @@ The following example uses `Fn::Join` to construct a string value\. It uses the 
  3.     "", [
  4.       "arn:",
  5.       {
- 6.         "Ref": "Partition"
+ 6.         "Ref": "AWS::Partition"
  7.       },
  8.       ":s3:::elasticbeanstalk-*-",
  9.       {
@@ -83,7 +83,7 @@ The following example uses `Fn::Join` to construct a string value\. It uses the 
 1. !Join
 2.   - ''
 3.   - - 'arn:'
-4.     - !Ref Partition
+4.     - !Ref 'AWS::Partition'
 5.     - ':s3:::elasticbeanstalk-*-'
 6.     - !Ref 'AWS::AccountId'
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The Fn::Join docs include an example with a reference to "Partition".  The correct pseduo parameter is "AWS::Partition".  Adding this example to a CloudFormation template will cause the template to fail validation.

Pseudo parameter reference here:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
