### PR TITLE
fixed incorrect FileSystemPolicy principal

### DIFF
--- a/doc_source/aws-resource-efs-filesystem.md
+++ b/doc_source/aws-resource-efs-filesystem.md
@@ -392,7 +392,8 @@ Resources:
           - Effect: "Allow"
             Action:
               - "elasticfilesystem:ClientMount"
-            Principal:'arn:aws:iam::111122223333:root'
+            Principal: 
+              AWS: 'arn:aws:iam::111122223333:root'
       KmsKeyId: !GetAtt 
         - key
         - Arn


### PR DESCRIPTION
The file system policy was incorrect and needed "AWS:" added to it. Otherwise this creates a 400 error when you try to execute the cloudformation.

*Issue #, if available:*

*Description of changes:* 

Fixes issue with incorrect Principal for FileSystemPolicy. The example policy needs to have "AWS:" to reference an account in AWS and will not work from a copy/paste perspective.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

I agree