### PR TITLE
Update aws-resource-elasticache-replicationgroup.md

### DIFF
--- a/doc_source/aws-resource-elasticache-replicationgroup.md
+++ b/doc_source/aws-resource-elasticache-replicationgroup.md
@@ -211,7 +211,7 @@ If you're going to launch your cluster in an Amazon VPC, you need to create a su
 
 `Engine`  <a name="cfn-elasticache-replicationgroup-engine"></a>
 The name of the cache engine to be used for the clusters in this replication group\. Must be Redis\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 


### PR DESCRIPTION
Set parameter as required, because in fact CloudFormation fails if it's not specified - "The parameter Engine must be provided and must not be null."

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
