### PR TITLE
Update aws-properties-lex-botalias-textlogdestination.md

### DIFF
--- a/doc_source/aws-properties-lex-botalias-textlogdestination.md
+++ b/doc_source/aws-properties-lex-botalias-textlogdestination.md
@@ -10,14 +10,14 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 ```
 {
-  "[CloudWatch](#cfn-lex-botalias-textlogdestination-cloudwatch)" : 
+  "[CloudWatch](#cfn-lex-botalias-textlogdestination-cloudwatch)" : CloudWatchLogGroupLogDestination
 }
 ```
 
 ### YAML<a name="aws-properties-lex-botalias-textlogdestination-syntax.yaml"></a>
 
 ```
-  [CloudWatch](#cfn-lex-botalias-textlogdestination-cloudwatch): 
+  [CloudWatch](#cfn-lex-botalias-textlogdestination-cloudwatch): CloudWatchLogGroupLogDestination
 ```
 
 ## Properties<a name="aws-properties-lex-botalias-textlogdestination-properties"></a>
@@ -25,5 +25,5 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 `CloudWatch`  <a name="cfn-lex-botalias-textlogdestination-cloudwatch"></a>
 Defines the Amazon CloudWatch Logs log group where text and metadata logs are delivered\.  
 *Required*: No  
-*Type*:   
+*Type*: [CloudWatchLogGroupLogDestination](aws-properties-lex-botalias-cloudwatchloggrouplogdestination.md)
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
Adds CloudWatchLogGroupLogDestination link to documentation

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
