### PR TITLE
Add SignInWithApple to SupportedIdentityProviders

### DIFF
--- a/doc_source/aws-resource-cognito-userpoolclient.md
+++ b/doc_source/aws-resource-cognito-userpoolclient.md
@@ -205,7 +205,7 @@ The time limit, in days, after which the refresh token is no longer valid and ca
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `SupportedIdentityProviders`  <a name="cfn-cognito-userpoolclient-supportedidentityproviders"></a>
-A list of provider names for the identity providers that are supported on this client\. The following are supported: `COGNITO`, `Facebook`, `Google` and `LoginWithAmazon`\.  
+A list of provider names for the identity providers that are supported on this client\. The following are supported: `COGNITO`, `Facebook`, `Google`, `SignInWithApple` and `LoginWithAmazon`\.  
 *Required*: No  
 *Type*: List of String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
SupportedIdentityProviders is missing SignInWithApple provider option


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
