### PR TITLE
Fix links

### DIFF
--- a/doc_source/aws-resource-glue-devendpoint.md
+++ b/doc_source/aws-resource-glue-devendpoint.md
@@ -1,6 +1,6 @@
 # AWS::Glue::DevEndpoint<a name="aws-resource-glue-devendpoint"></a>
 
-The `AWS::Glue::DevEndpoint` resource specifies a development endpoint where a developer can remotely debug ETL scripts for AWS Glue\. For more information, see [DevEndpoint Structure](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-dev-endpoint.html#aws-glue-api-jobs-dev-endpoint-DevEndpoint) in the AWS Glue Developer Guide\.
+The `AWS::Glue::DevEndpoint` resource specifies a development endpoint where a developer can remotely debug ETL scripts for AWS Glue\. For more information, see [DevEndpoint Structure](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-dev-endpoint.html#aws-glue-api-jobs-dev-endpoint-DevEndpoint) in the AWS Glue Developer Guide\.
 
 ## Syntax<a name="aws-resource-glue-devendpoint-syntax"></a>
 
@@ -172,5 +172,5 @@ Known issue: when a development endpoint is created with the `G.2X` `WorkerType`
 For more information about using the `Ref` function, see [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html)\.
 
 ## See also<a name="aws-resource-glue-devendpoint--seealso"></a>
-+  [DevEndpoint Structure](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-dev-endpoint.html#aws-glue-api-jobs-dev-endpoint-DevEndpoint) in the *AWS Glue Developer Guide* 
++  [DevEndpoint Structure](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-dev-endpoint.html#aws-glue-api-jobs-dev-endpoint-DevEndpoint) in the *AWS Glue Developer Guide* 
 


### PR DESCRIPTION
The existing links are wrong and just take you to the general page for AWS Glue.

*Issue #, if available:*
None that I know of

*Description of changes:*
Remove 'jobs-' from the link to make it work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
