### PR TITLE
fix: CloudFront Function FunctionConfig incorrectly marked as optional

### DIFF
--- a/doc_source/aws-resource-cloudfront-function.md
+++ b/doc_source/aws-resource-cloudfront-function.md
@@ -59,7 +59,7 @@ The function code\. For more information about writing a CloudFront function, se
 
 `FunctionConfig`  <a name="cfn-cloudfront-function-functionconfig"></a>
 Contains configuration information about a CloudFront function\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: [FunctionConfig](aws-properties-cloudfront-function-functionconfig.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
The `FunctionConfig` is currently marked as optional, but omitting it results in an error when creating a Function. Updating the docs to reflect that this property is required.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
