### PR TITLE
Update description for `MaximumRecordAgeInSeconds`

### DIFF
--- a/doc_source/aws-resource-lambda-eventsourcemapping.md
+++ b/doc_source/aws-resource-lambda-eventsourcemapping.md
@@ -148,7 +148,7 @@ Valid Values: `ReportBatchItemFailures`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `MaximumRecordAgeInSeconds`  <a name="cfn-lambda-eventsourcemapping-maximumrecordageinseconds"></a>
-\(Streams only\) Discard records older than the specified age\. The default value is infinite \(\-1\)\. When set to infinite \(\-1\), failed records are retried until the record expires\.  
+\(Streams only\) Discard records older than the specified age\.
 *Required*: No  
 *Type*: Integer  
 *Minimum*: `-1`  


### PR DESCRIPTION
*Description of changes:*

Hi team! Description of `MaximumRecordAgeInSeconds` doesn't makes much sense presumably because it's copy-pasted from `MaximumRetryAttempts`. I've deleted misleading description.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
