### PR TITLE
Update aws-resource-dms-replicationtask.md

### DIFF
--- a/doc_source/aws-resource-dms-replicationtask.md
+++ b/doc_source/aws-resource-dms-replicationtask.md
@@ -13,7 +13,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
   "Type" : "AWS::DMS::ReplicationTask",
   "Properties" : {
       "[CdcStartPosition](#cfn-dms-replicationtask-cdcstartposition)" : String,
-      "[CdcStartTime](#cfn-dms-replicationtask-cdcstarttime)" : Double,
+      "[CdcStartTime](#cfn-dms-replicationtask-cdcstarttime)" : Number,
       "[CdcStopPosition](#cfn-dms-replicationtask-cdcstopposition)" : String,
       "[MigrationType](#cfn-dms-replicationtask-migrationtype)" : String,
       "[ReplicationInstanceArn](#cfn-dms-replicationtask-replicationinstancearn)" : String,
@@ -35,7 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 Type: AWS::DMS::ReplicationTask
 Properties: 
   [CdcStartPosition](#cfn-dms-replicationtask-cdcstartposition): String
-  [CdcStartTime](#cfn-dms-replicationtask-cdcstarttime): Double
+  [CdcStartTime](#cfn-dms-replicationtask-cdcstarttime): Number
   [CdcStopPosition](#cfn-dms-replicationtask-cdcstopposition): String
   [MigrationType](#cfn-dms-replicationtask-migrationtype): String
   [ReplicationInstanceArn](#cfn-dms-replicationtask-replicationinstancearn): String
@@ -54,7 +54,7 @@ Properties:
 
 `CdcStartPosition`  <a name="cfn-dms-replicationtask-cdcstartposition"></a>
 Indicates when you want a change data capture \(CDC\) operation to start\. Use either CdcStartPosition or CdcStartTime to specify when you want a CDC operation to start\. Specifying both values results in an error\.  
- The value can be in date, checkpoint, or LSN/SCN format\.  
+The value can be in date, checkpoint, or LSN/SCN format\.  
 Date Example: \-\-cdc\-start\-position “2018\-03\-08T12:12:12”  
 Checkpoint Example: \-\-cdc\-start\-position "checkpoint:V1\#27\#mysql\-bin\-changelog\.157832:1975:\-1:2002:677883278264080:mysql\-bin\-changelog\.157832:1876\#0\#0\#\*\#0\#93"  
 LSN Example: \-\-cdc\-start\-position “mysql\-bin\-changelog\.000024:373”  
@@ -65,8 +65,10 @@ When you use this task setting with a source PostgreSQL database, a logical repl
 
 `CdcStartTime`  <a name="cfn-dms-replicationtask-cdcstarttime"></a>
 Indicates the start time for a change data capture \(CDC\) operation\.  
+The value need to be in epoch timestamp in milliseconds format\.  
+Date Example: \-\-cdc\-start\-time 1641556979000  
 *Required*: No  
-*Type*: Double  
+*Type*: Number  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `CdcStopPosition`  <a name="cfn-dms-replicationtask-cdcstopposition"></a>


### PR DESCRIPTION
It's about the type of CdcStartTime in this Document.

Replicate in CFN template:
1) when define 'CdcStartTime': "2022-01-07T12:02:59"  
>>> get Error: Property validation failure: [Value of property {/CdcStartTime} does not match type {Number}]

2) when define 'CdcStartTime': 1641556979
>>> From RDS backend tool: "CdcStartTime": 1641556.979
>>> From AWS DMS console: Change data capture (CDC) start position: 1970-01-19T23:59:16

3) when define 'CdcStartTime': 1641556979000
>>> From backend tool: "CdcStartTime": 1641556979.0
>>> From AWS DMS console: Change data capture (CDC) start position: 2022-01-07T12:02:59

Seems in CFN pre-check, CdcStartTime need to be a 'Type: Number', and the Number need to be in epoch timestamp in milliseconds format.

Also, inside API reference, CreateReplicationTask API:
In Request Syntax >>> CdcStartTime Type: number
----------------------
{   ...
    "CdcStartTime": number 
    ...
}
----------------------

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
