### PR TITLE
Add Elasticsearch CustomEndpoint options

### DIFF
--- a/doc_source/aws-properties-elasticsearch-domain-domainendpointoptions.md
+++ b/doc_source/aws-properties-elasticsearch-domain-domainendpointoptions.md
@@ -37,3 +37,21 @@ The minimum TLS version required for traffic to the domain\. Valid values are TL
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+`CustomEndpointEnabled`  <a name="cfn-elasticsearch-domain-domainendpointoptions-customendpointenabled"></a>
+Whether to enable a custom endpoint for the domain\.  
+*Required*: No  
+*Type*: Boolean  
+*Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+`CustomEndpoint`  <a name="cfn-elasticsearch-domain-domainendpointoptions-customendpoint"></a>
+The fully qualified URL for the custom endpoint\.  
+*Required*: Required if `CustomEndpointEnabled` is `true`, optional otherwise\.  
+*Type*: String  
+*Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+`CustomEndpointCertificateArn`  <a name="cfn-elasticsearch-domain-domainendpointoptions-customendpointcertificatearn"></a>
+The ARN for your security certificate, managed in ACM\.  
+*Required*: Required if `CustomEndpointEnabled` is `true`, optional otherwise\.  
+*Type*: String  
+*Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Description of changes:*

Adds new properties for AWS::Elasticsearch::Domain DomainEndpointOptions to configure custom endpoints

See:

- [Creating a Custom Endpoint](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-customendpoint.html)
- [Amazon Elasticsearch Service Configuration API Reference](https://github.com/awsdocs/amazon-elasticsearch-service-developer-guide/blob/master/doc_source/es-configuration-api.md#domainendpointoptions)

Wording is taken from the [Amazon Elasticsearch Service Configuration API Reference](https://github.com/awsdocs/amazon-elasticsearch-service-developer-guide/blob/master/doc_source/es-configuration-api.md#domainendpointoptions).
Settings are verified to be working in CloudFormation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
