### PR TITLE
Update cfn-lambda-function-code-cfnresponsemodule.md

### DIFF
--- a/doc_source/cfn-lambda-function-code-cfnresponsemodule.md
+++ b/doc_source/cfn-lambda-function-code-cfnresponsemodule.md
@@ -255,8 +255,9 @@ def send(event, context, responseStatus, responseData, physicalResourceId=None, 
         request.add_header('Content-Length', str(len(json_responseBody)))
 
         request.get_method = lambda: 'PUT'
+        response = urllib2.urlopen(request)
 
-        print "Status code: " + response.getcode()
+        print "Status code: " + str(response.getcode())
     except Exception as e:
         print "send(..) failed executing urllib2.Request(..): " + str(e)
 ```


### PR DESCRIPTION
The response module source code for Python 2 functions was missing a very important call to urllib2.urlopen(), and declaration of response, without which it does not work.
There was also a bug in the line that prints the result.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
