### PR TITLE
Update resource-import-nested-stacks.md

### DIFF
--- a/doc_source/resource-import-nested-stacks.md
+++ b/doc_source/resource-import-nested-stacks.md
@@ -68,9 +68,9 @@ During a nested stack import operation, AWS CloudFormation performs the followin
 
 1. On the **Identify resources** page, identify the `AWS::CloudFormation::Stack` resource\.
 
-   1. Under **Identifier property**, choose the type of resource identifier\. For example, an `AWS::CloudFormation::Stack` resource can be identified using the `StackName` property\.
+   1. Under **Identifier property**, choose the type of resource identifier\. For example, an `AWS::CloudFormation::Stack` resource can be identified using the `StackId` property\.
 
-   1. Under **Identifier value**, type the actual property value\. For example, `my_stack`\.  
+   1. Under **Identifier value**, type the actual property value\. For example, `arn:aws:cloudformation:us-west-2:12345678910:stack/mystack/5b918d10-cd98-11ea-90d5-0a9cd3354c10`\.  
 ![\[The Identify resources page in the console.\]](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/images/resources-to-import-identifiers.png)
 
    1. Choose **Next**\.


### PR DESCRIPTION
*Issue #, if available:*
Step 6.a mentions that "an AWS::CloudFormation::Stack resource can be identified using the StackName property.". However, the Identifier property is StackId. The Identifier value has to be stack arn, instead fo stack name as specified in 6.b

*Description of changes:*
updated the information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
