### PR TITLE
fix: MaxEntries maximum 100 to 1000 of prefix list

### DIFF
--- a/doc_source/aws-resource-ec2-prefixlist.md
+++ b/doc_source/aws-resource-ec2-prefixlist.md
@@ -50,7 +50,7 @@ Valid Values: `IPv4` \| `IPv6`
 One or more entries for the prefix list\.  
 *Required*: No  
 *Type*: List of [Entry](aws-properties-ec2-prefixlist-entry.md)  
-*Maximum*: `100`  
+*Maximum*: `1000`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `MaxEntries`  <a name="cfn-ec2-prefixlist-maxentries"></a>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- because,
![image](https://user-images.githubusercontent.com/15692588/121853066-5f3c3080-cd2b-11eb-8554-5c9f2ee61942.png)
- And I can create prefix list which has 101 entry by cloudformation.