### PR TITLE
Fix contradicting information

### DIFF
--- a/doc_source/aws-properties-cloudwatch-alarm-metric.md
+++ b/doc_source/aws-properties-cloudwatch-alarm-metric.md
@@ -35,8 +35,8 @@ The metric dimensions that you want to be used for the metric that the alarm wil
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `MetricName`  <a name="cfn-cloudwatch-alarm-metric-metricname"></a>
-The name of the metric that you want the alarm to watch\. This is a required field\.  
-*Required*: No  
+The name of the metric that you want the alarm to watch\.
+*Required*: Yes  
 *Type*: String  
 *Minimum*: `1`  
 *Maximum*: `255`  


### PR DESCRIPTION
Or perhaps it should be "Required: *maybe*"

*Description of changes:*
The description states "This is a required field". Immediately after, we see "Required: No". Fixed that

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
