### PR TITLE
Added Example Code for Custom Event Bus for eventbuspolicy documentation

### DIFF
--- a/doc_source/aws-resource-events-eventbuspolicy.md
+++ b/doc_source/aws-resource-events-eventbuspolicy.md
@@ -229,3 +229,59 @@ SampleEventBusPolicy:
                 StringEquals:
                     "aws:PrincipalOrgID": "o-1234567890"
 ```
+
+### Grant Permission to an Organization using Custom Event Bus<a name="aws-resource-events-eventbuspolicy--examples--Grant_Permission_to_an_Organization_Custom_Bus"></a>
+
+The following example grants permission to all AWS accounts in the organization with an organization ID of `o-1234567890` using Custom Event Bus\.
+
+#### JSON<a name="aws-resource-events-eventbuspolicy--examples--Grant_Permission_to_an_Organization_Custom_Bus--json"></a>
+
+```
+"SampleCustomEventBus": {
+    "Type": "AWS::Events::EventBus",
+    "Properties": {
+        "Name": "MyCustomEventBus"
+    }
+}
+"SampleCustomEventBusPolicy": {
+    "Type": "AWS::Events::EventBusPolicy",
+    "Properties": {
+        "StatementId": "MyCustomEventBusStatement",
+        "Principal": {
+            "AWS": "*"
+        },
+        "Action": "events:PutEvents",
+        "EventBusName": {
+            "Ref": "SampleCustomEventBus"
+        },
+        "Condition": {
+            "Key": "aws:PrincipalOrgID",
+            "Type": "StringEquals",
+            "Value": "o-1234567890"
+        }
+    }
+}
+```
+
+#### YAML<a name="aws-resource-events-eventbuspolicy--examples--Grant_Permission_to_an_Organization_Custom_Bus--yaml"></a>
+
+```
+SampleCustomEventBus:
+    Type: AWS::Events::EventBus
+    Properties:
+        Name: "MyCustomEventBus"
+
+SampleCustomEventBusPolicy: 
+    Type: AWS::Events::EventBusPolicy
+    Properties: 
+        StatementId: "MyCustomEventBusStatement"
+        Principal: 
+             AWS: "*"
+        Action: "events:PutEvents"
+        EventBusName:
+            Ref: "SampleCustomEventBus"
+        Condition:
+            Key: 'aws:PrincipalOrgID'
+            Type: 'StringEquals'
+            Value: "o-1234567890"
+```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The examples in the section of  doc_source/aws-resource-events-eventbuspolicy.md only specifies if we are using default event bus. But if there is a custom event bus, these examples don’t help and even the syntax totally changes. Adding one example that allows all the accounts in organizations to send events to a custom event bus with the correct syntax

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
