### PR TITLE
Update the pattern of Security Group Arns

### DIFF
--- a/doc_source/aws-resource-datasync-locationfsxwindows.md
+++ b/doc_source/aws-resource-datasync-locationfsxwindows.md
@@ -67,7 +67,7 @@ The password of the user who has the permissions to access files and folders in 
 
 `SecurityGroupArns`  <a name="cfn-datasync-locationfsxwindows-securitygrouparns"></a>
 The Amazon Resource Names \(ARNs\) of the security groups that are to use to configure the FSx for Windows File Server file system\.  
-*Pattern*: `^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b):fsx:[a-z\-0-9]*:[0-9]{12}:file-system/fs-.*$`  
+*Pattern*: `^arn:aws:ec2:(region):(account-id):security-group/sg-.*$`  
 *Length Constraints*: Maximum length of 128\.  
 *Required*: Yes  
 *Type*: List of String  


### PR DESCRIPTION
The pattern is completely wrong, and references a File System rather than the EC2 Security Group.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
