### PR TITLE
Fixed Type field in YAML example for AWS::CertificateManager::Certificate

### DIFF
--- a/doc_source/aws-resource-certificatemanager-certificate.md
+++ b/doc_source/aws-resource-certificatemanager-certificate.md
@@ -141,8 +141,8 @@ The following example shows how to declare an `AWS::CertificateManager::Certific
 ```
 Resources: 
   MyCertificate: 
+    Type: "AWS::CertificateManager::Certificate"
     Properties: 
       DomainName: example.com
       ValidationMethod: DNS
-      Type: "AWS::CertificateManager::Certificate"
 ```


### PR DESCRIPTION
YAML example for AWS::CertificateManager::Certificate has the Type field in the incorrect location.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
