### PR TITLE
Fixed typo in example YAML code of AWS::S3::Bucket ServerSideEncryptionRule

### DIFF
--- a/doc_source/aws-properties-s3-bucket-serversideencryptionrule.md
+++ b/doc_source/aws-properties-s3-bucket-serversideencryptionrule.md
@@ -142,6 +142,6 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: 'aws:kms'
               KMSMasterKeyID: KMS-KEY-ARN
-          - BucketKeyEnabled: true
+            BucketKeyEnabled: true
     DeletionPolicy: Delete
 ```


### PR DESCRIPTION
Removed incorrect dash in front of BucketKeyEnabled: true.
