### PR TITLE
Declaring correct authentiation type values in AWS::AppSync::GraphQLApi AdditionalAuthenticationProviders

### DIFF
--- a/doc_source/aws-properties-appsync-graphqlapi-additionalauthenticationprovider.md
+++ b/doc_source/aws-properties-appsync-graphqlapi-additionalauthenticationprovider.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-appsync-graphqlapi-additionalauthenticationprovider-properties"></a>
 
 `AuthenticationType`  <a name="cfn-appsync-graphqlapi-additionalauthenticationprovider-authenticationtype"></a>
-The authentication type: Allowed values are (API_KEY, AWS_IAM, or AMAZON_COGNITO_USER_POOLS, OPENID_CONNECT)
+The authentication type: Allowed values are (API_KEY, AWS_IAM, or AMAZON_COGNITO_USER_POOLS, OPENID_CONNECT)\.
 *Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/doc_source/aws-properties-appsync-graphqlapi-additionalauthenticationprovider.md
+++ b/doc_source/aws-properties-appsync-graphqlapi-additionalauthenticationprovider.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-appsync-graphqlapi-additionalauthenticationprovider-properties"></a>
 
 `AuthenticationType`  <a name="cfn-appsync-graphqlapi-additionalauthenticationprovider-authenticationtype"></a>
-The authentication type: API key, AWS IAM, OIDC, or Amazon Cognito user pools\.  
+The authentication type: Allowed values are (API_KEY, AWS_IAM, or AMAZON_COGNITO_USER_POOLS, OPENID_CONNECT)
 *Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/doc_source/aws-properties-appsync-graphqlapi-userpoolconfig.md
+++ b/doc_source/aws-properties-appsync-graphqlapi-userpoolconfig.md
@@ -41,7 +41,7 @@ The AWS Region in which the user pool was created\.
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `DefaultAction`  <a name="cfn-appsync-graphqlapi-userpoolconfig-defaultaction"></a>
-The action that you want your GraphQL API to take when a request that uses Amazon Cognito user pool authentication doesn't match the Amazon Cognito user pool configuration\.  
+The action that you want your GraphQL API to take when a request that uses Amazon Cognito user pool authentication doesn't match the Amazon Cognito user pool configuration. When specifying Cognito user pools as the default authentication for AppSync, the DefaultAction must be set to ALLOW if specifying AdditionalAuthenticationProviders\.
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Description of changes:*
This change aims to clarify expected authentication types within the `AdditionalAuthenticationProviders` documentation. When referencing this page directly, I assumed the values mentioned were the actual values, not approximate values that I would have to track down. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
