### PR TITLE
Update aws-properties-s3-websiteconfiguration.md

### DIFF
--- a/doc_source/aws-properties-s3-websiteconfiguration.md
+++ b/doc_source/aws-properties-s3-websiteconfiguration.md
@@ -38,7 +38,7 @@ The name of the error document for the website\.
 
 `IndexDocument`  <a name="cfn-s3-websiteconfiguration-indexdocument"></a>
 The name of the index document for the website\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
*Issue #, if available:* 
If the resources AWS::S3::Bucket WebsiteConfiguration is defined without IndexDocument propert the stack will fail with the error below.

> S3Bucket CREATE_FAILED Property IndexDocument cannot be empty

*Description of changes:*
The IndexDocument should be set to required yes.

The following S3 documentation seem to suggest that as well:
https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html
https://docs.aws.amazon.com/AmazonS3/latest/dev/EnableWebsiteHosting.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
