### PR TITLE
Update DefaultAuthenticationMethod valid options

### DIFF
--- a/doc_source/aws-resource-pinpoint-apnschannel.md
+++ b/doc_source/aws-resource-pinpoint-apnschannel.md
@@ -64,7 +64,7 @@ The APNs client certificate that you received from Apple\. Specify this value if
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `DefaultAuthenticationMethod`  <a name="cfn-pinpoint-apnschannel-defaultauthenticationmethod"></a>
-The default authentication method that you want Amazon Pinpoint to use when authenticating with APNs\. Valid options are `key` or `certificate`\.  
+The default authentication method that you want Amazon Pinpoint to use when authenticating with APNs\. Valid options are `token` or `certificate`\.  
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
Error from CloudFormation: Property validation failure: [Value for property {/DefaultAuthenticationMethod} does not match pattern {TOKEN|CERTIFICATE}]

Updating DefaultAuthenticationMethod valid options from key and certificate to token and certificate in documentation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
