### PR TITLE
Updated SecurityGroupIds description.

### DIFF
--- a/doc_source/aws-properties-transfer-server-endpointdetails.md
+++ b/doc_source/aws-properties-transfer-server-endpointdetails.md
@@ -45,7 +45,7 @@ This property can only be set when `EndpointType` is set to `VPC`\.
 
 `SecurityGroupIds`  <a name="cfn-transfer-server-endpointdetails-securitygroupids"></a>
 A list of security groups IDs that are available to attach to your server's endpoint\.  
-This property can only be set when `EndpointType` is set to `VPC`\.
+This property can only be set when `EndpointType` is set to `VPC`\. Maximum number of security groups that can be set is 5.
 *Required*: No  
 *Type*: List of String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
There is a limit for SecurityGroupIds for this resource, the limit is 5. This has been verified with test deployment but it is not documented anywhere.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
