### PR TITLE
Update the allowed values for deployment controller

### DIFF
--- a/doc_source/aws-properties-ecs-service-deploymentcontroller.md
+++ b/doc_source/aws-properties-ecs-service-deploymentcontroller.md
@@ -31,7 +31,7 @@ CODE\_DEPLOY
 The blue/green \(`CODE_DEPLOY`\) deployment type uses the blue/green deployment model powered by AWS CodeDeploy, which allows you to verify a new deployment of a service before sending production traffic to it\.  
 EXTERNAL  
 The external \(`EXTERNAL`\) deployment type enables you to use any third\-party deployment controller for full control over the deployment process for an Amazon ECS service\.
-*Allowed Values*: `ECS` \| `EXTERNAL`  
+*Allowed Values*: `ECS` \| `CODE_DEPLOY` \| `EXTERNAL`  
 *Required*: No  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
Update the allowed values to include Code Deploy

*Description of changes:*
Add the `CODE_DEPLOY` type to the documentation as per:
https://aws.amazon.com/about-aws/whats-new/2020/05/aws-cloudformation-now-supports-blue-green-deployments-for-amazon-ecs/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
