### PR TITLE
Fix Typo in Stacksets Resource: PermissionModels Allowed Values 

### DIFF
--- a/doc_source/aws-resource-cloudformation-stackset.md
+++ b/doc_source/aws-resource-cloudformation-stackset.md
@@ -114,7 +114,7 @@ The input parameters for the stack set template\.
 Describes how the IAM roles required for stack set operations are created\.  
 + With `SELF-MANAGED` permissions, you must create the administrator and execution roles required to deploy to target accounts\. For more information, see [Grant Self\-Managed Stack Set Permissions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs-self-managed.html)\.
 + With `SERVICE-MANAGED` permissions, StackSets automatically creates the IAM roles required to deploy to accounts managed by AWS Organizations\. For more information, see [Grant Service\-Managed Stack Set Permissions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs-service-managed.html)\.
-*Allowed Values*: `SERVICE_MANGED` \| `SELF_MANAGED`  
+*Allowed Values*: `SERVICE_MANAGED` \| `SELF_MANAGED`  
 *Required*: Yes  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
*Issue https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-cloudformation/issues/20*

* Typo Fix: Allowed Values: SERVICE_MANGED  changed to Allowed Values: SERVICE_MANAGED  *


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
