### PR TITLE
Keyword requires "sid:*" pattern

### DIFF
--- a/doc_source/aws-properties-networkfirewall-rulegroup-ruleoption.md
+++ b/doc_source/aws-properties-networkfirewall-rulegroup-ruleoption.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 *Type*: String  
 *Minimum*: `1`  
 *Maximum*: `128`  
-*Pattern*: `.*`  
+*Pattern*: `sid:*`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Settings`  <a name="cfn-networkfirewall-rulegroup-ruleoption-settings"></a>


### PR DESCRIPTION
When deployed with .* pattern (.test), received the following error:
stateful rule is invalid, rule: pass tcp 10.0.0.0/24 10 <> 10.0.1.0/24 1000 (.test; gid:123;), reason: sid not assigned (Service: NetworkFirewall, Status Code: 400)

When deployed with sid:1, the deployment was successful.

Please verify and update documentation accordingly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
