### PR TITLE
ImageScanningConfiguration: extraneous key [scanOnPush] is not permitted

### DIFF
--- a/doc_source/aws-resource-ecr-repository.md
+++ b/doc_source/aws-resource-ecr-repository.md
@@ -270,7 +270,7 @@ MyRepository:
   Properties: 
     RepositoryName: "test-repository"
     ImageScanningConfiguration: 
-      scanOnPush: "true"
+      ScanOnPush: "true"
 ```
 
 ## See also<a name="aws-resource-ecr-repository--seealso"></a>


### PR DESCRIPTION
Updates scanOnPush to ScanOnPush, 
I was getting, 
“Stack operations on resource PrivateRepository would fail starting from 03/01/2021 as the template has invalid properties. Please refer to the resource documentation to fix the template. Properties validation failed for resource PrivateRepository with message: #/ImageScanningConfiguration: extraneous key [scanOnPush] is not permitted “

But updating it to ScanOnPush fixed the problem

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
