### PR TITLE
Correct schema used in uri field

### DIFF
--- a/doc_source/aws-resource-authentication.md
+++ b/doc_source/aws-resource-authentication.md
@@ -218,7 +218,7 @@ The following example template snippet includes both *basic* and *S3* authentica
       "type" : "basic",
       "username" : { "Ref" : "UserName" },
       "password" : { "Ref" : "Password" },
-      "uris" : [ "http://www.example.com/test" ]
+      "uris" : [ "example.com/test" ]
    },
    "testS3" : {
       "type" : "S3",
@@ -240,7 +240,7 @@ AWS::CloudFormation::Authentication:
     password: 
       Ref: "Password"
     uris: 
-      - "http://www.example.com/test"
+      - "example.com/test"
   testS3: 
     type: "S3"
     accessKeyId: 


### PR DESCRIPTION
cfn-init performs a comparison against schemaless URIs, so these examples do not work as written.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
