### PR TITLE
Update aws-resource-codepipeline-webhook.md

### DIFF
--- a/doc_source/aws-resource-codepipeline-webhook.md
+++ b/doc_source/aws-resource-codepipeline-webhook.md
@@ -179,7 +179,7 @@ Webhook:
   Type: 'AWS::CodePipeline::Webhook' 
   Properties:
     AuthenticationConfiguration: 
-      SecretToken: {{resolve:secretsmanager:MyGitHubSecret:SecretString:token}} 
+      SecretToken: "{{resolve:secretsmanager:MyGitHubSecret:SecretString:token}}"
     Filters: 
     - JsonPath: "$.ref" 
       MatchEquals: refs/heads/{Branch} 


### PR DESCRIPTION
Hi Team,
Could you please add "" to SecretToken in AWS::CodePipeline::Webhook, as while working without adding "", It gives me error.

*Issue #, if available:*

found unhashable key
  in "<unicode string>", line 269, column 23:
            SecretToken: {{resolve:secretsmanager:

*Description of changes:*

Hi Team,
Could you please add "" to SecretToken in AWS::CodePipeline::Webhook, as while working without adding "", It gives me error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
