### PR TITLE
Add missing requirement for SNS FIFO topic name

### DIFF
--- a/doc_source/aws-properties-sns-topic.md
+++ b/doc_source/aws-properties-sns-topic.md
@@ -87,9 +87,9 @@ To be able to tag a topic on creation, you must have the `sns:CreateTopic` and `
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `TopicName`  <a name="cfn-sns-topic-topicname"></a>
-The name of the topic you want to create\. Topic names must include only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long\.  
+The name of the topic you want to create\. Topic names must include only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long\. FIFO topic names must end with `.fifo`\.  
 If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the topic name\. For more information, see [Name Type](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-name.html)\.  
-If you specify a name, you can't perform updates that require replacement of this resource\. You can perform updates that require no or some interruption\. If you must replace the resource, specify a new name\.
+If you specify a name, you can't perform updates that require replacement of this resource\. You can perform updates that require no or some interruption\. If you must replace the resource, specify a new name\.  
 *Required*: No  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
*Description of changes:*

Added important information about required `.fifo` suffix for Simple Notification Service FIFO topic names.
An attempt to create FIFO topic according to the rules currently described in user guide (suffix is not mentioned) causes `InvalidParameterException` with undescriptive message `Invalid parameter: Topic Name`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
