### PR TITLE
Update to be List of InstanceIpv6Address

### DIFF
--- a/doc_source/aws-properties-ec2-networkinterface-instanceipv6address.md
+++ b/doc_source/aws-properties-ec2-networkinterface-instanceipv6address.md
@@ -1,6 +1,6 @@
 # AWS::EC2::NetworkInterface InstanceIpv6Address<a name="aws-properties-ec2-networkinterface-instanceipv6address"></a>
 
-Describes an IPv6 address to associate with the network interface\.
+Describes a list of IPv6 addresses to associate with the network interface\.
 
 ## Syntax<a name="aws-properties-ec2-networkinterface-instanceipv6address-syntax"></a>
 
@@ -9,15 +9,18 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### JSON<a name="aws-properties-ec2-networkinterface-instanceipv6address-syntax.json"></a>
 
 ```
-{
-  "[Ipv6Address](#cfn-ec2-networkinterface-instanceipv6address-ipv6address)" : String
-}
+[
+  {
+    "[Ipv6Address](#cfn-ec2-networkinterface-instanceipv6address-ipv6address)" : String
+  }
+  ...
+]
 ```
 
 ### YAML<a name="aws-properties-ec2-networkinterface-instanceipv6address-syntax.yaml"></a>
 
 ```
-  [Ipv6Address](#cfn-ec2-networkinterface-instanceipv6address-ipv6address): String
+  - [Ipv6Address](#cfn-ec2-networkinterface-instanceipv6address-ipv6address): String
 ```
 
 ## Properties<a name="aws-properties-ec2-networkinterface-instanceipv6address-properties"></a>


### PR DESCRIPTION
CreateStack without list will result in an error Value of property Ipv6Addresses must be of type List

*Description of changes:*
[CloudFormation documentation for AWS::EC2::NetworkInterface.Ipv6Addresses](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html#cfn-ec2-networkinterface-ipv6addresses) describes its type is [InstanceIpv6Address](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinterface-instanceipv6address.html) object.
However, it should be List of InstanceIpv6Address, as [CreateNetworkInterface](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkInterface.html) API accepts an array of InstanceIpv6Address objects.

Example of a incorrect (following current cfn doc and type definition) template. CreateStack with this template fails due to an error _Value of property Ipv6Addresses must be of type List_.

`{
  "Resources": {
    "NetworkInterface": {
      "Type": "AWS::EC2::NetworkInterface",
      "Properties": {
        "Ipv6Addresses": {
          "Ipv6Address": "2a05:d018:431:d700:8bce:af14:b554:b13"
        },
        "SubnetId": "subnet-08e4605e0dcb8f44a"
      }
    }
  }
}`

Example of a deployable template with 2 IPv6 addresses specified.

`{
	"Resources": {
		"NetworkInterface": {
			"Type": "AWS::EC2::NetworkInterface",
			"Properties": {
				"Ipv6Addresses": [{
					"Ipv6Address": "2a05:d018:431:d700:8bce:af14:b554:b13"
				}, {
					"Ipv6Address": "2a05:d018:431:d700:8bce:af14:b554:a13"
				}],
				"SubnetId": "subnet-08e4605e0dcb8f44a"
			}
		}
	}
}`



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
