### PR TITLE
Removed TCP and UDP warning on same port

### DIFF
--- a/doc_source/aws-properties-ecs-taskdefinition-containerdefinitions-portmappings.md
+++ b/doc_source/aws-properties-ecs-taskdefinition-containerdefinitions-portmappings.md
@@ -34,7 +34,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 The port number on the container that is bound to the user\-specified or automatically assigned host port\.  
 If you are using containers in a task with the `awsvpc` or `host` network mode, exposed ports should be specified using `containerPort`\.  
 If you are using containers in a task with the `bridge` network mode and you specify a container port and not a host port, your container automatically receives a host port in the ephemeral port range\. For more information, see `hostPort`\. Port mappings that are automatically assigned in this way do not count toward the 100 reserved ports limit of a container instance\.  
-You cannot expose the same container port for multiple protocols\. An error will be returned if this is attempted\.
 *Required*: No  
 *Type*: Integer  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
I have removed the note that states that an error will be thrown if a task definition is created on both TCP and UDP ports, as this is no longer true

*Issue #, if available:*

*Description of changes:* I have removed the note that states that an error will be thrown if a task definition is created on both TCP and UDP ports, as this is no longer true


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
