### PR TITLE
[aws-resource-transfer-user] fix example key format

### DIFF
--- a/doc_source/aws-resource-transfer-user.md
+++ b/doc_source/aws-resource-transfer-user.md
@@ -182,7 +182,9 @@ The following example associates a user with a server\.
       },
       "Role": "arn:aws:iam::176354371281:role/Transfer_role",
       "ServerId": "s-01234567890abcdef",
-      "SshPublicKeys": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCOtfCAis3aHfM6yc8KWAlMQxVDBHyccCde9MdLf4DQNXn8HjAHf+Bc1vGGCAREFUL1NO2PEEKING3ALLOWEDfIf+JBecywfO35Cm6IKIV0JF2YOPXvOuQRs80hQaBUvQL9xw6VEb4xzbit2QB6",
+      "SshPublicKeys": [
+        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCOtfCAis3aHfM6yc8KWAlMQxVDBHyccCde9MdLf4DQNXn8HjAHf+Bc1vGGCAREFUL1NO2PEEKING3ALLOWEDfIf+JBecywfO35Cm6IKIV0JF2YOPXvOuQRs80hQaBUvQL9xw6VEb4xzbit2QB6"
+      ],
       "Tags": [
         {
           "Key": "KeyName",
@@ -216,7 +218,8 @@ transfer_user:
           arn:aws:s3:::bucket_name/*
     Role: arn:aws:iam::176354371281:role/Transfer_role
     ServerId: s-01234567890abcdef
-    SshPublicKeys: AAAAB3NzaC1yc2EAAAADAQABAAABAQCOtfCAis3aHfM6yc8KWAlMQxVDBHyccCde9MdLf4DQNXn8HjAHf+Bc1vGGCAREFUL1NO2PEEKING3ALLOWEDfIf+JBecywfO35Cm6IKIV0JF2YOPXvOuQRs80hQaBUvQL9xw6VEb4xzbit2QB6
+    SshPublicKeys: 
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCOtfCAis3aHfM6yc8KWAlMQxVDBHyccCde9MdLf4DQNXn8HjAHf+Bc1vGGCAREFUL1NO2PEEKING3ALLOWEDfIf+JBecywfO35Cm6IKIV0JF2YOPXvOuQRs80hQaBUvQL9xw6VEb4xzbit2QB6
     Tags:
       - Key: KeyName
         Value: ValueName


### PR DESCRIPTION
Fix example key format in aws-resource-transfer-user.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.