### PR TITLE
Update aws-properties-autoscaling-launchconfig-metadataoption.md

### DIFF
--- a/doc_source/aws-properties-autoscaling-launchconfig-metadataoption.md
+++ b/doc_source/aws-properties-autoscaling-launchconfig-metadataoption.md
@@ -1,34 +1,34 @@
-# AWS::AutoScaling::LaunchConfiguration MetadataOption<a name="aws-properties-autoscaling-launchconfig-metadataoption"></a>
+# AWS::AutoScaling::LaunchConfiguration MetadataOptions<a name="aws-properties-autoscaling-launchconfig-metadataoptions"></a>
 
- `MetadataOption` is a property of [AWS::AutoScaling::LaunchConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html) that describes metadata options for the instances\.
+ `MetadataOptions` is a property of [AWS::AutoScaling::LaunchConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html) that describes metadata options for the instances\.
 
 For more information, see [Configuring the Instance Metadata Options](https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-launch-config.html#launch-configurations-imds) in the *Amazon EC2 Auto Scaling User Guide*\.
 
-## Syntax<a name="aws-properties-autoscaling-launchconfig-metadataoption-syntax"></a>
+## Syntax<a name="aws-properties-autoscaling-launchconfig-metadataoptions-syntax"></a>
 
 To declare this entity in your AWS CloudFormation template, use the following syntax:
 
-### JSON<a name="aws-properties-autoscaling-launchconfig-metadataoption-syntax.json"></a>
+### JSON<a name="aws-properties-autoscaling-launchconfig-metadataoptions-syntax.json"></a>
 
 ```
 {
-  "[HttpEndpoint](#cfn-autoscaling-launchconfig-metadataoption-httpendpoint)" : String,
-  "[HttpPutResponseHopLimit](#cfn-autoscaling-launchconfig-metadataoption-httpputresponsehoplimit)" : Integer,
-  "[HttpTokens](#cfn-autoscaling-launchconfig-metadataoption-httptokens)" : String
+  "[HttpEndpoint](#cfn-autoscaling-launchconfig-metadataoptions-httpendpoint)" : String,
+  "[HttpPutResponseHopLimit](#cfn-autoscaling-launchconfig-metadataoptions-httpputresponsehoplimit)" : Integer,
+  "[HttpTokens](#cfn-autoscaling-launchconfig-metadataoptions-httptokens)" : String
 }
 ```
 
-### YAML<a name="aws-properties-autoscaling-launchconfig-metadataoption-syntax.yaml"></a>
+### YAML<a name="aws-properties-autoscaling-launchconfig-metadataoptions-syntax.yaml"></a>
 
 ```
-  [HttpEndpoint](#cfn-autoscaling-launchconfig-metadataoption-httpendpoint): String
-  [HttpPutResponseHopLimit](#cfn-autoscaling-launchconfig-metadataoption-httpputresponsehoplimit): Integer
-  [HttpTokens](#cfn-autoscaling-launchconfig-metadataoption-httptokens): String
+  [HttpEndpoint](#cfn-autoscaling-launchconfig-metadataoptions-httpendpoint): String
+  [HttpPutResponseHopLimit](#cfn-autoscaling-launchconfig-metadataoptions-httpputresponsehoplimit): Integer
+  [HttpTokens](#cfn-autoscaling-launchconfig-metadataoptions-httptokens): String
 ```
 
-## Properties<a name="aws-properties-autoscaling-launchconfig-metadataoption-properties"></a>
+## Properties<a name="aws-properties-autoscaling-launchconfig-metadataoptions-properties"></a>
 
-`HttpEndpoint`  <a name="cfn-autoscaling-launchconfig-metadataoption-httpendpoint"></a>
+`HttpEndpoint`  <a name="cfn-autoscaling-launchconfig-metadataoptions-httpendpoint"></a>
 This parameter enables or disables the HTTP metadata endpoint on your instances\. If the parameter is not specified, the default state is `enabled`\.  
 If you specify a value of `disabled`, you will not be able to access your instance metadata\. 
 *Required*: No  
@@ -36,7 +36,7 @@ If you specify a value of `disabled`, you will not be able to access your instan
 *Allowed values*: `disabled | enabled`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
-`HttpPutResponseHopLimit`  <a name="cfn-autoscaling-launchconfig-metadataoption-httpputresponsehoplimit"></a>
+`HttpPutResponseHopLimit`  <a name="cfn-autoscaling-launchconfig-metadataoptions-httpputresponsehoplimit"></a>
 The desired HTTP PUT response hop limit for instance metadata requests\. The larger the number, the further instance metadata requests can travel\.  
 Default: 1  
 Possible values: Integers from 1 to 64  
@@ -46,7 +46,7 @@ Possible values: Integers from 1 to 64
 *Maximum*: `64`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
-`HttpTokens`  <a name="cfn-autoscaling-launchconfig-metadataoption-httptokens"></a>
+`HttpTokens`  <a name="cfn-autoscaling-launchconfig-metadataoptions-httptokens"></a>
 The state of token usage for your instance metadata requests\. If the parameter is not specified in the request, the default state is `optional`\.  
 If the state is `optional`, you can choose to retrieve instance metadata with or without a signed token header on your request\. If you retrieve the IAM role credentials without a token, the version 1\.0 role credentials are returned\. If you retrieve the IAM role credentials using a valid signed token, the version 2\.0 role credentials are returned\.  
 If the state is `required`, you must send a signed token header with any instance metadata retrieval requests\. In this state, retrieving the IAM role credentials always returns the version 2\.0 credentials; the version 1\.0 credentials are not available\.  


### PR DESCRIPTION
Fixed documentation to state the correct implementation where it uses MetadataOptions and not MetadataOption. Similar to: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html

*Issue #, if available:*

*Description of changes:*
Added 's' to MetadataOption throughout the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
