### PR TITLE
Update "The parameters for the AUTOMATION task"

### DIFF
--- a/doc_source/aws-properties-ssm-maintenancewindowtask-maintenancewindowautomationparameters.md
+++ b/doc_source/aws-properties-ssm-maintenancewindowtask-maintenancewindowautomationparameters.md
@@ -36,5 +36,5 @@ The version of an Automation document to use during task execution\.
 `Parameters`  <a name="cfn-ssm-maintenancewindowtask-maintenancewindowautomationparameters-parameters"></a>
 The parameters for the AUTOMATION task\.  
 *Required*: No  
-*Type*: Json  
+*Type*: String to array of strings map  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
`Parameters` should have parameter type as "String to array of strings map" 

*Description of changes:*

`Parameters` should have parameter type as "String to array of strings map" according to API reference https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_MaintenanceWindowAutomationParameters.html#API_MaintenanceWindowAutomationParameters_Contents

Providing a "Json" will result in resource creation failure.
```
      TaskInvocationParameters:
        MaintenanceWindowAutomationParameters:
          DocumentVersion: $DEFAULT
          Parameters: '{ "AutomationAssumeRole": "arn:aws:iam::377xxxxx2249:role/AmazonSSMAutomationRole","InstanceId": "i-00e3xxxxx9ae41631","SNSTopicArn": "arn:aws:sns:ap-southeast-2:377xxxxx2249:Automation-xxxx-PatchSingleInstance","ReportS3Bucket": "s3-xxxxx-ngo-sandbox-9"}'
```
Correct template snippet:
```
      TaskInvocationParameters:
        MaintenanceWindowAutomationParameters:
          DocumentVersion: $DEFAULT
          Parameters:
            AutomationAssumeRole: 
              - arn:aws:iam::377xxxxx2249:role/AmazonSSMAutomationRole
            InstanceId:
              - i-00e3xxxxx9ae41631
            SNSTopicArn: 
              - arn:aws:sns:ap-southeast-2:377xxxxx2249:Automation-xxxx-PatchSingleInstance
            ReportS3Bucket: 
              - s3-xxxxx-ngo-sandbox-9
      TaskType: AUTOMATION
      WindowId: !Ref NonProdMaintenanceWindow
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
