### PR TITLE
Add a note regarding `Image` property of `AWS::CodeBuild::Project Environment`

### DIFF
--- a/doc_source/aws-properties-codebuild-project-environment.md
+++ b/doc_source/aws-properties-codebuild-project-environment.md
@@ -61,7 +61,7 @@ A set of environment variables to make available to builds for this build projec
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Image`  <a name="cfn-codebuild-project-environment-image"></a>
-The image tag or image digest that identifies the Docker image to use for this build project\. Use the following formats:  
+The image tag or image digest that identifies the Docker image to use for this build project\. The Docker image must be hosted on an accessible ECR private registry, or have a publicly resolvable URL\. Use the following formats:  
 + For an image tag: `<registry>/<repository>:<tag>`\. For example, in the Docker repository that CodeBuild uses to manage its Docker images, this would be `aws/codebuild/standard:4.0`\. 
 + For an image digest: `<registry>/<repository>@<digest>`\. For example, to specify an image with the digest "sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf," use `<registry>/<repository>@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf`\.
 *Required*: Yes  


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Adding a note regarding `Image` property of `AWS::CodeBuild::Project Environment` to reflect the following limitation:

During the pulling stage, CodeBuilds's network is used to resolve the `Image` URL and so the URL must be publicly resolvable
or the Docker image must be hosted on ECR (private ECR is supported).
The VPC configuration (`VpcConfig`) is not relevant to the pulling stage, it's relevant only once the task (the Docker container)
is running.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
