### PR TITLE
ArchiveName is not a valid property

### DIFF
--- a/doc_source/aws-resource-events-archive.md
+++ b/doc_source/aws-resource-events-archive.md
@@ -90,7 +90,6 @@ The following example creates an archive for all EC2 events sent from the defaul
   "SampleArchive": 
     "Type" : "AWS::Events::Archive",
     "Properties" : {
-        "ArchiveName" : "MyArchive",
         "Description" : "Archive for all EC2 events",
         "EventPattern" : {
               "source": [
@@ -109,7 +108,6 @@ The following example creates an archive for all EC2 events sent from the defaul
 SampleArchive:
   Type: 'AWS::Events::Archive'
   Properties: 
-    ArchiveName: MyArchive
     Description: Archive for all EC2 events
     EventPattern:
       source:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While copying the sample I notices that the sample included an `ArchiveName`, but the properties section does not mention the `ArchiveName` property and `cfn-lint` also complains about it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
