### PR TITLE
Improve NotificationRule around TargetAddress

### DIFF
--- a/doc_source/aws-properties-codestarnotifications-notificationrule-target.md
+++ b/doc_source/aws-properties-codestarnotifications-notificationrule-target.md
@@ -25,7 +25,8 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-codestarnotifications-notificationrule-target-properties"></a>
 
 `TargetAddress`  <a name="cfn-codestarnotifications-notificationrule-target-targetaddress"></a>
-The Amazon Resource Name \(ARN\) of the AWS Chatbot topic or AWS Chatbot client\.  
+The Amazon Resource Name \(ARN\) of the AWS Chatbot client if `TargetType: AWSChatbotSlack`.
+For `TargetType: SNS` it must be topic's ARN\.  
 *Required*: Yes  
 *Type*: String  
 *Minimum*: `1`  


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Previously documentation did not specify that `TargetAddress` may be something else other than a resource related to AWS Chatbot.
Now, documentation explicitly mentions that target can be either AWS Chatbot Client or particular SNS Topic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
