### PR TITLE
Delete false ordering requirement

### DIFF
--- a/doc_source/template-description-structure.md
+++ b/doc_source/template-description-structure.md
@@ -1,6 +1,6 @@
 # Description<a name="template-description-structure"></a>
 
-The `Description` section \(optional\) enables you to include comments about your template\. The `Description` must follow the `AWSTemplateFormatVersion` section\.
+The `Description` section \(optional\) enables you to include comments about your template\.
 
 The value for the description declaration must be a literal string that is between 0 and 1024 bytes in length\. You cannot use a parameter or function to specify the description\. The following snippet is an example of a description declaration:
 


### PR DESCRIPTION
This statement seems unlikely to actually be true, just based on the json spec ("An object is an unordered set of name/value pairs")

*Issue #, if available:*

*Description of changes:*

Removed false statement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
