### PR TITLE
AWS::AppRunner::Service based on image must specify ImageRepositoryType

### DIFF
--- a/doc_source/aws-resource-apprunner-service.md
+++ b/doc_source/aws-resource-apprunner-service.md
@@ -222,6 +222,7 @@ This example illustrates creating a service based on an image stored in Amazon E
       "AutoDeploymentsEnabled": true,
       "ImageRepository": {
         "ImageIdentifier": "123456789012.dkr.ecr.us-east-1.amazonaws.com/golang-app:latest",
+        "ImageRepositoryType": "ECR",
         "ImageConfiguration": {
           "Port": "8080",
           "RuntimeEnvironmentVariables": [
@@ -253,6 +254,7 @@ Properties:
     AutoDeploymentsEnabled: true
     ImageRepository:
       ImageIdentifier: "123456789012.dkr.ecr.us-east-1.amazonaws.com/golang-app:latest"
+      ImageRepositoryType: ECR
       ImageConfiguration:
         Port: 8080
         RuntimeEnvironmentVariables:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The examples provided for AWS::AppRunner::Service when based on a source image do not specify `ImageRepositoryType`, which is a required field. Added type `ECR` for the existing examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
