### PR TITLE
@starpebble - correctly identify the Ref output for a MediaLive input

### DIFF
--- a/doc_source/aws-resource-medialive-input.md
+++ b/doc_source/aws-resource-medialive-input.md
@@ -117,7 +117,7 @@ Settings that apply only if the input is an push input where the source is on Am
 
 ### Ref<a name="aws-resource-medialive-input-return-values-ref"></a>
 
-When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the name of the input\.
+When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the MediaLive id of the input\.
 
 For example: `{ "Ref": "myInput" }`
 


### PR DESCRIPTION
*Description of changes:*

Correct the description of the Ref return value for an AWS::MediaLive::Input data type.  The description is misidentified as the "name of the input".  This is the problem.  The correct description is the "MediaLive id of the input".  I fix the problem for you.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


