### PR TITLE
Fixing identation: InputFormatConfiguration, OutputFormatConfiguratio…

### DIFF
--- a/doc_source/aws-resource-kinesisfirehose-deliverystream.md
+++ b/doc_source/aws-resource-kinesisfirehose-deliverystream.md
@@ -342,13 +342,13 @@ Resources:
             TableName: !Ref GlueTable 
             Region: !Ref AWS::Region
             VersionId: LATEST 
-            InputFormatConfiguration: 
-              Deserializer: 
-                OpenXJsonSerDe: {}
-            OutputFormatConfiguration: 
-              Serializer: 
-                ParquetSerDe: {} 
-            Enabled: True 
+          InputFormatConfiguration: 
+            Deserializer: 
+              OpenXJsonSerDe: {}
+          OutputFormatConfiguration: 
+            Serializer: 
+              ParquetSerDe: {} 
+          Enabled: True 
   s3bucket: 
     Type: AWS::S3::Bucket 
     Properties: 


### PR DESCRIPTION
…n and Enabled

Wrong Identation of these keys leads to cloudformation error:
"Model validation failed (#: extraneous key [InputFormatConfiguration] is not permitted)"

*Issue #, if available:*

Cloudformation deploy error: "Model validation failed (#: extraneous key [InputFormatConfiguration] is not permitted)"

*Description of changes:*
One upper level for keys InputFormatConfiguration, OutputFormatConfiguration and Enabled on section "Convert Record Format >> YAML"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
