### PR TITLE
AWS::CloudWatch::Alarm minumum period not suported

### DIFF
--- a/doc_source/aws-properties-cw-alarm.md
+++ b/doc_source/aws-properties-cw-alarm.md
@@ -198,7 +198,7 @@ The period, in seconds, over which the statistic is applied\. This is required f
 For an alarm based on a math expression, you can't specify `Period`, and instead you use the `Metrics` parameter\.  
 *Required*: No  
 *Type*: Integer  
-*Minimum*: `1`  
+*Minimum*: `10`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Statistic`  <a name="cfn-cloudwatch-alarms-statistic"></a>


### PR DESCRIPTION
when using the value `1` the following error is returned: 

```
Period must be 10, 30 or a multiple of 60 (Service: AmazonCloudWatch; Status Code: 400; Error Code: ValidationError; Request ID: [Request ID]) 
```
