### PR TITLE
Increment JobCommand documentation

### DIFF
--- a/doc_source/aws-properties-glue-job-jobcommand.md
+++ b/doc_source/aws-properties-glue-job-jobcommand.md
@@ -1,6 +1,6 @@
 # AWS::Glue::Job JobCommand<a name="aws-properties-glue-job-jobcommand"></a>
 
-Specifies code executed when a job is run\.
+Specifies code executed when a job is run\. For more information, see [Job Command Structure](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-job.html#aws-glue-api-jobs-job-JobCommand) in the AWS Glue Developer Guide.
 
 ## Syntax<a name="aws-properties-glue-job-jobcommand-syntax"></a>
 
@@ -39,7 +39,7 @@ The Python version being used to execute a Python shell job\. Allowed values are
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `ScriptLocation`  <a name="cfn-glue-job-jobcommand-scriptlocation"></a>
-Specifies the Amazon Simple Storage Service \(Amazon S3\) path to a script that executes a job \(required\)\.  
+Specifies the Amazon Simple Storage Service \(Amazon S3\) path to a script that executes a job \(required when `Name` is `glueetl`\)\.  
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
This change proposal adds a link to Job Command structure documentation on AWS Glue Developer Guide, to guide users to service updated documentation.

It also ensures `ScriptLocation` property clearly indicates when it is required. When declaring`Name:  glueetl` without `ScriptLocation`, CloudFormation stack fails with this error:

```
Script location cannot be null or empty for glueetl command (Service: AWSGlue; Status Code: 400; Error Code: InvalidInputException; Request ID: ...)
```

*Description of changes:*
Updates CloudFormation resource documentation to match service documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
