### PR TITLE
Update aws-properties-cloudtrail-trail-eventselector.md

### DIFF
--- a/doc_source/aws-properties-cloudtrail-trail-eventselector.md
+++ b/doc_source/aws-properties-cloudtrail-trail-eventselector.md
@@ -31,8 +31,9 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 `DataResources`  <a name="cfn-cloudtrail-trail-eventselector-dataresources"></a>
 CloudTrail supports data event logging for Amazon S3 objects and AWS Lambda functions\. You can specify up to 250 resources for an individual event selector, but the total number of data resources cannot exceed 250 across all event selectors in a trail\. This limit does not apply if you configure resource logging for all data events\.   
+If IncludeManagementEvents is false, DataResources must not be empty\.   
 For more information, see [Data Events](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-management-and-data-events-with-cloudtrail.html#logging-data-events) and [Limits in AWS CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/WhatIsCloudTrail-Limits.html) in the *AWS CloudTrail User Guide*\.  
-*Required*: No  
+*Required*: Conditional  
 *Type*: List of [DataResource](aws-properties-cloudtrail-trail-dataresource.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
If IncludeManagementEvents is false, DataResources must not be empty, otherwise we see an error: Invalid combination of parameters in EventSelectors. When includeManagementEvents is false, DataResources must not be empty.

Effectively, if IncludeManagementEvents is false, then DataResources is required and cannot be empty either.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
