### PR TITLE
Removing unnecessary note about workgroup

### DIFF
--- a/doc_source/aws-resource-athena-namedquery.md
+++ b/doc_source/aws-resource-athena-namedquery.md
@@ -2,9 +2,6 @@
 
 The `AWS::Athena::NamedQuery` resource specifies an Amazon Athena saved query, where `QueryString` is the list of SQL query statements that comprise the query\.
 
-**Note**  
-The `AWS::Athena::NamedQuery` resource creates a named query in the primary workgroup\. To create a named query in a different workgroup, use the [CreateNamedQuery](https://docs.aws.amazon.com/athena/latest/APIReference/API_CreateNamedQuery.html) API operation and specify a workgroup in the `WorkGroup` parameter, or use the [create\-named\-query](https://docs.aws.amazon.com/cli/latest/reference/athena/create-named-query.html) AWS CLI command and specify a workgroup in the `--work-group` option\.
-
 ## Syntax<a name="aws-resource-athena-namedquery-syntax"></a>
 
 To declare this entity in your AWS CloudFormation template, use the following syntax:


### PR DESCRIPTION
*Description of changes:*
`Workgroup` is already available as a property of the `NamedQuery` so it does not and should not be changed outside of CF anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
