### PR TITLE
Format examples in AWS::CertificateManager::Certificate

### DIFF
--- a/doc_source/aws-resource-certificatemanager-certificate.md
+++ b/doc_source/aws-resource-certificatemanager-certificate.md
@@ -123,15 +123,26 @@ The following example shows how to declare an `AWS::CertificateManager::Certific
 #### JSON<a name="aws-resource-certificatemanager-certificate--examples--Declaring_an_Amazon_Certificate_Manager_Certificate_Resource--json"></a>
 
 ```
-{ "Resources":{ "MyCertificate":{
-            "Type":"AWS::CertificateManager::Certificate", "Properties":{
-            "DomainName":"example.com", "ValidationMethod":"DNS" } } } }
+{
+  "Resources": {
+    "MyCertificate": {
+      "Type": "AWS::CertificateManager::Certificate",
+      "Properties": {
+        "DomainName": "example.com",
+        "ValidationMethod": "DNS"
+      }
+    }
+  }
+}
 ```
 
 #### YAML<a name="aws-resource-certificatemanager-certificate--examples--Declaring_an_Amazon_Certificate_Manager_Certificate_Resource--yaml"></a>
 
 ```
-Resources: MyCertificate: Type:
-            AWS::CertificateManager::Certificate Properties: DomainName: example.com
-            ValidationMethod: DNS
+Resources:
+  MyCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: example.com
+      ValidationMethod: DNS
 ```


### PR DESCRIPTION
*Description of changes:*

Fixes incorrect formatting on https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
