### PR TITLE
Fixed TaskInvocationParameters for Lambda task type

### DIFF
--- a/doc_source/aws-resource-ssm-maintenancewindowtask.md
+++ b/doc_source/aws-resource-ssm-maintenancewindowtask.md
@@ -692,7 +692,7 @@ Resources:
       ServiceRoleArn: Lambda.Arn
       TaskType: LAMBDA
       TaskInvocationParameters:
-        MaintenanceWindowAutomationParameters:
+        MaintenanceWindowLambdaParameters:
 			ClientContext": "ew0KICAi--truncated--0KIEXAMPLE"
 			Qualifier: '$LATEST'
 			Payload: '{ \"instanceId\": \"{{RESOURCE_ID}}\", \"targetType\": \"{{TARGET_TYPE}}\" }'


### PR DESCRIPTION
Changed MaintenanceWindowAutomationParameters to MaintenanceWindowLambdaParameters

*Issue #, if available:*

*Description of changes:*
This is a correction in example code for MaintenanceWindowTask for LAMBDA task type. The mistake is only present in the YAML version, the JSON is correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
