### PR TITLE
Fix typo of MySQL to PostgreSQL in examples

### DIFF
--- a/doc_source/aws-resource-rds-dbcluster.md
+++ b/doc_source/aws-resource-rds-dbcluster.md
@@ -609,7 +609,7 @@ The following example creates an Amazon Aurora PostgreSQL DB cluster that export
   "Parameters" : {
       "DBUsername" : {
         "NoEcho" : "true",
-        "Description" : "Username for MySQL database access",
+        "Description" : "Username for PostgreSQL database access",
 
         "Type" : "String",
         "MinLength" : "1",
@@ -619,7 +619,7 @@ The following example creates an Amazon Aurora PostgreSQL DB cluster that export
       },
       "DBPassword" : {
         "NoEcho" : "true",
-        "Description" : "Password MySQL database access",
+        "Description" : "Password PostgreSQL database access",
 
         "Type" : "String",
         "MinLength" : "8",
@@ -688,7 +688,7 @@ Description: >-
 Parameters:
   DBUsername:
     NoEcho: 'true'
-    Description: Username for MySQL database access
+    Description: Username for PostgreSQL database access
     Type: String
     MinLength: '1'
     MaxLength: '16'
@@ -696,7 +696,7 @@ Parameters:
     ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
   DBPassword:
     NoEcho: 'true'
-    Description: Password MySQL database access
+    Description: Password PostgreSQL database access
     Type: String
     MinLength: '8'
     MaxLength: '41'


### PR DESCRIPTION
*Description of changes:*
In the example "Creating an Amazon Aurora DB cluster that exports logs to Amazon CloudWatch Logs" an Amazon Aurora PostgreSQL DB cluster cloudformation template is presented. In both the respective JSON and YAML examples the parameter descriptions speak about MySQL and not PostgreSQL.

This commit fixes this typo and includes PostgreSQL within the parameter descriptions.

See:
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html or
- https://github.com/awsdocs/aws-cloudformation-user-guide/blob/main/doc_source/aws-resource-rds-dbcluster.md#creating-an-amazon-aurora-db-cluster-that-exports-logs-to-amazon-cloudwatch-logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
