### PR TITLE
Update aws-resource-elasticloadbalancingv2-listener.md

### DIFF
--- a/doc_source/aws-resource-elasticloadbalancingv2-listener.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-listener.md
@@ -121,7 +121,7 @@ HTTPlistener:
        - Type: "redirect"
          RedirectConfig:
            Protocol: "HTTPS"
-           Port: "443"
+           Port: 443
            Host: "#{host}"
            Path: "/#{path}"
            Query: "#{query}"


### PR DESCRIPTION
The example code causes an error due to the value's type mismatch.
The type of the `Port` value is "Integer" instead of "String".

*Issue #, if available:*
I haven't checked the issue # since it's just a kind of typo.

*Description of changes:*
The type of the `Port` value is Integer instead of String. The integer value should not be surrounded by quotations in YAML.
I've removed the double quotations (") around the `443`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
