### PR TITLE
Update aws-resource-cloudwatch-compositealarm.md

### DIFF
--- a/doc_source/aws-resource-cloudwatch-compositealarm.md
+++ b/doc_source/aws-resource-cloudwatch-compositealarm.md
@@ -137,7 +137,9 @@ This example creates composite alarms named "HighResourceUsage" and "DeploymentI
         "Properties": {
             "AlarmName": "HighResourceUsage",
             "AlarmRule": "(ALARM(HighCPUUsage) OR ALARM(HighMemoryUsage)) AND NOT ALARM(DeploymentInProgress)",
-            "AlarmActions": "arn:aws:sns:us-west-2:123456789012:my-sns-topic",
+            "AlarmActions": [
+                "arn:aws:sns:us-west-2:123456789012:my-sns-topic"
+            ],
             "AlarmDescription": "Indicates that the system resource usage is high while no known 
             deployment is in progress"
         },
@@ -197,12 +199,13 @@ Resources:
     Properties:
       AlarmName: HighResourceUsage
       AlarmRule: (ALARM(HighCPUUsage) OR ALARM(HighMemoryUsage)) AND NOT ALARM(DeploymentInProgress)
-      AlarmActions: arn:aws:sns:us-west-2:123456789012:my-sns-topic
+      AlarmActions:
+        - arn:aws:sns:us-west-2:123456789012:my-sns-topic
       AlarmDescription: Indicates that the system resource usage is high while no known deployment is in progress
     DependsOn:
-    - DeploymentInProgress
-    - HighCPUUsage
-    - HighMemoryUsage
+      - DeploymentInProgress
+      - HighCPUUsage
+      - HighMemoryUsage
   DeploymentInProgress:
     Type: AWS::CloudWatch::CompositeAlarm
     Properties:


### PR DESCRIPTION
AlarmActions in template example (json and yaml) should be "list of strings"

*Description of changes:*

The example template is inconsistent with Properties description.

"AlarmActions" in template example (json and yaml) should be "list of strings" instead of "strings", and using the template example will results in "Internal Failure" when creating AWS::CloudWatch::CompositeAlarm due to incorrect data type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
