### PR TITLE
parameter-section-structure: Fix SSM parameter example

### DIFF
--- a/doc_source/parameters-section-structure.md
+++ b/doc_source/parameters-section-structure.md
@@ -271,11 +271,11 @@ A Systems Manager parameter whose value is a list of strings\. This corresponds 
 
 `AWS::SSM::Parameter::Value<AWS-specific parameter type>`  
 A Systems Manager parameter whose value is an [AWS\-specific parameter type](#aws-specific-parameter-types)\. For example, the following specifies the `AWS::EC2::KeyPair::KeyName` type:  
-`AWS::SSM::Parameter::Value<AWS::EC2::KeyPair::KeyPairName>`
+`AWS::SSM::Parameter::Value<AWS::EC2::KeyPair::KeyName>`
 
 `AWS::SSM::Parameter::Value<List<AWS-specific parameter type>>`  
 A Systems Manager parameter whose value is a list of [AWS\-specific parameter types](#aws-specific-parameter-types)\. For example, the following specifies a list of `AWS::EC2::KeyPair::KeyName` types:  
-`AWS::SSM::Parameter::Value<List<AWS::EC2::KeyPair::KeyPairName>>`
+`AWS::SSM::Parameter::Value<List<AWS::EC2::KeyPair::KeyName>>`
 
 ### Unsupported SSM Parameter Types<a name="aws-ssm-parameter-types-unsupported"></a>
 


### PR DESCRIPTION
The correct type for a KeyPair's name is `AWS::EC2::KeyPair::KeyName`.

*Issue #, if available:*

*Description of changes:*

Updated the SSM parameter type examples to use the correct names for the AWS-specific parameter types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
