### PR TITLE
Replaced the obsolete db.m1.small class

### DIFF
--- a/doc_source/aws-attribute-dependson.md
+++ b/doc_source/aws-attribute-dependson.md
@@ -112,7 +112,7 @@ The following template contains an [AWS::EC2::Instance](https://docs.aws.amazon.
 25.     Type: AWS::RDS::DBInstance
 26.     Properties:
 27.       AllocatedStorage: '5'
-28.       DBInstanceClass: db.m1.small
+28.       DBInstanceClass: db.t2.small
 29.       Engine: MySQL
 30.       EngineVersion: '5.5'
 31.       MasterUsername: MyName

--- a/doc_source/aws-attribute-dependson.md
+++ b/doc_source/aws-attribute-dependson.md
@@ -71,7 +71,7 @@ The following template contains an [AWS::EC2::Instance](https://docs.aws.amazon.
 39.             "Type" : "AWS::RDS::DBInstance",
 40.             "Properties" : {
 41.                "AllocatedStorage" : "5",
-42.                "DBInstanceClass" : "db.m1.small",
+42.                "DBInstanceClass" : "db.t2.small",
 43.                "Engine" : "MySQL",
 44.                "EngineVersion" : "5.5",
 45.                "MasterUsername" : "MyName",


### PR DESCRIPTION
Issue #, if available:

Replaced "db.m1.small" to "db.t2.small"
RDS no longer support the creation of db.m1.small instance type.

Reference:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.