### PR TITLE
Removed duplicate line in TaskType definition

### DIFF
--- a/doc_source/aws-properties-appflow-flow-task.md
+++ b/doc_source/aws-properties-appflow-flow-task.md
@@ -64,7 +64,6 @@ Specifies the particular task implementation that Amazon AppFlow performs\.
 *Allowed values*: `Arithmetic` \| `Filter` \| `Map` \| `Map_all` \| `Mask` \| `Merge` \| `Truncate` \| `Validate`  
 *Required*: Yes  
 *Type*: String  
-*Allowed values*: `Arithmetic | Filter | Map | Mask | Merge | Truncate | Validate`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 ## See also<a name="aws-properties-appflow-flow-task--seealso"></a>


### PR DESCRIPTION
There were two 'Allowed Values' lines in the TaskType documentation. I removed the second one which was also out of date. The first one contains the correct list of allowed values.

*Issue #, if available:*

*Description of changes:*
Removed duplicate AllowedValues line

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
