### PR TITLE
Document default values for optional parameters of AWS Lambda EventSourceMapping

### DIFF
--- a/doc_source/aws-resource-lambda-eventsourcemapping.md
+++ b/doc_source/aws-resource-lambda-eventsourcemapping.md
@@ -68,6 +68,7 @@ The maximum number of items to retrieve in a single batch\.
 \(Streams\) If the function returns an error, split the batch in two and retry\.  
 *Required*: No  
 *Type*: Boolean  
+*Default*: `false`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `DestinationConfig`  <a name="cfn-lambda-eventsourcemapping-destinationconfig"></a>
@@ -112,6 +113,7 @@ The length constraint applies only to the full ARN\. If you specify only the fun
 \(Streams\) The maximum amount of time to gather records before invoking the function, in seconds\.  
 *Required*: No  
 *Type*: Integer  
+*Default*: `0`  
 *Minimum*: `0`  
 *Maximum*: `300`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
@@ -120,6 +122,7 @@ The length constraint applies only to the full ARN\. If you specify only the fun
 \(Streams\) The maximum age of a record that Lambda sends to a function for processing\.  
 *Required*: No  
 *Type*: Integer  
+*Default*: `604800`  
 *Minimum*: `60`  
 *Maximum*: `604800`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
@@ -128,6 +131,7 @@ The length constraint applies only to the full ARN\. If you specify only the fun
 \(Streams\) The maximum number of times to retry when the function returns an error\.  
 *Required*: No  
 *Type*: Integer  
+*Default*: `10000`  
 *Minimum*: `0`  
 *Maximum*: `10000`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
@@ -136,6 +140,7 @@ The length constraint applies only to the full ARN\. If you specify only the fun
 \(Streams\) The number of batches to process from each shard concurrently\.  
 *Required*: No  
 *Type*: Integer  
+*Default*: `1`  
 *Minimum*: `1`  
 *Maximum*: `10`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Description of changes:*

Default values for many of the optional parameters are missing from this documentation.

Per https://aws.amazon.com/blogs/compute/new-aws-lambda-controls-for-stream-processing-and-asynchronous-invocations/:

- `MaximumRetryAttempts` default is 10,000
- `MaximumRecordAgeInSeconds` default is 604,800
- `BisectBatchOnFunctionError` default is false

Per https://aws.amazon.com/about-aws/whats-new/2019/11/aws-lambda-supports-parallelization-factor-for-kinesis-and-dynamodb-event-sources/:

- `ParallelizationFactor` default is 1

Per https://aws.amazon.com/about-aws/whats-new/2019/09/aws-lambda-now-supports-custom-batch-window-for-kinesis-and-dynamodb-event-sources/, it appears that:

- `MaximumBatchingWindowInSeconds` default is 0

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
