### PR TITLE
Change code snippet default value for InstanceTenancy

### DIFF
--- a/doc_source/aws-resource-ec2-vpc.md
+++ b/doc_source/aws-resource-ec2-vpc.md
@@ -117,10 +117,11 @@ The following example specifies a VPC\.
    "Type" : "AWS::EC2::VPC",
    "Properties" : {
       "CidrBlock" : "10.0.0.0/16",
-      "EnableDnsSupport" : "false",
-      "EnableDnsHostnames" : "false",
-      "InstanceTenancy" : "default",
-      "Tags" : [ {"Key" : "stack", "Value" : "production"} ]
+      "EnableDnsSupport" : "true",
+      "EnableDnsHostnames" : "true",
+      "Tags" : [ 
+         {"Key" : "stack", "Value" : "production"} 
+      ]
    }
 }
 ```
@@ -132,9 +133,8 @@ myVPC:
   Type: AWS::EC2::VPC
   Properties:
     CidrBlock: 10.0.0.0/16
-    EnableDnsSupport: 'false'
-    EnableDnsHostnames: 'false'
-    InstanceTenancy: default
+    EnableDnsSupport: 'true'
+    EnableDnsHostnames: 'true'
     Tags:
      - Key: stack
        Value: production

--- a/doc_source/aws-resource-ec2-vpc.md
+++ b/doc_source/aws-resource-ec2-vpc.md
@@ -119,7 +119,7 @@ The following example specifies a VPC\.
       "CidrBlock" : "10.0.0.0/16",
       "EnableDnsSupport" : "false",
       "EnableDnsHostnames" : "false",
-      "InstanceTenancy" : "dedicated",
+      "InstanceTenancy" : "default",
       "Tags" : [ {"Key" : "stack", "Value" : "production"} ]
    }
 }
@@ -134,7 +134,7 @@ myVPC:
     CidrBlock: 10.0.0.0/16
     EnableDnsSupport: 'false'
     EnableDnsHostnames: 'false'
-    InstanceTenancy: dedicated
+    InstanceTenancy: default
     Tags:
      - Key: stack
        Value: production


### PR DESCRIPTION
The dedicated value in InstanceTenancy caused me a few hours of delay after causing a very vague error message in a cloudformation system I was starting to build. I finally found this solution https://stackoverflow.com/questions/45691826/aws-launch-configuration-error-the-requested-configuration-is-currently-not-sup and back traced the problem to this piece of documentation.  I think the most common reason someone would copy this code is a new build and unlikely that a newb would want dedicated tenancy. I think it would be best to set this flag to default so others don't get sent down this same rabbit hole.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
