### PR TITLE
Handler only accepts one value

### DIFF
--- a/doc_source/aws-properties-synthetics-canary-code.md
+++ b/doc_source/aws-properties-synthetics-canary-code.md
@@ -31,7 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-synthetics-canary-code-properties"></a>
 
 `Handler`  <a name="cfn-synthetics-canary-code-handler"></a>
-The entry point to use for the source code when running the canary\. This value must end with the string `.handler`\. The string is limited to 29 characters or fewer\.  
+The entry point to use for the source code when running the canary\. This value must be `pageLoadBlueprint.handler`\.  
 *Required*: Conditional  
 *Type*: String  
 *Minimum*: `1`  


### PR DESCRIPTION
Handler only accepts pageLoadBlueprint.handler

*Issue #, if available:*

*Description of changes:*

any value other than `pageLoadBlueprint.handler` for the `Handler` property causes CloudFormation to error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
