### PR TITLE
Fix incorrect slot types names and add missing slot priorities

### DIFF
--- a/doc_source/aws-resource-lex-bot.md
+++ b/doc_source/aws-resource-lex-bot.md
@@ -284,7 +284,7 @@ Resources:
                   MessageGroupsList:
                     - Message:
                         PlainTextMessage:
-                          Value: "Okay, your {FlowerType} will be ready for pickup by {PickupTime} on {PickupDate}.  Does this sound okay?"
+                          Value: "Okay, your {FlowerType} will be ready for pickup by {PickUpTime} on {PickUpDate}.  Does this sound okay?"
                   MaxRetries: 3
                   AllowInterrupt: false
                 DeclinationResponse:
@@ -330,6 +330,13 @@ Resources:
                               Value: "At what time do you want the {FlowerType} to be picked up?"
                       MaxRetries: 3
                       AllowInterrupt: false
+              SlotPriorities:
+                - Priority: 1
+                  SlotName: FlowerType
+                - Priority: 2
+                  SlotName: PickUpDate
+                - Priority: 3
+                  SlotName: PickUpTime
             - Name: "FallbackIntent"
               Description: "Default intent when no other intent matches"
               ParentIntentSignature: "AMAZON.FallbackIntent"
@@ -529,6 +536,17 @@ Resources:
                               Value: "What type of car would you like to rent?  Our most popular options are economy, midsize, and luxury"
                       MaxRetries: 3
                       AllowInterrupt: false
+              SlotPriorities:
+                - Priority: 1
+                  SlotName: PickUpCity
+                - Priority: 2
+                  SlotName: PickUpDate
+                - Priority: 3
+                  SlotName: ReturnDate  
+                - Priority: 4
+                  SlotName: DriverAge  
+                - Priority: 5
+                  SlotName: CarType  
             # We expect developers to provide the FallbackIntent when generating their bot.
             # The service will throw an exception when it is not provided.
             - Name: "BookHotel"


### PR DESCRIPTION
Both the `OrderFlower` and `BookTrip` do not work when copy pasted, because of the following errors:

* `OrderFlower` has incorrect slot names referenced in the confirmation message
* `OrderFlower` and `BookTrip` are both missing a required `SlotPriorities` field

*Issue #, if available:*
N/A

*Description of changes:*
* Updated slot names inside the confirmation message to match the actual slot names
* Added missing SlotPriorities field which seems to be required by CF

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
