### PR TITLE
Fix requirement for Vcpus and Memory

### DIFF
--- a/doc_source/aws-properties-batch-jobdefinition-containerproperties.md
+++ b/doc_source/aws-properties-batch-jobdefinition-containerproperties.md
@@ -142,7 +142,7 @@ This parameter indicates the memory hard limit \(in MiB\) for a container\. If y
 This parameter maps to `Memory` in the [Create a container](https://docs.docker.com/engine/api/v1.23/#create-a-container) section of the [Docker Remote API](https://docs.docker.com/engine/api/v1.23/) and the `--memory` option to [docker run](https://docs.docker.com/engine/reference/run/)\.  
 This parameter is supported on EC2 resources but isn't supported on Fargate resources\. For Fargate resources, you should specify the memory requirement using `resourceRequirement`\. You can also do this for EC2 resources\.  
 If you're trying to maximize your resource utilization by providing your jobs as much memory as possible for a particular instance type, see [Memory Management](https://docs.aws.amazon.com/batch/latest/userguide/memory-management.html) in the *AWS Batch User Guide*\.
-*Required*: No  
+*Required*: Yes (for EC2 Platform), No (for Fargate)
 *Type*: Integer  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -200,7 +200,7 @@ The user name to use inside the container\. This parameter maps to `User` in the
 The number of vCPUs reserved for the job\. Each vCPU is equivalent to 1,024 CPU shares\. This parameter maps to `CpuShares` in the [Create a container](https://docs.docker.com/engine/api/v1.23/#create-a-container) section of the [Docker Remote API](https://docs.docker.com/engine/api/v1.23/) and the `--cpu-shares` option to [docker run](https://docs.docker.com/engine/reference/run/)\. The number of vCPUs must be specified but can be specified in several places\. You must specify it at least once for each node\.  
 This parameter is supported on EC2 resources but isn't supported for jobs that run on Fargate resources\. For these resources, use `resourceRequirement` instead\. You can use this parameter or `resourceRequirements` structure but not both\.  
 This parameter isn't applicable to jobs that are running on Fargate resources and shouldn't be provided\. For jobs that run on Fargate resources, you must specify the vCPU requirement for the job using `resourceRequirements`\.
-*Required*: No  
+*Required*: Yes (for EC2 Platform), No (for Fargate)
 *Type*: Integer  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
This patch is to clarify that the `Vcpus` and `Memory` fields in the JobDefinition's ContainerProperties are required for the EC2 platform, but not for Fargate.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
