### PR TITLE
ECS TaskDefinition ResourceRequirement allows InferenceAccelerator

### DIFF
--- a/doc_source/aws-properties-ecs-taskdefinition-resourcerequirement.md
+++ b/doc_source/aws-properties-ecs-taskdefinition-resourcerequirement.md
@@ -1,6 +1,6 @@
 # AWS::ECS::TaskDefinition ResourceRequirement<a name="aws-properties-ecs-taskdefinition-resourcerequirement"></a>
 
-The `ResourceRequirement` property specifies the type and amount of a resource to assign to a container\. The only supported resource is a GPU\. For more information, see [Working with GPUs on Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html) in the *Amazon Elastic Container Service Developer Guide* 
+The `ResourceRequirement` property specifies the type and amount of a resource to assign to a container\. The only supported resources are a GPU or Inference Accelerator\. For more information, see [Working with GPUs on Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html) in the *Amazon Elastic Container Service Developer Guide* 
 
 ## Syntax<a name="aws-properties-ecs-taskdefinition-resourcerequirement-syntax"></a>
 


### PR DESCRIPTION
*Description of changes:*

The summary of this page says that a GPU is the only supported ResourceRequirement. However, the properties section states that `InferenceAccelerator` is also a supported value. This change updates the summary to reflect that difference.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.