### PR TITLE
AWS::ElastiCache::User - `AccessString` property is now required

### DIFF
--- a/doc_source/aws-resource-elasticache-user.md
+++ b/doc_source/aws-resource-elasticache-user.md
@@ -41,7 +41,7 @@ Properties:
 
 `AccessString`  <a name="cfn-elasticache-user-accessstring"></a>
 Access permissions string used for this user\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Pattern*: `.*\S.*`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
If the 'AccessString' property is omitted, a generic exception is thrown by the stack.
Example error:
------------------------
Resource handler returned message: "An internal error has occurred. Please try your query again at a later time. (Service: ElastiCache, Status Code: 500, Request ID: [...], Extended Request ID: null)" (RequestToken: [...], HandlerErrorCode: GeneralServiceException)
------------------------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.