### PR TITLE
Fix indentation in "AWS::ApiGatewayV2::Route"

### DIFF
--- a/doc_source/aws-resource-apigatewayv2-route.md
+++ b/doc_source/aws-resource-apigatewayv2-route.md
@@ -172,7 +172,7 @@ MyRoute:
     Target: !Join
       - /
       - - integrations
-      - !Ref MyIntegration
+        - !Ref MyIntegration
 ```
 
 ### WebSocket API route creation example<a name="aws-resource-apigatewayv2-route--examples--WebSocket_API_route_creation_example"></a>


### PR DESCRIPTION
*Description of changes:*
Fix indentation in example.
`cfn-lint` generated that error with the previous example:

> E1022 Join should be an array of 2 for Resources/Route/Properties/Target/Fn::Join
