### PR TITLE
Fix RDS Database Instance LicenseModel valid values

### DIFF
--- a/doc_source/aws-properties-rds-database-instance.md
+++ b/doc_source/aws-properties-rds-database-instance.md
@@ -535,7 +535,15 @@ Not applicable\. The KMS key identifier is managed by the DB cluster\.
 
 `LicenseModel`  <a name="cfn-rds-dbinstance-licensemodel"></a>
 License model information for this DB instance\.  
- Valid values: `license-included` \| `bring-your-own-license` \| `general-public-license`   
+
+Valid values for MariaDB and MySQL engines: `general-public-license`   
+
+Valid values for MS SQL Server engines: `license-included`
+   
+Valid values for Oracle engines: `license-included` \| `bring-your-own-license`   
+
+Valid values for PostgreSQL engine: `postgresql-license`   
+
 If you've specified `DBSecurityGroups` and then you update the license model, AWS CloudFormation replaces the underlying DB instance\. This will incur some interruptions to database availability\. 
 *Required*: No  
 *Type*: String  


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Value values listed for RDS instance LicenseModel was inaccurate.  It's dependent on the selected engine.  It's also not easy to find the available options for each engine, so I've expanded on it in this CF documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
