### PR TITLE
Replaced url.parse, returns promise

### DIFF
--- a/doc_source/cfn-lambda-function-code-cfnresponsemodule.md
+++ b/doc_source/cfn-lambda-function-code-cfnresponsemodule.md
@@ -121,54 +121,61 @@ The following is the response module source code for the Node\.js functions\. Re
 ```
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
- 
+
 exports.SUCCESS = "SUCCESS";
 exports.FAILED = "FAILED";
- 
-exports.send = function(event, context, responseStatus, responseData, physicalResourceId, noEcho) {
- 
-    var responseBody = JSON.stringify({
-        Status: responseStatus,
-        Reason: "See the details in CloudWatch Log Stream: " + context.logStreamName,
-        PhysicalResourceId: physicalResourceId || context.logStreamName,
-        StackId: event.StackId,
-        RequestId: event.RequestId,
-        LogicalResourceId: event.LogicalResourceId,
-        NoEcho: noEcho || false,
-        Data: responseData
-    });
- 
-    console.log("Response body:\n", responseBody);
- 
-    var https = require("https");
-    var url = require("url");
- 
-    var parsedUrl = url.parse(event.ResponseURL);
-    var options = {
-        hostname: parsedUrl.hostname,
-        port: 443,
-        path: parsedUrl.path,
-        method: "PUT",
-        headers: {
-            "content-type": "",
-            "content-length": responseBody.length
-        }
+
+exports.send = function (event, context, responseStatus, responseData, physicalResourceId, noEcho) {
+  try {
+    const https = require("https");
+    const { URL } = require("url");
+
+    const responseBody = {
+      Status: responseStatus,
+      Reason: "See the details in CloudWatch Log Stream: " + context.logStreamName,
+      PhysicalResourceId: physicalResourceId || context.logStreamName,
+      StackId: event.StackId,
+      RequestId: event.RequestId,
+      LogicalResourceId: event.LogicalResourceId,
+      NoEcho: noEcho || false,
+      Data: responseData,
     };
- 
-    var request = https.request(options, function(response) {
-        console.log("Status code: " + response.statusCode);
-        console.log("Status message: " + response.statusMessage);
-        context.done();
+    console.log("Response body:\n", JSON.stringify(responseBody));
+
+    const parsedUrl = new URL(event.ResponseURL);
+    const requestOptions = {
+      hostname: parsedUrl.hostname,
+      port: 443,
+      path: parsedUrl.pathname + parsedUrl.search,
+      method: "PUT",
+      headers: {
+        "content-type": "",
+        "content-length": JSON.stringify(responseBody).length,
+      },
+    };
+    console.log("Request options:\n", JSON.stringify(requestOptions));
+
+    return new Promise((resolve, reject) => {
+      const request = https.request(requestOptions, function (response) {
+        response.on("data", () => {});
+        response.on("end", () => {
+          console.log("Status code: ", response.statusCode);
+          console.log("Status message: ", response.statusMessage);
+          resolve("Success");
+        });
+      });
+      request.on("error", (e) => {
+        console.error(e);
+        reject("Error");
+      });
+      request.write(JSON.stringify(responseBody));
+      request.end();
     });
- 
-    request.on("error", function(error) {
-        console.log("send(..) failed executing https.request(..): " + error);
-        context.done();
-    });
- 
-    request.write(responseBody);
-    request.end();
-}
+  } catch (error) {
+    console.error("Error in cfn_response:\n", error);
+    return;
+  }
+};
 ```
 
 The following is the response module source code for Python 2 and 3 functions:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replaced url.parse since it is no longer recommended for use.
https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost

Supports async/await with returned promise.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
