### PR TITLE
ObjectLambdaConfiguration property is required

### DIFF
--- a/doc_source/aws-resource-s3objectlambda-accesspoint.md
+++ b/doc_source/aws-resource-s3objectlambda-accesspoint.md
@@ -38,7 +38,7 @@ The name of this access point\.
 
 `ObjectLambdaConfiguration`  <a name="cfn-s3objectlambda-accesspoint-objectlambdaconfiguration"></a>
 A configuration used when creating an Object Lambda Access Point\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: [ObjectLambdaConfiguration](aws-properties-s3objectlambda-accesspoint-objectlambdaconfiguration.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
`ObjectLambdaConfiguration` property was marked as not required. This is wrong, CloudFormation will return 'Request body is missing required field ObjectLambdaAccessPointConfiguration.' error

*Issue #, if available:*

*Description of changes:*
Changed ObjectLambdaConfiguration's required info from No to Yes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
