### PR TITLE
Added explanation for "Location"

### DIFF
--- a/doc_source/aws-properties-codepipeline-pipeline-artifactstore.md
+++ b/doc_source/aws-properties-codepipeline-pipeline-artifactstore.md
@@ -37,7 +37,7 @@ The encryption key used to encrypt the data in the artifact store, such as an AW
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Location`  <a name="cfn-codepipeline-pipeline-artifactstore-location"></a>
-The S3 bucket used for storing the artifacts for a pipeline\. You can specify the name of an S3 bucket but not a folder in the bucket\. A folder to contain the pipeline artifacts is created for you based on the name of the pipeline\. You can use any S3 bucket in the same AWS Region as the pipeline to store your pipeline artifacts\.  
+The S3 bucket used for storing the artifacts for a pipeline\. You can specify the name of an S3 bucket but not a folder in the bucket\. A folder to contain the pipeline artifacts is created for you based on the name of the pipeline (first 20 characters of the pipeline name)\. You can use any S3 bucket in the same AWS Region as the pipeline to store your pipeline artifacts\.  
 *Required*: Yes  
 *Type*: String  
 *Minimum*: `3`  


### PR DESCRIPTION
Added "(first 20 characters of the pipeline name)" to tell customers that the prefix under artifact bucket will be made using only first 20 characters of the pipeline name (customer come back asking it is not same as pipeline name as mentioned here)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
