### PR TITLE
Examples use AutoMinorVersionUpdate

### DIFF
--- a/doc_source/aws-resource-docdb-dbinstance.md
+++ b/doc_source/aws-resource-docdb-dbinstance.md
@@ -130,7 +130,6 @@ The port number on which the database accepts connections, such as `27017`\.
 {
    "Type" : "AWS::DocDB::DBInstance",
    "Properties" : {
-      "AutoMinorVersionUpgrade" : true,
       "AvailabilityZone" : "us-east-1c",
       "DBClusterIdentifier" : "sample-cluster",
       "DBInstanceClass" : "db.r5.large",
@@ -146,7 +145,6 @@ The port number on which the database accepts connections, such as `27017`\.
 ```
 Type: "AWS::DocDB::DBInstance"
 Properties:
-   AutoMinorVersionUpgrade: true
    AvailabilityZone: "us-east-1c"
    DBClusterIdentifier: "sample-cluster"
    DBInstanceClass: "db.r5.large"


### PR DESCRIPTION
Both the JSON and YAML examples show the usage of AutoMinorVersionUpdate which is not valid.  Usage of this property will cause the deployment to fail.

Earlier in the documentation, it states that AutoMinorVersionUpdate - "does not apply to Amazon DocumentDB.  Amazon DocumentDB does not perform minor version upgrades..."

*Issue #, if available: N/A

*Description of changes: Updates to examples of the CloudFormation template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
