### PR TITLE
[CodeArtifact] ExternalConnections, RepositoryName

### DIFF
--- a/doc_source/aws-resource-codeartifact-repository.md
+++ b/doc_source/aws-resource-codeartifact-repository.md
@@ -71,7 +71,14 @@ Properties:
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `ExternalConnections`  <a name="cfn-codeartifact-repository-externalconnections"></a>
- An array of external connections associated with the repository\.   
+ An array of external connections associated with the repository\. CloudFormation only supports a single external connection\. The following values are supported:
+ * `public:npmjs` - for the npm public repository\.
+ * `public:pypi` - for the Python Package Index\.
+ * `public:maven-central` - for Maven Central\.
+ * `public:maven-googleandroid` - for the Google Android repository\.
+ * `public:maven-gradleplugins` - for the Gradle plugins repository\.
+ * `public:maven-commonsware` - for the CommonsWare Android repository\.
+
 *Required*: No  
 *Type*: List of String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
@@ -83,7 +90,7 @@ The document that defines the resource policy that is set on a repository\.
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `RepositoryName`  <a name="cfn-codeartifact-repository-repositoryname"></a>
- The name of an upstream repository\.   
+ The name of the repository to create\.   
 *Required*: Yes  
 *Type*: String  
 *Minimum*: `2`  


### PR DESCRIPTION
* Corrected description of the `RepositoryName` property
* Added valid `ExternalConnections` values
* Documented that only a single external connection is supported 

Resource creation fails with the following error if more than one item is specified in the ExternalConnections array:
```
Resource handler returned message: "ExternalConnections for repositories are currently limited to 1 (Service: Codeartifact, Status Code: 400, Request ID: 72f79605-..., Extended Request ID: null)" (RequestToken: ddb0e3d5-..., HandlerErrorCode: InvalidRequest)
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
