### PR TITLE
Fix typo

### DIFF
--- a/doc_source/aws-properties-ecs-cluster-executecommandlogconfiguration.md
+++ b/doc_source/aws-properties-ecs-cluster-executecommandlogconfiguration.md
@@ -51,7 +51,7 @@ The S3 bucket must already be created\.
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `S3EncryptionEnabled`  <a name="cfn-ecs-cluster-executecommandlogconfiguration-s3encryptionenabled"></a>
-Whether or not to enable encryption on the CloudWatch logs\. If not specified, encryption will be disabled\.  
+Whether or not to enable encryption on the S3 bucket\. If not specified, encryption will be disabled\.  
 *Required*: No  
 *Type*: Boolean  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Description of changes:*
The description of 'S3EncryptionEnabled' speaks the same as 'CloudWatchEncryptionEnabled'.
This commit fixes 'CloudWatch logs' to 'S3 bucket' in the description.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
