### PR TITLE
Fix AWS::Kendra::Faq Tag type from Taglist to Tag

### DIFF
--- a/doc_source/aws-resource-kendra-faq.md
+++ b/doc_source/aws-resource-kendra-faq.md
@@ -73,10 +73,9 @@ The Amazon Simple Storage Service \(Amazon S3\) location of the FAQ input data\.
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `Tags`  <a name="cfn-kendra-faq-tags"></a>
-An array of key\-value pairs to apply to this resource  
-For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html)\.  
+A list of [tags](https://docs.aws.amazon.com/lambda/latest/dg/tagging.html) to apply to this resource\. 
 *Required*: No  
-*Type*: [TagList](aws-properties-kendra-faq-taglist.md)  
+*Type*: List of [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 ## Return values<a name="aws-resource-kendra-faq-return-values"></a>


### PR DESCRIPTION
*Description of changes:*
This PR fixes and issue with Tags property. The type is currently set to TagList, however CloudFormation throws a following error:

Code used:
```
  KendraFaq:
    Type: AWS::Kendra::Faq
    Properties:
      Description: Kendra FAQ
      IndexId: !Ref KendraIndex
      Name: 'kendra-faq'
      RoleArn: !GetAtt KendraFaqRole.Arn
      S3Path:
        Bucket: !Ref FaqS3Bucket
        Key: !Ref FaqFileName
      Tags:
         TagList:
           - Key: 'Name'
            Value: !Ref ResourceTags
    DependsOn:
      - LambdaTriggerUploadFaqToS3
```
CloudFormation Error:
`Model validation failed (#/Tags: expected type: JSONArray, found: JSONObject)`
The below code using Tags type Tag works as expected.
```
  KendraFaq:
    Type: AWS::Kendra::Faq
    Properties:
      Description: Kendra FAQ
      IndexId: !Ref KendraIndex
      Name: 'kendra-faq'
      RoleArn: !GetAtt KendraFaqRole.Arn
      S3Path:
        Bucket: !Ref FaqS3Bucket
        Key: !Ref FaqFileName
      Tags:
        - Key: 'Name'
          Value: !Ref ResourceTags
    DependsOn:
      - LambdaTriggerUploadFaqToS3
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
