### PR TITLE
Creating a Replication Group as part of a Global Datastore

### DIFF
--- a/doc_source/aws-resource-elasticache-replicationgroup.md
+++ b/doc_source/aws-resource-elasticache-replicationgroup.md
@@ -237,7 +237,7 @@ The version number of the cache engine to be used for the clusters in this repli
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `GlobalReplicationGroupId`  <a name="cfn-elasticache-replicationgroup-globalreplicationgroupid"></a>
-The name of the Global datastore  
+The name of the Global datastore.  If this property is specified, the Engine, EngineVersion, and AtRestEncryptionEnabled properties cannot be specified.  For more information, \(see [Using global datastores](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Redis-Global-Datastores-Console.htm)\)
 *Required*: No  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)

--- a/doc_source/aws-resource-elasticache-replicationgroup.md
+++ b/doc_source/aws-resource-elasticache-replicationgroup.md
@@ -237,7 +237,7 @@ The version number of the cache engine to be used for the clusters in this repli
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `GlobalReplicationGroupId`  <a name="cfn-elasticache-replicationgroup-globalreplicationgroupid"></a>
-The name of the Global datastore.  If this property is specified, the Engine, EngineVersion, and AtRestEncryptionEnabled properties cannot be specified.  For more information, \(see [Using global datastores](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Redis-Global-Datastores-Console.htm)\)
+The name of the Global datastore.  If this property is specified, the Engine, EngineVersion, and AtRestEncryptionEnabled properties cannot be specified.  For more information, \(see [Using global datastores](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Redis-Global-Datastores-Console.htm)\)\.
 *Required*: No  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
If GlobalReplicationGroupId is specified, the Engine, EngineVersion, AtRestEncryptionEnabled properties cannot be specified as they are prepopulated to match the primary cluster.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
