### PR TITLE
Change principal to avoid errors if example is modified by user

### DIFF
--- a/doc_source/aws-properties-s3-policy.md
+++ b/doc_source/aws-properties-s3-policy.md
@@ -89,7 +89,9 @@ The following sample is a bucket policy that is attached to the DOC\-EXAMPLE\-BU
                                 ]
                             ]
                         },
-                        "Principal": "*",
+                        "Principal": {
+                            "AWS": "*"
+                        },
                         "Condition": {
                             "StringLike": {
                                 "aws:Referer": [
@@ -123,7 +125,8 @@ SampleBucketPolicy:
             - - 'arn:aws:s3:::'
               - !Ref DOC-EXAMPLE-BUCKET
               - /*
-          Principal: '*'
+          Principal: 
+            AWS: '*'
           Condition:
             StringLike:
               'aws:Referer':


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added AWS key to principal policy. If a user copy+paste this policy and then change the principal to a specific role the template will show up as valid but will fail to deploy because of a "Invalid policy syntax" error that is very hard to track down. Thats because when using the "Principal" key directly only a wildcard is valid. 

See `Anonymous user principals (public access)` section in [AWS JSON policy elements: Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html) documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
