### PR TITLE
Update Elasticesearch docs for MasterUserOptions options

### DIFF
--- a/doc_source/aws-properties-elasticsearch-domain-advancedsecurityoptionsinput.md
+++ b/doc_source/aws-properties-elasticsearch-domain-advancedsecurityoptionsinput.md
@@ -28,19 +28,19 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-elasticsearch-domain-advancedsecurityoptionsinput-properties"></a>
 
 `Enabled`  <a name="cfn-elasticsearch-domain-advancedsecurityoptionsinput-enabled"></a>
-True to enable fine\-grained access control\.  
+True to enable fine\-grained access control\.  You will need to enable Encyption to use this\. 
 *Required*: No  
 *Type*: Boolean  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `InternalUserDatabaseEnabled`  <a name="cfn-elasticsearch-domain-advancedsecurityoptionsinput-internaluserdatabaseenabled"></a>
-True to enable the internal user database\.  
+True to enable the internal user database\.  You will need to enable Encyption to use this\. 
 *Required*: No  
 *Type*: Boolean  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `MasterUserOptions`  <a name="cfn-elasticsearch-domain-advancedsecurityoptionsinput-masteruseroptions"></a>
-Specifies information about the master user\.  
+Specifies information about the master user\.  You will need to enable Encyption to use this\. 
 *Required*: No  
 *Type*: [MasterUserOptions](aws-properties-elasticsearch-domain-masteruseroptions.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/doc_source/aws-properties-elasticsearch-domain-advancedsecurityoptionsinput.md
+++ b/doc_source/aws-properties-elasticsearch-domain-advancedsecurityoptionsinput.md
@@ -28,19 +28,19 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-elasticsearch-domain-advancedsecurityoptionsinput-properties"></a>
 
 `Enabled`  <a name="cfn-elasticsearch-domain-advancedsecurityoptionsinput-enabled"></a>
-True to enable fine\-grained access control\.  You will need to enable Encryption to use this\. 
+True to enable fine\-grained access control\. You must also enable encryption of data at rest and node-to-node encryption\. 
 *Required*: No  
 *Type*: Boolean  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `InternalUserDatabaseEnabled`  <a name="cfn-elasticsearch-domain-advancedsecurityoptionsinput-internaluserdatabaseenabled"></a>
-True to enable the internal user database\.  You will need to enable Encryption to use this\. 
+True to enable the internal user database\. 
 *Required*: No  
 *Type*: Boolean  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `MasterUserOptions`  <a name="cfn-elasticsearch-domain-advancedsecurityoptionsinput-masteruseroptions"></a>
-Specifies information about the master user\.  You will need to enable Encryption to use this\. 
+Specifies information about the master user\.
 *Required*: No  
 *Type*: [MasterUserOptions](aws-properties-elasticsearch-domain-masteruseroptions.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/doc_source/aws-properties-elasticsearch-domain-advancedsecurityoptionsinput.md
+++ b/doc_source/aws-properties-elasticsearch-domain-advancedsecurityoptionsinput.md
@@ -28,19 +28,19 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-elasticsearch-domain-advancedsecurityoptionsinput-properties"></a>
 
 `Enabled`  <a name="cfn-elasticsearch-domain-advancedsecurityoptionsinput-enabled"></a>
-True to enable fine\-grained access control\.  You will need to enable Encyption to use this\. 
+True to enable fine\-grained access control\.  You will need to enable Encryption to use this\. 
 *Required*: No  
 *Type*: Boolean  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `InternalUserDatabaseEnabled`  <a name="cfn-elasticsearch-domain-advancedsecurityoptionsinput-internaluserdatabaseenabled"></a>
-True to enable the internal user database\.  You will need to enable Encyption to use this\. 
+True to enable the internal user database\.  You will need to enable Encryption to use this\. 
 *Required*: No  
 *Type*: Boolean  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `MasterUserOptions`  <a name="cfn-elasticsearch-domain-advancedsecurityoptionsinput-masteruseroptions"></a>
-Specifies information about the master user\.  You will need to enable Encyption to use this\. 
+Specifies information about the master user\.  You will need to enable Encryption to use this\. 
 *Required*: No  
 *Type*: [MasterUserOptions](aws-properties-elasticsearch-domain-masteruseroptions.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
you need to enable encryption to use MasterUserOptions, this adds the wording to the docs

*Issue #, if available:*

*Description of changes:*
To use the options under  "MasterUserOptions:, like "Enabled", "InternalUserDatabaseEnabled" and "MasterUserOptions", you will need to enable Encryption settings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
