### PR TITLE
Changes to Amazon MSK `KafkaVersion` property.

### DIFF
--- a/doc_source/aws-resource-msk-cluster.md
+++ b/doc_source/aws-resource-msk-cluster.md
@@ -92,8 +92,7 @@ Specifies the level of monitoring for the MSK cluster\. The possible values are 
 `KafkaVersion`  <a name="cfn-msk-cluster-kafkaversion"></a>
 The version of Apache Kafka\. For more information, see [Supported Apache Kafka versions](https://docs.aws.amazon.com/msk/latest/developerguide/supported-kafka-versions.html) in the *Amazon MSK Developer Guide*\. 
 *Required*: Yes  
-*Type*: String  
-*Allowed values*: `2.2.1 | 2.3.1 | 2.4.1 | 2.4.1.1 | 2.5.1 | 2.6.0 | 2.6.1 | 2.7.0 | 2.6.2 | 2.7.1 | 2.8.0 | 2.8.1`
+*Type*: String
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `LoggingInfo`  <a name="cfn-msk-cluster-logginginfo"></a>

--- a/doc_source/aws-resource-msk-cluster.md
+++ b/doc_source/aws-resource-msk-cluster.md
@@ -90,9 +90,10 @@ Specifies the level of monitoring for the MSK cluster\. The possible values are 
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `KafkaVersion`  <a name="cfn-msk-cluster-kafkaversion"></a>
-The version of Apache Kafka\. You can use Amazon MSK to create clusters that use Apache Kafka versions 1\.1\.1 and 2\.2\.1\.  
+The version of Apache Kafka\. For more information, see [Supported Apache Kafka versions](https://docs.aws.amazon.com/msk/latest/developerguide/supported-kafka-versions.html) in the *Amazon MSK Developer Guide*\. 
 *Required*: Yes  
 *Type*: String  
+*Allowed values*: `2.2.1 | 2.3.1 | 2.4.1 | 2.4.1.1 | 2.5.1 | 2.6.0 | 2.6.1 | 2.7.0 | 2.6.2 | 2.7.1 | 2.8.0 | 2.8.1`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `LoggingInfo`  <a name="cfn-msk-cluster-logginginfo"></a>


### PR DESCRIPTION
Current documentation contains errorneous information about supported versions (i.e. cannot create clusters with version 1.1.1 anymore).

This change will provide a link to supported versions page in the Developer Guide, as well as provide a list of valid values for this property.

The change will fix Issue #1080.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
