### PR TITLE
Removed division column on RegularColumns.

### DIFF
--- a/doc_source/aws-resource-cassandra-table.md
+++ b/doc_source/aws-resource-cassandra-table.md
@@ -194,10 +194,6 @@ The following example creates a table with specific read and write capacity\.
             "ColumnType":"TEXT"
           },
           {
-            "ColumnName":"division",
-            "ColumnType":"TEXT"
-          },
-          {
             "ColumnName":"project",
             "ColumnType":"TEXT"
           },
@@ -254,8 +250,6 @@ Resources:
         ColumnType: TEXT
       - ColumnName: region
         ColumnType: TEXT
-      - ColumnName: division
-        ColumnType: TEXT
       - ColumnName: project
         ColumnType: TEXT
       - ColumnName: role
@@ -310,10 +304,6 @@ The following example creates a table with point\-in\-time enabled and with tags
                },
                {
                   "ColumnName": "region",
-                  "ColumnType": "TEXT"
-               },
-               {
-                  "ColumnName": "division",
                   "ColumnType": "TEXT"
                },
                {
@@ -376,8 +366,6 @@ Resources:
       - ColumnName: name
         ColumnType: TEXT
       - ColumnName: region
-        ColumnType: TEXT
-      - ColumnName: division
         ColumnType: TEXT
       - ColumnName: project
         ColumnType: TEXT


### PR DESCRIPTION
*Issue #, if available:*
As division column is created in ClusteringKeyColumns we cant create the division in RegularColumns if we run CFT with division being in both columns we get error and stack will destroy automatically.

*Description of changes:*
remove division in RegularColumns. So, I have updated the same please verify and approve. 

Thank you.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
