### PR TITLE
DLM Lifecycle example is missing the 'service-role' part of the ARN.

### DIFF
--- a/doc_source/aws-resource-dlm-lifecyclepolicy.md
+++ b/doc_source/aws-resource-dlm-lifecyclepolicy.md
@@ -111,7 +111,7 @@ Resources:
     Properties:
       Description: "Lifecycle Policy using CloudFormation"
       State: "ENABLED"
-      ExecutionRoleArn: "arn:aws:iam::123456789012:role/AWSDataLifecycleManagerDefaultRole"
+      ExecutionRoleArn: "arn:aws:iam::123456789012:role/service-role/AWSDataLifecycleManagerDefaultRole"
       PolicyDetails:
         ResourceTypes:
           - "VOLUME"
@@ -149,7 +149,7 @@ Resources:
             "Properties": {
                 "Description": "Lifecycle Policy using CloudFormation",
                 "State": "ENABLED",
-                "ExecutionRoleArn": "arn:aws:iam::123456789012:role/AWSDataLifecycleManagerDefaultRole",
+                "ExecutionRoleArn": "arn:aws:iam::123456789012:role/service-role/AWSDataLifecycleManagerDefaultRole",
                 "PolicyDetails": {
                     "ResourceTypes": [
                         "VOLUME"


### PR DESCRIPTION
*Issue #, if available:*
None
*Description of changes:*
The example for lifecycle policy was missing the "service-role" part in the ARN. Without this, it does not work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
