### PR TITLE
docs: Change the RefreshTokenValidity precision

### DIFF
--- a/doc_source/aws-resource-cognito-userpoolclient.md
+++ b/doc_source/aws-resource-cognito-userpoolclient.md
@@ -174,10 +174,10 @@ The read attributes\.
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `RefreshTokenValidity`  <a name="cfn-cognito-userpoolclient-refreshtokenvalidity"></a>
-The time limit, in days, after which the refresh token is no longer valid and cannot be used\.  
+The time limit, in seconds, after which the refresh token is no longer valid and cannot be used\.  
 *Required*: No  
 *Type*: Integer  
-*Minimum*: `0`  
+*Minimum*: `600`  
 *Maximum*: `315360000`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
According to https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-with-identity-providers.html, the RefreshTokenValidity is set in seconds, with a minimum of 600 seconds

*Issue #, if available:*

*Description of changes:*
Minor change to the timeframe precision of the RefreshTokenValidity from days to seconds, and the minimum set to 600, as described in other documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
