### PR TITLE
Fix AWS::Kendra::Index Tag type from Taglist to Tag

### DIFF
--- a/doc_source/aws-resource-kendra-index.md
+++ b/doc_source/aws-resource-kendra-index.md
@@ -94,10 +94,9 @@ The identifier of the AWS KMS customer managed key \(CMK\) to use to encrypt dat
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `Tags`  <a name="cfn-kendra-index-tags"></a>
-An array of key\-value pairs to apply to this resource\.  
-For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html)\.  
+A list of [tags](https://docs.aws.amazon.com/lambda/latest/dg/tagging.html) to apply to this resource\.  
 *Required*: No  
-*Type*: [TagList](aws-properties-kendra-index-taglist.md)  
+*Type*: List of [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 ## Return values<a name="aws-resource-kendra-index-return-values"></a>


### PR DESCRIPTION
*Description of changes:*
This PR fixes and issue with `Tags` property. The type is currently set to `TagList`, however CloudFormation throws a following error:

Code used:
```
  KendraIndex:
    Type: AWS::Kendra::Index
    Properties:
      Description: Kendra index
      Edition: !Ref KendraEdition
      Name: !Ref KendraIndexName
      RoleArn: !GetAtt KendraIndexRole.Arn
      Tags:
        TagList:
          - Key: 'Name'
            Value: !Ref ResourceTags
```
CloudFormation Error:
```
Model validation failed (#/Tags: expected type: JSONArray, found: JSONObject)
```

The below code using Tags type `Tag` works as expected.
```
KendraIndex:
    Type: AWS::Kendra::Index
    Properties:
      Description: Kendra index
      Edition: !Ref KendraEdition
      Name: !Ref KendraIndexName
      RoleArn: !GetAtt KendraIndexRole.Arn
      Tags:
        - Key: 'Name'
          Value: !Ref ResourceTags
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
