### PR TITLE
fix(blue-green.md): Scale value should be 100%, not 1%.

### DIFF
--- a/doc_source/blue-green.md
+++ b/doc_source/blue-green.md
@@ -601,10 +601,10 @@ If you then made any changes to properties in the `"BlueTaskSet"` resource that 
                         ]
                     }
                 },
-                "PlatformVersion": "1.3.0",
+                "PlatformVersion": "1.4.0",
                 "Scale": {
                     "Unit": "PERCENT",
-                    "Value": 1
+                    "Value": 100
                 },
                 "Service": {
                     "Ref": "ECSDemoService"
@@ -839,10 +839,10 @@ Resources:
           Subnets:
             - !Ref Subnet1
             - !Ref Subnet2
-      PlatformVersion: 1.3.0
+      PlatformVersion: 1.4.0
       Scale:
         Unit: PERCENT
-        Value: 1
+        Value: 100
       Service: !Ref ECSDemoService
       TaskDefinition: !Ref BlueTaskDefinition
       LoadBalancers:


### PR DESCRIPTION
*Issue #, if available:*

Taskset should have scale percent of 100%, not 1% - since there's only one service in this example.

*Description of changes:*

- Update fargate version to latest
- change taskset scale value to be 100%

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
