### PR TITLE
Update aws-resource-lambda-layerversionpermission.md

### DIFF
--- a/doc_source/aws-resource-lambda-layerversionpermission.md
+++ b/doc_source/aws-resource-lambda-layerversionpermission.md
@@ -2,6 +2,8 @@
 
 The `AWS::Lambda::LayerVersionPermission` resource adds permissions to the resource\-based policy of a version of an [AWS Lambda layer](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)\. Use this action to grant layer usage permission to other accounts\. You can grant permission to a single account, all AWS accounts, or all accounts in an organization\.
 
+**Important Note**: Since the release of the [UpdateReplacePolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html) both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/LayerPermissions from deletion\.
+
 ## Syntax<a name="aws-resource-lambda-layerversionpermission-syntax"></a>
 
 To declare this entity in your AWS CloudFormation template, use the following syntax:


### PR DESCRIPTION
This is not clear in the docs, but just received a case where this message came up -> [cfn-lint] W3011: Both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/LayerPermissions from deletion

Would be great to have it in the docs as well

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
