### PR TITLE
Update aws-properties-codepipeline-pipeline-stages-actions.md

### DIFF
--- a/doc_source/aws-properties-codepipeline-pipeline-stages-actions.md
+++ b/doc_source/aws-properties-codepipeline-pipeline-stages-actions.md
@@ -59,7 +59,7 @@ The values can be represented in either JSON or YAML format\. For example, the J
 `InputArtifacts`  <a name="cfn-codepipeline-pipeline-stages-actions-inputartifacts"></a>
 The name or ID of the artifact consumed by the action, such as a test or build artifact\.  
 For a CodeBuild action with multiple input artifacts, one of your input sources must be designated the PrimarySource\. For more information, see the [CodeBuild action reference page](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodeBuild.html) in the *AWS CodePipeline User Guide*\.
-*Required*: No  
+*Required*: Yes  
 *Type*: List of [InputArtifact](aws-properties-codepipeline-pipeline-stages-actions-inputartifacts.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
Input Artifacts appears to be required. Omitting the InputArtificats property or setting its value to "[ ]" results in an exception in CloudFormation:

Action {NameOfAction} declares 0 input artifacts which is less than the minimum count (1) (Service: AWSCodePipeline; Status Code: 400; Error Code: InvalidActionDeclarationException; Request ID: 6dffc042-0a2f-44af-8e94-45dcf3e006ef; Proxy: null)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
