### PR TITLE
fixed YAML formatting

### DIFF
--- a/doc_source/aws-resource-route53resolver-resolverrule.md
+++ b/doc_source/aws-resource-route53resolver-resolverrule.md
@@ -161,23 +161,23 @@ The following example creates an Amazon Route 53 outbound resolver rule\.
 #### YAML<a name="aws-resource-route53resolver-resolverrule--examples--Create_Resolver_rule--yaml"></a>
 
 ```
-Type : AWS::Route53Resolver::ResolverRule
-Properties : 
-  DomainName : example.com
-  Name : MyRule
-  ResolverEndpointId : rslvr-out-fdc049932dexample
-  RuleType : FORWARD 
-  Tags : 
+Type: AWS::Route53Resolver::ResolverRule
+Properties: 
+  DomainName: example.com
+  Name: MyRule
+  ResolverEndpointId: rslvr-out-fdc049932dexample
+  RuleType: FORWARD 
+  Tags: 
     - 
-      Key : LineOfBusiness
-      Value : Engineering
-  TargetIps :
+      Key: LineOfBusiness
+      Value: Engineering
+  TargetIps:
     - 
-      Ip : 192.0.2.6
-      Port : 53
+      Ip: 192.0.2.6
+      Port: 53
     -  
-      Ip : 192.0.2.99
-      Port : 53
+      Ip: 192.0.2.99
+      Port: 53
 ```
 
 ## See also<a name="aws-resource-route53resolver-resolverrule--seealso"></a>


### PR DESCRIPTION
Fixed unnecessary spacing for YAML configuration on page.

*Issue #, if available:*

*Description of changes:*
I fixed the additional spacing for the YAML configuration. This makes it more uniform with typical AWS Cloudformation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
