### PR TITLE
Update aws-resource-networkfirewall-rulegroup.md

### DIFF
--- a/doc_source/aws-resource-networkfirewall-rulegroup.md
+++ b/doc_source/aws-resource-networkfirewall-rulegroup.md
@@ -192,17 +192,13 @@ The following shows example stateless rule group specifications\.
                                     ],
                                     "SourcePorts": [
                                         {
-                                            "FromPort": 15000
-                                        },
-                                        {
+                                            "FromPort": 15000,
                                             "ToPort": 30000
                                         }
                                     ],
                                     "DestinationPorts": [
                                         {
-                                            "FromPort": 443
-                                        },
-                                        {
+                                            "FromPort": 443,
                                             "ToPort": 443
                                         }
                                     ],
@@ -252,10 +248,10 @@ SampleStatelessRulegroup:
                       - AddressDefinition: 10.0.0.0/8
                     SourcePorts:
                       - FromPort: 15000
-                      - ToPort: 30000
+                        ToPort: 30000
                     DestinationPorts:
                       - FromPort: 443
-                      - ToPort: 443
+                        ToPort: 443
                     Protocols:
                       - 6
                   Actions:


### PR DESCRIPTION
Based on document [1], I believe DestinationPorts and SourcePosrts should be List of PortRange. I believe there should one '-' in the port range. So corrected the same in the sample template for both JSON and YAML format

Current sample template failed with validation error. 


 https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-networkfirewall-rulegroup-portrange.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
