### PR TITLE
Adding NETWORK Connection Type

### DIFF
--- a/doc_source/aws-properties-glue-connection-connectioninput.md
+++ b/doc_source/aws-properties-glue-connection-connectioninput.md
@@ -45,6 +45,7 @@ The type of the connection\. Currently, these types are supported:
 +  `JDBC` \- Designates a connection to a database through Java Database Connectivity \(JDBC\)\.
 +  `KAFKA` \- Designates a connection to an Apache Kafka streaming platform\.
 +  `MONGODB` \- Designates a connection to a MongoDB document database\.
++  `NETWORK` \- Designates a connection to a VPC/Subnet\.
 SFTP is not supported\.  
 *Required*: Yes  
 *Type*: String  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding NETWORK Connection Type, supported by Glue API as documented here: https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-connections.html#aws-glue-api-catalog-connections-Connection
> ConnectionType – UTF-8 string (valid values: JDBC | SFTP | MONGODB | KAFKA | NETWORK).
> The type of the connection. Currently, SFTP is not supported.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
