### PR TITLE
Update aws-properties-lakeformation-datalakesettings-admins.md

### DIFF
--- a/doc_source/aws-properties-lakeformation-datalakesettings-admins.md
+++ b/doc_source/aws-properties-lakeformation-datalakesettings-admins.md
@@ -1,3 +1,36 @@
 # AWS::LakeFormation::DataLakeSettings Admins<a name="aws-properties-lakeformation-datalakesettings-admins"></a>
 
 A list of AWS Lake Formation principals\.
+
+## Syntax<a name="aws-resource-lakeformation-datalakesettings-admins-syntax"></a>
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON<a name="aws-resource-lakeformation-datalakesettings-admins-syntax.json"></a>
+
+```
+{
+  "Type" : "AWS::LakeFormation::DataLakeSettings",
+  "Properties" : {
+      "[Admins](#cfn-lakeformation-datalakesettings-admins)" : 
+        - DataLakePrincipalIdentifier (#cfn-lakeformation-datalakesettings-datalakeprincipal-datalakeprincipalidentifier) : String
+    }
+}
+```
+
+### YAML<a name="aws-resource-lakeformation-datalakesettings-admins-syntax.yaml"></a>
+
+```
+Type: AWS::LakeFormation::DataLakeSettings
+Properties: 
+  [Admins](#cfn-lakeformation-datalakesettings-admins): 
+    - DataLakePrincipalIdentifier (#cfn-lakeformation-datalakesettings-datalakeprincipal-datalakeprincipalidentifier) : String
+```
+
+## Properties<a name="aws-resource-lakeformation-datalakesettings-admins-properties"></a>
+
+`DataLakePrincipalIdentifier`  <a name="cfn-lakeformation-datalakesettings-datalakeprincipal-datalakeprincipalidentifier"></a>
+An identifier for the AWS Lake Formation principal\.  
+*Required*: No  
+*Type*: String  
+*Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/doc_source/aws-properties-lakeformation-datalakesettings-admins.md
+++ b/doc_source/aws-properties-lakeformation-datalakesettings-admins.md
@@ -12,9 +12,10 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
   "Type" : "AWS::LakeFormation::DataLakeSettings",
   "Properties" : {
-      "[Admins](#cfn-lakeformation-datalakesettings-admins)" : 
-        - DataLakePrincipalIdentifier (#cfn-lakeformation-datalakesettings-datalakeprincipal-datalakeprincipalidentifier) : String
-    }
+      "[Admins](#cfn-lakeformation-datalakesettings-admins)" : {
+          DataLakePrincipalIdentifier (#cfn-lakeformation-datalakesettings-datalakeprincipal-datalakeprincipalidentifier) : String
+      }
+   }
 }
 ```
 

--- a/doc_source/aws-properties-lakeformation-datalakesettings-admins.md
+++ b/doc_source/aws-properties-lakeformation-datalakesettings-admins.md
@@ -13,7 +13,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
   "Type" : "AWS::LakeFormation::DataLakeSettings",
   "Properties" : {
       "[Admins](#cfn-lakeformation-datalakesettings-admins)" : {
-          DataLakePrincipalIdentifier (#cfn-lakeformation-datalakesettings-datalakeprincipal-datalakeprincipalidentifier) : String
+         "DataLakePrincipalIdentifier (#cfn-lakeformation-datalakesettings-datalakeprincipal-datalakeprincipalidentifier)" : String
       }
    }
 }


### PR DESCRIPTION
Update DataLakeSettings Admin declaration to include documentation showing each index under the Admins array is an object with key DataLakePrincipalIdentifier.

*Issue #, if available:*
None

*Description of changes:*
Updated documentation for DataLakeSettings to properly identify array attributes under the Admins object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
