### PR TITLE
Use a HTTPS URL instead of HTTP one for the YAML spec Web site

### DIFF
--- a/doc_source/template-formats.md
+++ b/doc_source/template-formats.md
@@ -41,4 +41,4 @@ AWS CloudFormation supports the YAML Version 1\.1 specification with a few excep
 + The `binary`, `omap`, `pairs`, `set`, and `timestamp` tags
 + Aliases
 + Hash merges
-For more information about YAML, see [http://www\.yaml\.org](http://www.yaml.org)\.
+For more information about YAML, see [https://yaml\.org](https://yaml.org)\.


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
I noticed access to `http://www.yaml.org` gets `301 Moved Permanently` redirect to https://yaml.org. So this patch updates the URL in the document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
