### PR TITLE
Add Outputs as attribute allowed in cloudformation

### DIFF
--- a/doc_source/aws-properties-stack.md
+++ b/doc_source/aws-properties-stack.md
@@ -98,9 +98,18 @@ Updates are not supported\.
 
 For more information about using the `Ref` function, see [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html)\.
 
+### Fn::GetAtt<a name="aws-resource-cloudfront-distribution-return-values-fn--getatt"></a>
+
+The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type\. The following are the available attributes and sample return values\.
+
+For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html)\.
+
+#### <a name="aws-resource-cloudfront-distribution-return-values-fn--getatt-fn--getatt"></a>
+
+`Outputs`  <a name="Outputs-fn::getatt"></a>
+The outputs of the nested stack, such as `Outputs.NestedStackOutputName`\.
+
 ## Examples<a name="aws-properties-stack--examples"></a>
-
-
 
 ### Specify stack parameters<a name="aws-properties-stack--examples--Specify_stack_parameters"></a>
 


### PR DESCRIPTION
*Description of changes:*
Outputs is available in CF from nested stacks, per documentation in https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-cloudformation.html but not listed in get attribute documentation in the cloudfromation resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
