### PR TITLE
Update aws-resource-efs-accesspoint.md

### DIFF
--- a/doc_source/aws-resource-efs-accesspoint.md
+++ b/doc_source/aws-resource-efs-accesspoint.md
@@ -61,7 +61,7 @@ The ID of the EFS file system that the access point applies to\.
 *Required*: Yes  
 *Type*: String  
 *Maximum*: `128`  
-*Pattern*: `^(arn:aws[-a-z]*:elasticfilesystem:[0-9a-z-:]+:file-system/fs-[0-9a-f]{8,40}|fs-[0-9a-f]{8,40})$`  
+*Pattern*: `fs-123456789`  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `PosixUser`  <a name="cfn-efs-accesspoint-posixuser"></a>


### PR DESCRIPTION
Customer is using ARN for the property `FileSystemId` which will return error message: 
`Resource handler returned message: "Invalid file system ID: arn:aws:elasticfilesystem:us-west-2:123456789:file-system/fs-123456789`

This is misleading and confusing. Please approve the pr to fix this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
