### PR TITLE
`DefaultCacheBehavior` is a required field

### DIFF
--- a/doc_source/aws-properties-cloudfront-distribution-distributionconfig.md
+++ b/doc_source/aws-properties-cloudfront-distribution-distributionconfig.md
@@ -111,7 +111,7 @@ Not currently supported by AWS CloudFormation\.
 
 `DefaultCacheBehavior`  <a name="cfn-cloudfront-distribution-distributionconfig-defaultcachebehavior"></a>
 A complex type that describes the default cache behavior if you don't specify a `CacheBehavior` element or if files don't match any of the values of `PathPattern` in `CacheBehavior` elements\. You must create exactly one default cache behavior\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: [DefaultCacheBehavior](aws-properties-cloudfront-distribution-defaultcachebehavior.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
A `DistributionConfig` resource cannot be created without this field specified. The member must not be null.

*Issue #, if available:*

*Description of changes:*

As per the documentation, "You must create exactly one default cache behavior." Hence, this field should be marked as required.

It is incorrectly marked as not required in the CloudFormation docs, but is correct in SDK docs, for example:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html
https://docs.aws.amazon.com/sdk-for-go/api/service/cloudfront/

If this field is omitted, deployment will yield a 400 error with the message "Member must not be null".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.