### PR TITLE
fixed example - incorrect elb name value

### DIFF
--- a/doc_source/aws-resource-ecs-service.md
+++ b/doc_source/aws-resource-ecs-service.md
@@ -462,7 +462,7 @@ The following example defines a service with a parameter that enables users to s
         "LoadBalancers": [{
           "ContainerName": {"Ref" : "AppName"},
           "ContainerPort": {"Ref":"AppContainerPort"},
-          "LoadBalancerName": {"Ref": "elb"}
+          "LoadBalancerName": {"Fn::GetAtt" : [ "elb", "LoadBalancerName" ]}
         }],
         "PlacementStrategies": [{
           "Type" : "binpack",
@@ -622,7 +622,7 @@ Resources:
       LoadBalancers:
         - ContainerName: !Ref AppName
           ContainerPort: !Ref AppContainerPort
-          LoadBalancerName: !Ref elb
+          LoadBalancerName: !GetAtt elb.LoadBalancerName
       PlacementStrategies:
         - Type: binpack
           Field: memory


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Examples both use Ref of `elb` for the ECSService's `LoadBalancerName`, whereas Ref actually returns the arn.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
