### PR TITLE
Fixed resource type in line 531

### DIFF
--- a/doc_source/aws-resource-config-aggregationauthorization.md
+++ b/doc_source/aws-resource-config-aggregationauthorization.md
@@ -528,7 +528,7 @@ Resources:
         SourceIdentifier: S3_BUCKET_PUBLIC_READ_PROHIBITED
 
   ConfigAggregator:
-    Type: AWS::Config::ConfigurationAggregatorName
+    Type: AWS::Config::ConfigurationAggregator
     Condition: CreateAggregator
     Properties:
     ConfigurationAggregatorName: name


### PR DESCRIPTION
Cloudformation console errors out with the message "Template format error: YAML not well-formed. (line 152, column 32)". Fixed it by changing the type from 'ConfigurationAggregatorName' to 'ConfigurationAggregator'

*Issue #, if available:*

*Description of changes:* Same as above


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
