### PR TITLE
Update aws-properties-lakeformation-permissions-datalocationresource.md

### DIFF
--- a/doc_source/aws-properties-lakeformation-permissions-datalocationresource.md
+++ b/doc_source/aws-properties-lakeformation-permissions-datalocationresource.md
@@ -31,7 +31,7 @@ Not currently supported by AWS CloudFormation\.
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `S3Resource`  <a name="cfn-lakeformation-permissions-datalocationresource-s3resource"></a>
-Currently not supported by AWS CloudFormation\.  
+The S3 ARN of the data location\.  
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
This property works is working now if an S3 ARN is specified.

*Issue #, if available:*

*Description of changes:*
Minor correction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
