### PR TITLE
Update SubscriptionFilter docs on resourceArn

### DIFF
--- a/doc_source/aws-resource-logs-subscriptionfilter.md
+++ b/doc_source/aws-resource-logs-subscriptionfilter.md
@@ -62,7 +62,7 @@ The log group to associate with the subscription filter\. All log events that ar
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `RoleArn`  <a name="cfn-cwl-subscriptionfilter-rolearn"></a>
-The ARN of an IAM role that grants CloudWatch Logs permissions to deliver ingested log events to the destination stream\.  
+The ARN of an IAM role that grants CloudWatch Logs permissions to deliver ingested log events to the destination stream\. You don't need to provide the ARN when you are working with a logical destination for cross-account delivery\.   
 *Required*: No  
 *Type*: String  
 *Minimum*: `1`  


### PR DESCRIPTION
*Description of changes:*
`AWS::Logs::SubscriptionFilter` docs are missing a key detail regarding `RoleArn` being unnecessary when doing cross-account delivery. This text addition is directly copied from the [AWS CLI put-subscription-filter command docs](https://docs.aws.amazon.com/cli/latest/reference/logs/put-subscription-filter.html#options).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
