### PR TITLE
Clustered vs Standalone Outputs

### DIFF
--- a/doc_source/aws-resource-elasticache-replicationgroup.md
+++ b/doc_source/aws-resource-elasticache-replicationgroup.md
@@ -384,12 +384,16 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 
 #### <a name="aws-resource-elasticache-replicationgroup-return-values-fn--getatt-fn--getatt"></a>
 
+### Cluster Mode Enabled
+
 `ConfigurationEndPoint.Address`  <a name="ConfigurationEndPoint.Address-fn::getatt"></a>
  The DNS hostname of the cache node\.  
 Redis \(cluster mode disabled\) replication groups don't have this attribute\. Therefore, `Fn::GetAtt` returns a value for this attribute only if the replication group is clustered\. Otherwise, `Fn::GetAtt` fails\.
 
 `ConfigurationEndPoint.Port`  <a name="ConfigurationEndPoint.Port-fn::getatt"></a>
 The port number that the cache engine is listening on\. 
+
+### Cluster Mode Disabled
 
 `PrimaryEndPoint.Address`  <a name="PrimaryEndPoint.Address-fn::getatt"></a>
 The DNS address of the primary read\-write cache node\. 


### PR DESCRIPTION
In the 'Return Values' section, there was no mention of which return values could be expected with what cluster mode. Cluster Mode Enabled, for example, only had the configuration endpoint, as where the Cluster Mode Disabled includes the primary and reader endpoints. The naming of the outputs doesn't make it immediately clear to a new user which outputs to expect, so these headers I think should give some quick direction.

*Issue #, if available:*

*Description of changes:* Modified the return values section to have headers to indicate which outputs are returned with each cluster mode of the elasticache replication group.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
