### PR TITLE
fix bad ARN format: account-id WAFv2Association

### DIFF
--- a/doc_source/aws-resource-wafv2-webaclassociation.md
+++ b/doc_source/aws-resource-wafv2-webaclassociation.md
@@ -38,7 +38,7 @@ Properties:
 The Amazon Resource Name \(ARN\) of the resource to associate with the web ACL\.   
 The ARN must be in one of the following formats:  
 + For an Application Load Balancer: `arn:aws:elasticloadbalancing:region:account-id:loadbalancer/app/load-balancer-name/load-balancer-id ` 
-+ For an Amazon API Gateway REST API: `arn:aws:apigateway:region::/restapis/api-id/stages/stage-name ` 
++ For an Amazon API Gateway REST API: `arn:aws:apigateway:region:account-id:/restapis/api-id/stages/stage-name ` 
 + For an AppSync GraphQL API: `arn:aws:appsync:region:account-id:apis/ GraphQLApiId`
 *Required*: Yes  
 *Type*: String  

--- a/doc_source/aws-resource-wafv2-webaclassociation.md
+++ b/doc_source/aws-resource-wafv2-webaclassociation.md
@@ -38,7 +38,7 @@ Properties:
 The Amazon Resource Name \(ARN\) of the resource to associate with the web ACL\.   
 The ARN must be in one of the following formats:  
 + For an Application Load Balancer: `arn:aws:elasticloadbalancing:region:account-id:loadbalancer/app/load-balancer-name/load-balancer-id ` 
-+ For an Amazon API Gateway REST API: `arn:aws:apigateway:region:account-id:/restapis/api-id/stages/stage-name ` 
++ For an Amazon API Gateway REST API: `arn:aws:apigateway:region:account-id:restapis/api-id/stages/stage-name ` 
 + For an AppSync GraphQL API: `arn:aws:appsync:region:account-id:apis/ GraphQLApiId`
 *Required*: Yes  
 *Type*: String  


### PR DESCRIPTION
*Issue #, if available:*

The docs for WAF v2 Association show a double colon `::` in the ARN example. This is incorrect - it requires the account-id in between those colon symbols. Just like the examples on the lines above and below.

*Description of changes:*

Adds `account-id` to incorrect example for API gateway usage of WAF v2 Association.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
