### PR TITLE
Update 'MaxConcurrentRuns' type

### DIFF
--- a/doc_source/aws-properties-glue-job-executionproperty.md
+++ b/doc_source/aws-properties-glue-job-executionproperty.md
@@ -10,14 +10,14 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 ```
 {
-  "[MaxConcurrentRuns](#cfn-glue-job-executionproperty-maxconcurrentruns)" : Double
+  "[MaxConcurrentRuns](#cfn-glue-job-executionproperty-maxconcurrentruns)" : Integer
 }
 ```
 
 ### YAML<a name="aws-properties-glue-job-executionproperty-syntax.yaml"></a>
 
 ```
-  [MaxConcurrentRuns](#cfn-glue-job-executionproperty-maxconcurrentruns): Double
+  [MaxConcurrentRuns](#cfn-glue-job-executionproperty-maxconcurrentruns): Integer
 ```
 
 ## Properties<a name="aws-properties-glue-job-executionproperty-properties"></a>
@@ -25,5 +25,5 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 `MaxConcurrentRuns`  <a name="cfn-glue-job-executionproperty-maxconcurrentruns"></a>
 The maximum number of concurrent runs allowed for the job\. The default is 1\. An error is returned when this threshold is reached\. The maximum value you can specify is controlled by a service limit\.  
 *Required*: No  
-*Type*: Double  
+*Type*: Integer  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
AWS Glue [ExecutionProperty documentation](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-job.html#aws-glue-api-jobs-job-ExecutionProperty) states that expected type for field 'MaxConcurrentRuns' is `Integer`, and not `Double`. When passing a `Double` value, CloudFormation stack creation fails with an `Internal Failure` error. This proposal fixes it.

*Description of changes:*
Fixes wrong property type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
