### PR TITLE
Update the required property from No to Yes for the Metric name of the CloudWatch Alarm Metric

### DIFF
--- a/doc_source/aws-properties-cloudwatch-alarm-metric.md
+++ b/doc_source/aws-properties-cloudwatch-alarm-metric.md
@@ -36,7 +36,7 @@ The metric dimensions that you want to be used for the metric that the alarm wil
 
 `MetricName`  <a name="cfn-cloudwatch-alarm-metric-metricname"></a>
 The name of the metric that you want the alarm to watch\. This is a required field\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Minimum*: `1`  
 *Maximum*: `255`  


### PR DESCRIPTION
Metric name is a required field but the Required property incorrectly displayed as No rather than Yes

*Issue #, if available:*
None raised

*Description of changes:*
Change the required property of the MetricName to Yes rather than No

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
