### PR TITLE
Fix typo in AWS RUM documentation

### DIFF
--- a/doc_source/aws-properties-rum-appmonitor-appmonitorconfiguration.md
+++ b/doc_source/aws-properties-rum-appmonitor-appmonitorconfiguration.md
@@ -89,7 +89,7 @@ You can't include both `ExcludedPages` and `IncludedPages` in the same app monit
 `SessionSampleRate`  <a name="cfn-rum-appmonitor-appmonitorconfiguration-sessionsamplerate"></a>
 Specifies the percentage of user sessions to use for CloudWatch RUM data collection\. Choosing a higher percentage gives you more data but also incurs more costs\.  
 The number you specify is the percentage of user sessions that will be used\.  
-If you omit this parameter, the default of 10 is used\.  
+If you omit this parameter, the default of 1.0 is used\.  
 *Required*: No  
 *Type*: Double  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*
No issue created

*Description of changes:*
* `SessionSampleRate` is a double from 0 to 1 (inclusive). This shows the default as being `10` when it should be `1` or `1.0`

Tagging RUM team member for visibility: @qhanam

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
