### PR TITLE
Update aws-properties-apitgateway-stage-methodsetting.md

### DIFF
--- a/doc_source/aws-properties-apitgateway-stage-methodsetting.md
+++ b/doc_source/aws-properties-apitgateway-stage-methodsetting.md
@@ -91,7 +91,7 @@ The resource path for this method\. Forward slashes \(`/`\) are encoded as `~1` 
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `ThrottlingBurstLimit`  <a name="cfn-apigateway-stage-methodsetting-throttlingburstlimit"></a>
-The number of burst requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account\. For more information, see [Manage API Request Throttling](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-request-throttling.html) in the *API Gateway Developer Guide*\.  
+The maximum number of concurrent request submissions that API Gateway permits at any moment across all APIs, stages, and methods in your AWS account\. For more information, see [Manage API Request Throttling](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-request-throttling.html) in the *API Gateway Developer Guide*\.  
 *Required*: No  
 *Type*: Integer  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
According to https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-request-throttling.html, `ThrottlingBurstLimit` is defined as follows:

>In API Gateway, the burst limit corresponds to the maximum number of concurrent request submissions that API Gateway can fulfill at any moment without returning 429 Too Many Requests error responses.

the burst limit does not define the maximum number of requests **per second** but **at any moment** .  This means API Gateway returns 429 when it receives more requests during a millisecond time-window than the value of `ThrottlingBurstLimit`.  So, the current explanation of `ThrottlingBurstLimit` is not accurate and a replacement with accurate documents make sense.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
