### PR TITLE
Update aws-resource-cloudfront-function.md

### DIFF
--- a/doc_source/aws-resource-cloudfront-function.md
+++ b/doc_source/aws-resource-cloudfront-function.md
@@ -89,6 +89,3 @@ The ARN of the function\. For example:
 `arn:aws:cloudfront::123456789012:function/ExampleFunction`\.  
 To get the function ARN, use the following syntax:  
 `!GetAtt Function_Logical_ID.FunctionMetadata.FunctionARN`
-
-`FunctionMetadata.FunctionARN`  <a name="FunctionMetadata.FunctionARN-fn::getatt"></a>
-Not currently supported by AWS CloudFormation\.


### PR DESCRIPTION
Per my testing/development, referencing the FunctionArn of a CloudFront Function (via !GetAtt Function_Logical_ID.FunctionMetadata.FunctionARN) appears to now be working in CloudFormation.  Suggest removing the statement from the documentation indicating this feature does not work.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
