### PR TITLE
Update aws-properties-cognito-userpoolclient-tokenvalidityunits.md

### DIFF
--- a/doc_source/aws-properties-cognito-userpoolclient-tokenvalidityunits.md
+++ b/doc_source/aws-properties-cognito-userpoolclient-tokenvalidityunits.md
@@ -26,20 +26,17 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 ## Properties<a name="aws-properties-cognito-userpoolclient-tokenvalidityunits-properties"></a>
 
-`AccessToken`  <a name="cfn-cognito-userpoolclient-tokenvalidityunits-accesstoken"></a>
-Not currently supported by AWS CloudFormation\.  
+`AccessToken`  <a name="cfn-cognito-userpoolclient-tokenvalidityunits-accesstoken"></a> 
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `IdToken`  <a name="cfn-cognito-userpoolclient-tokenvalidityunits-idtoken"></a>
-Not currently supported by AWS CloudFormation\.  
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `RefreshToken`  <a name="cfn-cognito-userpoolclient-tokenvalidityunits-refreshtoken"></a>
-Not currently supported by AWS CloudFormation\.  
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
Specification of TokenValidityUnits seems to be supported by AWS CloudFormation now. 

The following configuration will cause the "Invalid range for token validity" exception
```CognitoUserPoolClient:
    Type: AWS::Cognito::UserPoolClient
    Properties:
...
      AccessTokenValidity: 1
      IdTokenValidity: 1
      RefreshTokenValidity: 36500
      TokenValidityUnits:
        AccessToken: "days"
        IdToken: "days"
        RefreshToken: "days"
```

while the following configuration works

```CognitoUserPoolClient:
    Type: AWS::Cognito::UserPoolClient
    Properties:
...
      AccessTokenValidity: 1
      IdTokenValidity: 1
      RefreshTokenValidity: 36500
      TokenValidityUnits:
        AccessToken: "days"
        IdToken: "days"
        RefreshToken: "minutes"
```

*Issue #, if available:*

*Description of changes:*
The "Not currently supported by AWS CloudFormation." string is removed from documentation since these parameters are now supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
