### PR TITLE
Remove mention of "replica key" from Tags property

### DIFF
--- a/doc_source/aws-resource-kms-key.md
+++ b/doc_source/aws-resource-kms-key.md
@@ -150,7 +150,7 @@ For information about the `Pending Deletion` and `Pending Replica Deletion` key 
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Tags`  <a name="cfn-kms-key-tags"></a>
-Assigns one or more tags to the replica key\.  
+Assigns one or more tags to the key\.  
 Tagging or untagging a KMS key can allow or deny permission to the KMS key\. For details, see [Using ABAC in AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/abac.html) in the *AWS Key Management Service Developer Guide*\.
 For information about tags in AWS KMS, see [Tagging keys](https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html) in the *AWS Key Management Service Developer Guide*\. For information about tags in CloudFormation, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html)\.  
 *Required*: No  


### PR DESCRIPTION
This appears to be a typo or copy/paste error.  These tags are for the primary key, not a replica key.


*Description of changes:*
Simply removing the word "replica" here makes it clear that this property is for the primary key.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
