### PR TITLE
Update aws-resource-glue-securityconfiguration.md

### DIFF
--- a/doc_source/aws-resource-glue-securityconfiguration.md
+++ b/doc_source/aws-resource-glue-securityconfiguration.md
@@ -45,3 +45,7 @@ The name of the security configuration\.
 ## Return values<a name="aws-resource-glue-securityconfiguration-return-values"></a>
 
 ### Ref<a name="aws-resource-glue-securityconfiguration-return-values-ref"></a>
+
+When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the security configuration name\.
+
+For more information about using the `Ref` function, see [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html)\.


### PR DESCRIPTION
I tested using !Ref GlueSecurityConfigResource and it referenced the security configuration name, the current documentation on this page does not have this info available

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
