### PR TITLE
docs: make Glue database name lowercase

### DIFF
--- a/doc_source/aws-resource-glue-crawler.md
+++ b/doc_source/aws-resource-glue-crawler.md
@@ -191,7 +191,7 @@ The following example creates a crawler for an Amazon S3 target\.
                     "Ref": "AWS::AccountId"
                 },
                 "DatabaseInput": {
-                    "Name": "dbCrawler",
+                    "Name": "dbcrawler",
                     "Description": "TestDatabaseDescription",
                     "LocationUri": "TestLocationUri",
                     "Parameters": {
@@ -292,7 +292,7 @@ Resources:
     Properties:
       CatalogId: !Ref AWS::AccountId
       DatabaseInput:
-        Name: "dbCrawler"
+        Name: "dbcrawler"
         Description: "TestDatabaseDescription"
         LocationUri: "TestLocationUri"
         Parameters:


### PR DESCRIPTION
Changed Glue database name to only include lower case letters as per:

"The only acceptable characters for database names, table names, and column names are lowercase letters, numbers, and the underscore character."

from https://docs.aws.amazon.com/athena/latest/ug/glue-best-practices.html
