### PR TITLE
Update aws-properties-elasticsearch-domain-cognitooptions.md

### DIFF
--- a/doc_source/aws-properties-elasticsearch-domain-cognitooptions.md
+++ b/doc_source/aws-properties-elasticsearch-domain-cognitooptions.md
@@ -36,18 +36,18 @@ Whether to enable or disable Amazon Cognito authentication for Kibana\. See [Ama
 
 `IdentityPoolId`  <a name="cfn-elasticsearch-domain-cognitooptions-identitypoolid"></a>
 The Amazon Cognito identity pool ID that you want Amazon ES to use for Kibana authentication\.  
-*Required*: No  
+*Required*: Yes if enabled  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `RoleArn`  <a name="cfn-elasticsearch-domain-cognitooptions-rolearn"></a>
 The `AmazonESCognitoAccess` role that allows Amazon ES to configure your user pool and identity pool\.  
-*Required*: No  
+*Required*: Yes if enabled  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `UserPoolId`  <a name="cfn-elasticsearch-domain-cognitooptions-userpoolid"></a>
 The Amazon Cognito user pool ID that you want Amazon ES to use for Kibana authentication\.  
-*Required*: No  
+*Required*: Yes if enabled  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/doc_source/aws-properties-elasticsearch-domain-cognitooptions.md
+++ b/doc_source/aws-properties-elasticsearch-domain-cognitooptions.md
@@ -29,25 +29,25 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-elasticsearch-domain-cognitooptions-properties"></a>
 
 `Enabled`  <a name="cfn-elasticsearch-domain-cognitooptions-enabled"></a>
-Whether to enable or disable Amazon Cognito authentication for Kibana\. See [Amazon Cognito Authentication for Kibana](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-cognito-auth.html)\.  
+Whether to enable or disable Amazon Cognito authentication for Kibana\. See [Amazon Cognito Authentication for Kibana](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-cognito-auth.html)\. If you set Enabled to true, you must specify values for IdentityPoolId, RoleArn, and UserPoolId.  
 *Required*: No  
 *Type*: Boolean  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `IdentityPoolId`  <a name="cfn-elasticsearch-domain-cognitooptions-identitypoolid"></a>
 The Amazon Cognito identity pool ID that you want Amazon ES to use for Kibana authentication\.  
-*Required*: Yes if enabled  
+*Required*: Conditional  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `RoleArn`  <a name="cfn-elasticsearch-domain-cognitooptions-rolearn"></a>
 The `AmazonESCognitoAccess` role that allows Amazon ES to configure your user pool and identity pool\.  
-*Required*: Yes if enabled  
+*Required*: Conditional  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `UserPoolId`  <a name="cfn-elasticsearch-domain-cognitooptions-userpoolid"></a>
 The Amazon Cognito user pool ID that you want Amazon ES to use for Kibana authentication\.  
-*Required*: Yes if enabled  
+*Required*: Conditional  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
According to the Prerequisites of Amazon Cognito Authentication for Kibana - Prerequisites - https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-cognito-auth.html#es-cognito-auth-prereq

If Enabled, you need all 3 of those properties set, otherwise in CFN you get an "xxx must be specified" error. By saying "Required: No", the document does not clearly indicate the necessity of those properties, which is misleading the users into that error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
