### PR TITLE
Reformat the AppSync API cache example.

### DIFF
--- a/doc_source/aws-resource-appsync-apicache.md
+++ b/doc_source/aws-resource-appsync-apicache.md
@@ -104,18 +104,45 @@ The following example creates an ApiCache for your GraphQL API\.
 #### YAML<a name="aws-resource-appsync-apicache--examples--ApiCache_Creation_Example--yaml"></a>
 
 ```
-Parameters: graphQlApiId: Type: String Resources: ApiCache: Type:
-            'AWS::AppSync::ApiCache' Properties: ApiId: graphQlApiId Type: T2_SMALL
-            ApiCachingBehavior: FULL_REQUEST_CACHING Ttl: 1200 TransitEncryptionEnabled: true
-            AtRestEncryptionEnabled: true
+Parameters:
+  graphQlApiId:
+  Type: String
+
+Resources:
+  ApiCache:
+    Type: AWS::AppSync::ApiCache
+    Properties:
+      ApiId: !Ref graphQlApiId
+      Type: SMALL
+      ApiCachingBehavior: FULL_REQUEST_CACHING
+      Ttl: 1200
+      TransitEncryptionEnabled: true
+      AtRestEncryptionEnabled: true
 ```
 
 #### JSON<a name="aws-resource-appsync-apicache--examples--ApiCache_Creation_Example--json"></a>
 
 ```
-{ "Parameters": { "graphQlApiId": { "Type": "String" } },
-            "Resources": { "ApiCache": { "Type": "AWS::AppSync::ApiCache", "Properties": { "ApiId":
-            "graphQlApiId", "Type": "T2_SMALL", "ApiCachingBehavior": "FULL_REQUEST_CACHING", "Ttl":
-            1200, "TransitEncryptionEnabled": true, "AtRestEncryptionEnabled": true } } }
-            }
+{
+  "Parameters": {
+    "graphQlApiId": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "ApiCache": {
+      "Type": "AWS::AppSync::ApiCache",
+      "Properties": {
+        "ApiId": {
+          "Ref": "graphQlApiId"
+        },
+        "Type": "SMALL",
+        "ApiCachingBehavior": "FULL_REQUEST_CACHING",
+        "Ttl": 1200,
+        "TransitEncryptionEnabled": true,
+        "AtRestEncryptionEnabled": true
+      }
+    }
+  }
+}
 ```

--- a/doc_source/aws-resource-appsync-apicache.md
+++ b/doc_source/aws-resource-appsync-apicache.md
@@ -106,7 +106,7 @@ The following example creates an ApiCache for your GraphQL API\.
 ```
 Parameters:
   graphQlApiId:
-  Type: String
+    Type: String
 
 Resources:
   ApiCache:


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
- Made the examples readable for both Yaml and JSON
- Corrected missing "Ref" for the reference to the example parameter "graphQlApiId"
- Corrected reference to T2_SMALL in the example.  Should not recommend against using the EC2-styled cache types in the property description then turn around and use them in an example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
