### PR TITLE
Revert "AWS::Transfer::Server - Clarify that `Ref` does not return multiple values, just ARN."

### DIFF
--- a/doc_source/aws-resource-transfer-server.md
+++ b/doc_source/aws-resource-transfer-server.md
@@ -135,7 +135,7 @@ Key\-value pairs that can be used to group and search for servers\.
 
 ### Ref<a name="aws-resource-transfer-server-return-values-ref"></a>
 
- When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` the server ARN, such as `arn:aws:transfer:us-east-1:123456789012:server/s-01234567890abcdef`\.
+ When you pass the logical ID of this resource to the intrinsic `Ref` function, `Ref` returns the ServerId, such as `s-01234567890abcdef`, and the server ARN, such as `arn:aws:transfer:us-east-1:123456789012:server/s-01234567890abcdef`\.
 
 For more information about using the `Ref` function, see [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html)\.
 


### PR DESCRIPTION
Reverts awsdocs/aws-cloudformation-user-guide#918