### PR TITLE
Updated required statement for external table definition

### DIFF
--- a/doc_source/aws-properties-dms-endpoint-s3settings.md
+++ b/doc_source/aws-properties-dms-endpoint-s3settings.md
@@ -67,7 +67,7 @@ An optional parameter to use GZIP to compress the target files\. Set to GZIP to 
 
 `ExternalTableDefinition`  <a name="cfn-dms-endpoint-s3settings-externaltabledefinition"></a>
  The external table definition\.   
-*Required*: No  
+*Required*: No, unless S3 is being used as a source then Yes\.  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION

*Issue #, if available:* N/A

*Description of changes:* While doing setup with DMS today I found through using CloudFormation and the APIs for DMS that the External Table Definition parameter is required. I haven't been able to find another piece of documentation that states this but it likely needs to be updated elsewhere as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
