### PR TITLE
Updating info on supported Output on CF

### DIFF
--- a/doc_source/aws-resource-ecr-repository.md
+++ b/doc_source/aws-resource-ecr-repository.md
@@ -110,7 +110,7 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 Returns the Amazon Resource Name \(ARN\) for the specified `AWS::ECR::Repository` resource\. For example, `arn:aws:ecr:eu-west-1:123456789012:repository/test-repository `\.
 
 `RepositoryUri`  <a name="RepositoryUri-fn::getatt"></a>
-Not currently supported by AWS CloudFormation\.
+Returns the Uri of the repository\. For example, `123456789012.dkr.ecr.us-west-1.amazonaws.com/test-repository`\.
 
 ## Examples<a name="aws-resource-ecr-repository--examples"></a>
 


### PR DESCRIPTION
Documentation says Uri output is not supported but I have just used it successfully with Cloudformation.

*Description of changes:*
Changed the documentation regarding to Output 'RepositoryUri' not being supported to *being* supported (as tested on my account).
Github diff tool said it would change mixed line breaks on the document, that's why all lines were updated, but I changed only line 112.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
