### PR TITLE
Fix typo in aws-resource-dynamodb-table.md

### DIFF
--- a/doc_source/aws-resource-dynamodb-table.md
+++ b/doc_source/aws-resource-dynamodb-table.md
@@ -105,7 +105,7 @@ Local secondary indexes to be created on the table\. You can create up to 5 loca
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `PointInTimeRecoverySpecification`  <a name="cfn-dynamodb-table-pointintimerecoveryspecification"></a>
-The settings used to enable point in time recover\.  
+The settings used to enable point in time recovery\.  
 *Required*: No  
 *Type*: [PointInTimeRecoverySpecification](aws-properties-dynamodb-table-pointintimerecoveryspecification.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
Under `PointInTimeRecoverySpecification`, change:
>The settings used to enable point in time recover.
to:
>The settings used to enable point in time recovery.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
