### PR TITLE
Update aws-resource-fsx-filesystem.md

### DIFF
--- a/doc_source/aws-resource-fsx-filesystem.md
+++ b/doc_source/aws-resource-fsx-filesystem.md
@@ -91,7 +91,7 @@ For Lustre file systems:
 For Windows file systems:  
 + If `StorageType=SSD`, valid values are 32 GiB \- 65,536 GiB \(64 TiB\)\.
 + If `StorageType=HDD`, valid values are 2000 GiB \- 65,536 GiB \(64 TiB\)\.
-*Required*: No  
+*Required*: Yes  
 *Type*: Integer  
 *Minimum*: `0`  
 *Maximum*: `2147483647`  


### PR DESCRIPTION
StorageCapacity is required, will throw error like below without it.

```
1 validation error detected: Value null at 'storageCapacity' failed to satisfy constraint: Member must not be null (Service: AmazonFSx; Status Code: 400; Error Code: BadRequest; Request ID: 852ac170-3486-4cba-9b91-8e029d7359fc; Proxy: null)
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
