### PR TITLE
Fix indentation and spacing on tags for Kinesis stream examples

### DIFF
--- a/doc_source/aws-resource-kinesis-stream.md
+++ b/doc_source/aws-resource-kinesis-stream.md
@@ -112,10 +112,13 @@ The following example creates a `Stream` resource that uses three shards, sets a
             "EncryptionType": "KMS", 
             "KeyId": "!Ref myKey" 
             }, 
-        "Tags": [ {
-            "Key": "Environment", 
-            "Value": "Production" } ] 
-        } 
+        "Tags": [
+          {
+            "Key": "Environment",
+            "Value": "Production"
+          }
+        ]
+    }
 }
 ```
 
@@ -132,7 +135,6 @@ MyStream:
             EncryptionType: KMS 
             KeyId: !Ref myKey 
         Tags: 
-            -
-                Key: Environment Value:
-                Production
+            - Key: Environment
+              Value: Production
 ```


### PR DESCRIPTION
*Description of changes:*
- Fixes spacing and indentation for `tags` in Kinesis Stream examples 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
