### PR TITLE
Update aws-properties-cognito-userpoolclient-tokenvalidityunits.md

### DIFF
--- a/doc_source/aws-properties-cognito-userpoolclient-tokenvalidityunits.md
+++ b/doc_source/aws-properties-cognito-userpoolclient-tokenvalidityunits.md
@@ -1,6 +1,6 @@
 # AWS::Cognito::UserPoolClient TokenValidityUnits<a name="aws-properties-cognito-userpoolclient-tokenvalidityunits"></a>
 
-<a name="aws-properties-cognito-userpoolclient-tokenvalidityunits-description"></a>The `TokenValidityUnits` property type specifies Not currently supported by AWS CloudFormation\. for an [AWS::Cognito::UserPoolClient](aws-resource-cognito-userpoolclient.md)\.
+<a name="aws-properties-cognito-userpoolclient-tokenvalidityunits-description"></a>The `TokenValidityUnits` property type specifies the units of time for each token types' validty for a [AWS::Cognito::UserPoolClient](aws-resource-cognito-userpoolclient.md)\.
 
 ## Syntax<a name="aws-properties-cognito-userpoolclient-tokenvalidityunits-syntax"></a>
 
@@ -27,19 +27,22 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-cognito-userpoolclient-tokenvalidityunits-properties"></a>
 
 `AccessToken`  <a name="cfn-cognito-userpoolclient-tokenvalidityunits-accesstoken"></a>
-Not currently supported by AWS CloudFormation\.  
+The unit of time for the specified validity of the AccessToken.\.  
+Allowed values: `hours` \| `days` \| `minutes` \| `seconds` 
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `IdToken`  <a name="cfn-cognito-userpoolclient-tokenvalidityunits-idtoken"></a>
-Not currently supported by AWS CloudFormation\.  
+The unit of time for the specified validity of the IdToken.\.  
+Allowed values: `hours` \| `days` \| `minutes` \| `seconds`
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `RefreshToken`  <a name="cfn-cognito-userpoolclient-tokenvalidityunits-refreshtoken"></a>
-Not currently supported by AWS CloudFormation\.  
+The unit of time for the specified validity of the RefreshToken.\.  
+Allowed values: `hours` \| `days` \| `minutes` \| `seconds`
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
These attributes on this property appear to be working in CloudFormation as of this morning 11/10/20.

*Issue #, if available:*

*Description of changes:*
Documentation updates for aws-properties-cognito-userpoolclient-tokenvalidityunits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
