### PR TITLE
Update aws-resource-iam-instanceprofile.md

### DIFF
--- a/doc_source/aws-resource-iam-instanceprofile.md
+++ b/doc_source/aws-resource-iam-instanceprofile.md
@@ -56,7 +56,7 @@ This parameter allows \(through its [regex pattern](http://wikipedia.org/wiki/re
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `Roles`  <a name="cfn-iam-instanceprofile-roles"></a>
-The name of the role to associate with the instance profile\. Only one role can be assigned to an EC2 instance at a time, and all applications on the instance share the same role and permissions\.  
+The name of the role (NOT the ARN) to associate with the instance profile\. Only one role can be assigned to an EC2 instance at a time, and all applications on the instance share the same role and permissions\.  
 *Required*: Yes  
 *Type*: List of String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
Clarify that the Role name is NOT an ARN.  Some CloudFormation resources require role ARN, others name.  Best to be clear.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
