### PR TITLE
Update CONTRIBUTING.md to refer to the correct default branch (main)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,13 +25,13 @@ We look forward to receiving your pull requests for:
 To contribute, send us a pull request. For small changes, such as fixing a typo or adding a link, you can use the [GitHub Edit Button](https://blog.github.com/2011-04-26-forking-with-the-edit-button/). For larger changes:
 
 1. [Fork the repository](https://help.github.com/articles/fork-a-repo/).
-2. In your fork, make your change in a branch that's based on this repo's **master** branch.
+2. In your fork, make your change in a branch that's based on this repo's **main** branch.
 3. Commit the change to your fork, using a clear and descriptive commit message.
 4. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/), answering any questions in the pull request form.
 
 Before you send us a pull request, please be sure that:
 
-1. You're working from the latest source on the **master** branch.
+1. You're working from the latest source on the **main** branch.
 2. You check [existing open](https://github.com/awsdocs/aws-cloudformation-user-guide/pulls), and [recently closed](https://github.com/awsdocs/aws-cloudformation-user-guide/pulls?q=is%3Apr+is%3Aclosed), pull requests to be sure that someone else hasn't already addressed the problem.
 3. You [create an issue](https://github.com/awsdocs/aws-cloudformation-user-guide/issues/new) before working on a contribution that will take a significant amount of your time.
 
@@ -53,4 +53,4 @@ If you discover a potential security issue, please notify AWS Security via our [
 
 ## Licensing
 
-See the [LICENSE](https://github.com/awsdocs/aws-cloudformation-user-guide/blob/master/LICENSE) file for this project's licensing. We will ask you to confirm the licensing of your contribution. We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.
+See the [LICENSE](https://github.com/awsdocs/aws-cloudformation-user-guide/blob/main/LICENSE) file for this project's licensing. We will ask you to confirm the licensing of your contribution. We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.


### PR DESCRIPTION
*Description of changes:*

I noticed CONTRIBUTING.md was still referring to master instead of main, as I believe main is now the default branch for this repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
