### PR TITLE
Update 'MaxRetries' type

### DIFF
--- a/doc_source/aws-resource-glue-job.md
+++ b/doc_source/aws-resource-glue-job.md
@@ -21,7 +21,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
       "[GlueVersion](#cfn-glue-job-glueversion)" : String,
       "[LogUri](#cfn-glue-job-loguri)" : String,
       "[MaxCapacity](#cfn-glue-job-maxcapacity)" : Double,
-      "[MaxRetries](#cfn-glue-job-maxretries)" : Double,
+      "[MaxRetries](#cfn-glue-job-maxretries)" : Integer,
       "[Name](#cfn-glue-job-name)" : String,
       "[NotificationProperty](#cfn-glue-job-notificationproperty)" : NotificationProperty,
       "[NumberOfWorkers](#cfn-glue-job-numberofworkers)" : Integer,
@@ -51,7 +51,7 @@ Properties:
   [GlueVersion](#cfn-glue-job-glueversion): String
   [LogUri](#cfn-glue-job-loguri): String
   [MaxCapacity](#cfn-glue-job-maxcapacity): Double
-  [MaxRetries](#cfn-glue-job-maxretries): Double
+  [MaxRetries](#cfn-glue-job-maxretries): Integer
   [Name](#cfn-glue-job-name): String
   [NotificationProperty](#cfn-glue-job-notificationproperty): 
     NotificationProperty
@@ -131,7 +131,7 @@ The value that can be allocated for `MaxCapacity` depends on whether you are run
 `MaxRetries`  <a name="cfn-glue-job-maxretries"></a>
 The maximum number of times to retry this job after a JobRun fails\.  
 *Required*: No  
-*Type*: Double  
+*Type*: Integer  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Name`  <a name="cfn-glue-job-name"></a>


### PR DESCRIPTION
AWS [Glue Job documentation](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-job.html#aws-glue-api-jobs-job-Job) states that expected type for field 'MaxRetries' is `Integer`, and not `Double`. When passing a `Double` value, CloudFormation stack creation fails with an `Internal Failure` error. This proposal fixes it.

*Description of changes:*
Fixes wrong property type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
