### PR TITLE
Update aws-resource-cloudtrail-trail.md

### DIFF
--- a/doc_source/aws-resource-cloudtrail-trail.md
+++ b/doc_source/aws-resource-cloudtrail-trail.md
@@ -309,6 +309,7 @@ The following example creates a trail that logs events in all regions, an Amazon
                 },
                 "IsLogging": true,
                 "IsMultiRegionTrail": true
+                "IncludeGlobalServiceEvents": true
             }
         }
     }
@@ -394,4 +395,5 @@ The following example creates a trail that logs events in all regions, an Amazon
             - TopicName
         IsLogging: true
         IsMultiRegionTrail: true
+        IncludeGlobalServiceEvents: true
 ```


### PR DESCRIPTION
*Description of changes:*
Fixed the example stack by adding IncludeGlobalServiceEvents to True, a Multi-region trail will fail to deploy if that is not enabled hence the stack does currently not work if deployed as in the documentation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
