### PR TITLE
Correct syntax error

### DIFF
--- a/doc_source/aws-resource-efs-filesystem.md
+++ b/doc_source/aws-resource-efs-filesystem.md
@@ -376,7 +376,7 @@ Resources:
     Type: 'AWS::EFS::FileSystem'
     Properties:
       BackupPolicy:
-        - Status: ENABLED
+        Status: ENABLED
       PerformanceMode: maxIO
       Encrypted: true
       LifecyclePolicies:


### PR DESCRIPTION
Per the [BackupPolicy documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-efs-filesystem-backuppolicy.html), BackupPolicy contains a single value, not a list of values, so there should be no hyphen. If you use it with a hyphen, you get a "Model validation failed" error from CloudFormation. Without the hyphen, it works as expected.

*Description of changes:*
Removed the hyphen at the start of BackupPolicy's "status" property.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
