### PR TITLE
Update aws-resource-transfer-server.md Yaml to match JSON example.

### DIFF
--- a/doc_source/aws-resource-transfer-server.md
+++ b/doc_source/aws-resource-transfer-server.md
@@ -228,7 +228,8 @@ MyTransferServer:
     LoggingRole:
       Ref: AWSTransferLoggingAccess
     Protocols: SFTP
-    SecurityPolicy: TransferSecurityPolicy-2020-06
+    SecurityPolicy:
+      Ref: TransferSecurityPolicy-2020-06
     Tags: 
       - Key: KeyName
         Value: ValueName


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Yaml template for `SecurityPolicy` needs to include the dictionary item `Ref: TransferSecurityPolicy-2020-06` under it like the JSON example. Tested in an AWS account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
