### PR TITLE
Update aws-properties-ecs-service-deploymentcontroller allowed values

### DIFF
--- a/doc_source/aws-properties-ecs-service-deploymentcontroller.md
+++ b/doc_source/aws-properties-ecs-service-deploymentcontroller.md
@@ -31,7 +31,7 @@ CODE\_DEPLOY
 The blue/green \(`CODE_DEPLOY`\) deployment type uses the blue/green deployment model powered by AWS CodeDeploy, which allows you to verify a new deployment of a service before sending production traffic to it\.  
 EXTERNAL  
 The external \(`EXTERNAL`\) deployment type enables you to use any third\-party deployment controller for full control over the deployment process for an Amazon ECS service\.
-*Allowed Values*: `ECS` \| `EXTERNAL`  
+*Allowed Values*: `ECS` \| `CODE_DEPLOY` \| `EXTERNAL`  
 *Required*: No  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
The current page does not include `CODE_DEPLOY` as an allowed value. This is inconsistent amongst other pages such as https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeploymentController.html. I have edited the page to include `CODE_DEPLOY` as an allowed value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
