### PR TITLE
Add hint about required weight property

### DIFF
--- a/doc_source/aws-properties-elasticloadbalancingv2-listener-forwardconfig.md
+++ b/doc_source/aws-properties-elasticloadbalancingv2-listener-forwardconfig.md
@@ -28,6 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 `TargetGroups`  <a name="cfn-elasticloadbalancingv2-listener-forwardconfig-targetgroups"></a>
 Information about how traffic will be distributed between multiple target groups in a forward rule\.  
+When providing multiple TargetGroups each requires the weight property\.
 *Required*: No  
 *Type*: List of [TargetGroupTuple](aws-properties-elasticloadbalancingv2-listener-targetgrouptuple.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
It seems like #1016 got reverted after being added. So here we go again

When specifying multiple TargetGroups the TargetGroupTuple property `weight` is required.
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#forward-actions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
