### PR TITLE
Fix invalid backup vault ARN

### DIFF
--- a/doc_source/aws-resource-backup-backupvault.md
+++ b/doc_source/aws-resource-backup-backupvault.md
@@ -86,7 +86,7 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 #### <a name="aws-resource-backup-backupvault-return-values-fn--getatt-fn--getatt"></a>
 
 `BackupVaultArn`  <a name="BackupVaultArn-fn::getatt"></a>
-An Amazon Resource Name \(ARN\) that uniquely identifies a backup vault; for example, `arn:aws:backup:us-east-1:123456789012:vault:aBackupVault`\.
+An Amazon Resource Name \(ARN\) that uniquely identifies a backup vault; for example, `arn:aws:backup:us-east-1:123456789012:backup-vault:aBackupVault`\.
 
 `BackupVaultName`  <a name="BackupVaultName-fn::getatt"></a>
 The name of a logical container where backups are stored\. Backup vaults are identified by names that are unique to the account used to create them and the Region where they are created\. They consist of lowercase and uppercase letters, numbers, and hyphens\.


### PR DESCRIPTION
Use "backup-vault" as ARN resource name instead of incorrect "vault".

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
