### PR TITLE
Fix typo `ECS` -> `EC2` in quickref-efs.md

### DIFF
--- a/doc_source/quickref-efs.md
+++ b/doc_source/quickref-efs.md
@@ -82,7 +82,7 @@ If you make an update to the mount target that causes it to be replaced, instanc
     },
     "KeyName": {
       "Type": "AWS::EC2::KeyPair::KeyName",
-      "Description": "Name of an existing EC2 key pair to enable SSH access to the ECS instances"
+      "Description": "Name of an existing EC2 key pair to enable SSH access to the EC2 instances"
     },
     "AsgMaxSize": {
       "Type": "Number",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
