### PR TITLE
Fix missing "Ref" in JSON for cost anomaly detection example.

### DIFF
--- a/doc_source/aws-resource-ce-anomalymonitor.md
+++ b/doc_source/aws-resource-ce-anomalymonitor.md
@@ -281,8 +281,8 @@ The following example shows two anomaly monitors attached to an anomaly subscrip
         "Threshold": 100,
         "Frequency": "DAILY",
         "MonitorArnList": [
-          "CustomAnomalyMonitorWithLinkedAccount",
-          "AnomalyServiceMonitor"
+          { "Ref": "CustomAnomalyMonitorWithLinkedAccount" },
+          { "Ref": "AnomalyServiceMonitor" }
         ],
         "Subscribers": [
           {


### PR DESCRIPTION
YAML was correct, JSON was not. AWS::CE::AnomalySubscription already
had the Ref's as well.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
