### PR TITLE
Changed ProvisionedThroughput Required Attribute

### DIFF
--- a/doc_source/aws-properties-dynamodb-globaltable-globalsecondaryindex.md
+++ b/doc_source/aws-properties-dynamodb-globaltable-globalsecondaryindex.md
@@ -41,7 +41,6 @@ The name of the global secondary index\. The name must be unique among all other
 The complete key schema for a global secondary index, which consists of one or more pairs of attribute names and key types:  
 +  `HASH` \- partition key
 +  `RANGE` \- sort key
-
 The partition key of an item is also known as its *hash attribute*\. The term "hash attribute" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values\.  
 The sort key of an item is also known as its *range attribute*\. The term "range attribute" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value\.
 *Required*: Yes  

--- a/doc_source/aws-properties-dynamodb-globaltable-globalsecondaryindex.md
+++ b/doc_source/aws-properties-dynamodb-globaltable-globalsecondaryindex.md
@@ -42,8 +42,6 @@ The complete key schema for a global secondary index, which consists of one or m
 +  `HASH` \- partition key
 +  `RANGE` \- sort key
 
-The attribute name of KeySchema for GSI must be defined in the [AttributeDefinitions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef) property of [DynamoDB::Table](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html) resource.
-
 The partition key of an item is also known as its *hash attribute*\. The term "hash attribute" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values\.  
 The sort key of an item is also known as its *range attribute*\. The term "range attribute" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value\.
 *Required*: Yes  

--- a/doc_source/aws-properties-dynamodb-globaltable-globalsecondaryindex.md
+++ b/doc_source/aws-properties-dynamodb-globaltable-globalsecondaryindex.md
@@ -41,6 +41,9 @@ The name of the global secondary index\. The name must be unique among all other
 The complete key schema for a global secondary index, which consists of one or more pairs of attribute names and key types:  
 +  `HASH` \- partition key
 +  `RANGE` \- sort key
+
+The attribute name of KeySchema for GSI must be defined in the [AttributeDefinitions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef) property of [DynamoDB::Table](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html) resource.
+
 The partition key of an item is also known as its *hash attribute*\. The term "hash attribute" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values\.  
 The sort key of an item is also known as its *range attribute*\. The term "range attribute" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value\.
 *Required*: Yes  

--- a/doc_source/aws-properties-dynamodb-gsi.md
+++ b/doc_source/aws-properties-dynamodb-gsi.md
@@ -65,6 +65,6 @@ Represents attributes that are copied \(projected\) from the table into the glob
 `ProvisionedThroughput`  <a name="cfn-dynamodb-gsi-provisionedthroughput"></a>
 Represents the provisioned throughput settings for the specified global secondary index\.  
 For current minimum and maximum provisioned throughput values, see [Service, Account, and Table Quotas](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html) in the *Amazon DynamoDB Developer Guide*\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: [ProvisionedThroughput](aws-properties-dynamodb-provisionedthroughput.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/doc_source/aws-properties-dynamodb-gsi.md
+++ b/doc_source/aws-properties-dynamodb-gsi.md
@@ -50,6 +50,9 @@ The name of the global secondary index\. The name must be unique among all other
 The complete key schema for a global secondary index, which consists of one or more pairs of attribute names and key types:  
 +  `HASH` \- partition key
 +  `RANGE` \- sort key
+
+The attribute name of KeySchema for GSI must be defined in the [AttributeDefinitions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef) property of [DynamoDB::Table](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html) resource.
+
 The partition key of an item is also known as its *hash attribute*\. The term "hash attribute" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values\.  
 The sort key of an item is also known as its *range attribute*\. The term "range attribute" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value\.
 *Required*: Yes  

--- a/doc_source/aws-properties-dynamodb-keyschema.md
+++ b/doc_source/aws-properties-dynamodb-keyschema.md
@@ -6,6 +6,8 @@ A `KeySchemaElement` represents exactly one attribute of the primary key\. For e
 
 A `KeySchemaElement` must be a scalar, top\-level attribute \(not a nested attribute\)\. The data type must be one of String, Number, or Binary\. The attribute cannot be nested within a List or a Map\.
 
+The AttributeName of KeySchema must be defined in the [AttributeDefinitions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef) property of [DynamoDB::Table](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html) resource.
+
 ## Syntax<a name="aws-properties-dynamodb-keyschema-syntax"></a>
 
 To declare this entity in your AWS CloudFormation template, use the following syntax:


### PR DESCRIPTION
*Issue #, if available:*

The provisioned throughput is actually required in order to create a global secondary index. Cloudformation throws an error if not specified.

`ProvisionedThroughput cannot be empty`

Related to: https://github.com/aws/serverless-application-model/issues/1464

*Description of changes:*

Modified Required Attribute from No to Yes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
