### PR TITLE
Update parameters-section-structure.md

### DIFF
--- a/doc_source/parameters-section-structure.md
+++ b/doc_source/parameters-section-structure.md
@@ -160,7 +160,6 @@ AWS\-Specific Parameter Types
 AWS values such as Amazon EC2 key pair names and VPC IDs\. For more information, see [AWS\-Specific Parameter Types](#aws-specific-parameter-types)\.  
 `SSM` Parameter Types  
 Parameters that correspond to existing parameters in Systems Manager Parameter Store\. You specify a Systems Manager parameter key as the value of the `SSM` parameter, and AWS CloudFormation fetches the latest value from Parameter Store to use for the stack\. For more information, see [SSM Parameter Types](#aws-ssm-parameter-types)\.  
-AWS CloudFormation doesn't currently support the `SecureString` Systems Manager parameter type\.
 
 ## AWS\-Specific Parameter Types<a name="aws-specific-parameter-types"></a>
 


### PR DESCRIPTION
Remove note on secure strings not being supported

If I am reading correctly secure string is supported as parameters for CloudFormation.  
"Support for secure strings was announced recently. We’ll cover an example on how to use secure strings later in this article."
Ref: https://aws.amazon.com/blogs/mt/using-aws-systems-manager-parameter-store-secure-string-parameters-in-aws-cloudformation-templates/ 