### PR TITLE
Added kafka.t3.small as a valid InstanceType

### DIFF
--- a/doc_source/aws-properties-msk-cluster-brokernodegroupinfo.md
+++ b/doc_source/aws-properties-msk-cluster-brokernodegroupinfo.md
@@ -51,7 +51,7 @@ Client subnets can't be in Availability Zone us\-east\-1e\.
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `InstanceType`  <a name="cfn-msk-cluster-brokernodegroupinfo-instancetype"></a>
-The type of Amazon EC2 instances to use for brokers\. The following instance types are allowed: kafka\.m5\.large, kafka\.m5\.xlarge, kafka\.m5\.2xlarge, kafka\.m5\.4xlarge, kafka\.m5\.8xlarge, kafka\.m5\.12xlarge, kafka\.m5\.16xlarge, and kafka\.m5\.24xlarge\.  
+The type of Amazon EC2 instances to use for brokers\. The following instance types are allowed: kafka\.t3\.small, kafka\.m5\.large, kafka\.m5\.xlarge, kafka\.m5\.2xlarge, kafka\.m5\.4xlarge, kafka\.m5\.8xlarge, kafka\.m5\.12xlarge, kafka\.m5\.16xlarge, and kafka\.m5\.24xlarge\.  
 *Required*: Yes  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
As per documentation https://docs.aws.amazon.com/msk/latest/developerguide/msk-create-cluster.html#broker-instance-types, kafka.t3.small is a valid instance type. Added to InstanceType property in CloudFormation document as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
