### PR TITLE
Updates Domain Validation documentation

### DIFF
--- a/doc_source/aws-resource-certificatemanager-certificate.md
+++ b/doc_source/aws-resource-certificatemanager-certificate.md
@@ -75,7 +75,9 @@ The fully qualified domain name \(FQDN\), such as www\.example\.com, with which 
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `DomainValidationOptions`  <a name="cfn-certificatemanager-certificate-domainvalidationoptions"></a>
-Domain information that domain name registrars use to verify your identity\.  
+Domain information that domain name registrars use to verify your identity\.
+**Important** 
+in order for a AWS::CertificateManager::Certificate to provisioned and validated in CloudFormation automatically, the `DomainName` property needs to be identical to one of the `DomainName` property supplied in DomainValidationOptions, if the ValidationMethod is **DNS**. Failing to keep them like-for-like will result in failure to create the domain validation records in Route53.
 *Required*: No  
 *Type*: List of [DomainValidationOption](aws-properties-certificatemanager-certificate-domainvalidationoption.md)  
 *Maximum*: `100`  

--- a/doc_source/aws-resource-certificatemanager-certificate.md
+++ b/doc_source/aws-resource-certificatemanager-certificate.md
@@ -77,7 +77,7 @@ The fully qualified domain name \(FQDN\), such as www\.example\.com, with which 
 `DomainValidationOptions`  <a name="cfn-certificatemanager-certificate-domainvalidationoptions"></a>
 Domain information that domain name registrars use to verify your identity\.
 **Important** 
-in order for a AWS::CertificateManager::Certificate to provisioned and validated in CloudFormation automatically, the `DomainName` property needs to be identical to one of the `DomainName` property supplied in DomainValidationOptions, if the ValidationMethod is **DNS**. Failing to keep them like-for-like will result in failure to create the domain validation records in Route53.
+in order for a AWS::CertificateManager::Certificate to be provisioned and validated in CloudFormation automatically, the `DomainName` property needs to be identical to one of the `DomainName` property supplied in DomainValidationOptions, if the ValidationMethod is **DNS**. Failing to keep them like-for-like will result in failure to create the domain validation records in Route53.
 *Required*: No  
 *Type*: List of [DomainValidationOption](aws-properties-certificatemanager-certificate-domainvalidationoption.md)  
 *Maximum*: `100`  


### PR DESCRIPTION
to reflect the fact that the DomainName in the validation has to be the same as the DomainName specified on the certificate. Failure to do so, causes CloudFormation to be stuck in `UPDATE IN PROGRESS` and not create the Route53 record, required to validate the ACM certificate creation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
