### PR TITLE
ADD parameter SampleSize for aws properties glue crawler s3Target

### DIFF
--- a/doc_source/aws-properties-glue-crawler-s3target.md
+++ b/doc_source/aws-properties-glue-crawler-s3target.md
@@ -13,6 +13,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
   "[ConnectionName](#cfn-glue-crawler-s3target-connectionname)" : String,
   "[Exclusions](#cfn-glue-crawler-s3target-exclusions)" : [ String, ... ],
   "[Path](#cfn-glue-crawler-s3target-path)" : String
+  "[SampleSize](#cfn-glue-crawler-s3target-samplesize)" : Integer
 }
 ```
 
@@ -23,6 +24,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
   [Exclusions](#cfn-glue-crawler-s3target-exclusions): 
     - String
   [Path](#cfn-glue-crawler-s3target-path): String
+  [SampleSize](#cfn-glue-crawler-s3target-samplesize) : Integer
 ```
 
 ## Properties<a name="aws-properties-glue-crawler-s3target-properties"></a>
@@ -43,4 +45,10 @@ A list of glob patterns used to exclude from the crawl\. For more information, s
 The path to the Amazon S3 target\.  
 *Required*: No  
 *Type*: String  
+*Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+`SampleSize`  <a name="cfn-glue-crawler-s3target-samplesize"></a>
+Sets the number of files in each leaf folder to be crawled when crawling sample files in a dataset. If not set, all the files are crawled. A valid value is an integer between 1 and 249\.  
+*Required*: No  
+*Type*: Integer  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Context:*
I was trying to search on internet how to configure the sample size on a s3 target for a glue crawler but nothing was on the documentation.
So I tried to put SampleSize as a variable and it works, I supposed that the doc isn't updated for this part.

*Description of changes:*
I put the parameter on the documentation by following the actual documentation please tell me if you see any problem.
Thanks,
Antoine

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
