### PR TITLE
Add none as a valid logDriver options

### DIFF
--- a/doc_source/aws-properties-ecs-taskdefinition-containerdefinitions-logconfiguration.md
+++ b/doc_source/aws-properties-ecs-taskdefinition-containerdefinitions-logconfiguration.md
@@ -37,7 +37,7 @@ For more information about using the `awsfirelens` log driver, see [Custom log r
 If you have a custom driver that is not listed, you can fork the Amazon ECS container agent project that is [available on GitHub](https://github.com/aws/amazon-ecs-agent) and customize it to work with that driver\. We encourage you to submit pull requests for changes that you would like to have included\. However, we do not currently provide support for running modified copies of this software\.
 *Required*: Yes  
 *Type*: String  
-*Allowed values*: `awsfirelens | awslogs | fluentd | gelf | journald | json-file | splunk | syslog`  
+*Allowed values*: `awsfirelens | awslogs | fluentd | gelf | journald | json-file | splunk | syslog | none`  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `Options`  <a name="cfn-ecs-taskdefinition-containerdefinition-logconfiguration-options"></a>


### PR DESCRIPTION
According to this - https://github.com/aws/amazon-ecs-agent/issues/528 the agent already supporting that.
Also its appears to be valid option in the code - https://github.com/aws/amazon-ecs-agent/blob/master/agent/dockerclient/logging_drivers.go

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
