### PR TITLE
Update tag value constraints

### DIFF
--- a/doc_source/aws-properties-resource-tags.md
+++ b/doc_source/aws-properties-resource-tags.md
@@ -40,7 +40,7 @@ The key name of the tag\. You can specify a value that is 1 to 128 Unicode chara
 *Type*: String
 
 `Value`  <a name="cfn-resource-tags-value"></a>
-The value for the tag\. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with `aws:`\. You can use any of the following characters: the set of Unicode letters, digits, whitespace, `_`, `.`, `/`, `=`, `+`, and `-`\.  
+The value for the tag\. You can specify a value that is 0 to 256 characters in length.
 *Required*: Yes  
 *Type*: String
 


### PR DESCRIPTION
*Description of changes:*

Aligning share resource `Tags` property value constraints to schema described in https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_Tag.html

The existing `Value` description and constraints seems like a copy/paste error from `Key` description.

Sources of description used for this correction :
- CloudFormation API Reference documentation : https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_Tag.html
- Resource Groups & Tagging API Reference documentation : https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_Tag.html

Actual behavior has been tested in https://github.com/serverless/serverless/issues/8304  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
