### PR TITLE
Remove upper case DB Name that triggers cloud formation error

### DIFF
--- a/doc_source/aws-resource-glue-crawler.md
+++ b/doc_source/aws-resource-glue-crawler.md
@@ -191,7 +191,7 @@ The following example creates a crawler for an Amazon S3 target\.
                     "Ref": "AWS::AccountId"
                 },
                 "DatabaseInput": {
-                    "Name": "dbCrawler",
+                    "Name": "dbcrawler",
                     "Description": "TestDatabaseDescription",
                     "LocationUri": "TestLocationUri",
                     "Parameters": {
@@ -292,7 +292,7 @@ Resources:
     Properties:
       CatalogId: !Ref AWS::AccountId
       DatabaseInput:
-        Name: "dbCrawler"
+        Name: "dbcrawler"
         Description: "TestDatabaseDescription"
         LocationUri: "TestLocationUri"
         Parameters:


### PR DESCRIPTION
Customers that follow the current example will see the following error, generated by Cloud Formation: **"Database name [ dbCrawler ] must not contain uppercase characters"**. This error will abort stack creation process and initiate roll back.

This proposal changes the database name to all lower case. Following the change the CFN template will work without triggering errors (with exception of the globally unique name for S3 bucket).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
