### PR TITLE
Fix doc for ApiGateway::Method "AuthorizationType" and "Integration" property

### DIFF
--- a/doc_source/aws-properties-apitgateway-method-integration.md
+++ b/doc_source/aws-properties-apitgateway-method-integration.md
@@ -65,8 +65,8 @@ An API\-specific tag group of related cached parameters\.
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `ConnectionId`  <a name="cfn-apigateway-method-integration-connectionid"></a>
-The ID of the `VpcLink` used for the integration when `connectionType=VPC_LINK`, otherwise undefined\.  
-*Required*: No  
+The ID of the `VpcLink` used for the integration when `ConnectionType: VPC_LINK`, otherwise undefined\.  
+*Required*: Conditional  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/doc_source/aws-resource-apigateway-method.md
+++ b/doc_source/aws-resource-apigateway-method.md
@@ -69,9 +69,9 @@ A list of authorization scopes configured on the method\. The scopes are used wi
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `AuthorizationType`  <a name="cfn-apigateway-method-authorizationtype"></a>
-The method's authorization type\. This parameter is required\. For valid values, see [Method](https://docs.aws.amazon.com/apigateway/api-reference/resource/method/) in the *API Gateway API Reference*\.  
+The method's authorization type\. For valid values, see [Method](https://docs.aws.amazon.com/apigateway/api-reference/resource/method/) in the *API Gateway API Reference*\.  
 If you specify the `AuthorizerId` property, specify `CUSTOM` or `COGNITO_USER_POOLS` for this property\.
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
Fix "Required" attribute for ApiGateway::Method AuthorizationType property.
I think that in this way it's correct and more clear.

I tried to recreate the pull request, but the problem of messy diff in markdown files remains and I don't know why.
I hope the PR can be good anyway!
