### PR TITLE
[Cloudfront Functions] FunctionConfig is required

### DIFF
--- a/doc_source/aws-resource-cloudfront-function.md
+++ b/doc_source/aws-resource-cloudfront-function.md
@@ -59,7 +59,7 @@ The function code\. For more information about writing a CloudFront function, se
 
 `FunctionConfig`  <a name="cfn-cloudfront-function-functionconfig"></a>
 Contains configuration information about a CloudFront function\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: [FunctionConfig](aws-properties-cloudfront-function-functionconfig.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Hi team,

I'm changing `FunctionConfig` to be required as cloudfront functions without this attibute will fail to create in cloudformation.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
