### PR TITLE
Adding "Allowed Values" for Type  in aws-resource-accessanalyzer-analyzer.md

### DIFF
--- a/doc_source/aws-resource-accessanalyzer-analyzer.md
+++ b/doc_source/aws-resource-accessanalyzer-analyzer.md
@@ -57,6 +57,7 @@ The tags to apply to the analyzer\.
 The type represents the zone of trust for the analyzer\.  
 *Required*: Yes  
 *Type*: String  
+*Allowed Values*: `ACCOUNT | ORGANIZATION`
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 ## Return Values<a name="aws-resource-accessanalyzer-analyzer-return-values"></a>


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Adding "Allowed Values" for Type definition in alignment with https://docs.aws.amazon.com/access-analyzer/latest/APIReference/API_CreateAnalyzer.html#API_CreateAnalyzer_RequestBody


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
