### PR TITLE
Fix typos in aws-properties-ecs-taskdefinition-runtimeplatform

### DIFF
--- a/doc_source/aws-properties-ecs-taskdefinition-runtimeplatform.md
+++ b/doc_source/aws-properties-ecs-taskdefinition-runtimeplatform.md
@@ -2,7 +2,7 @@
 
 Information about the platform for the Amazon ECS service or task\.
 
-For more informataion about `RuntimePlatform`, see [RuntimePlatform](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#runtime-platform) in the *Amazon Elastic Container Service Developer Guide*\.
+For more information about `RuntimePlatform`, see [RuntimePlatform](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#runtime-platform) in the *Amazon Elastic Container Service Developer Guide*\.
 
 ## Syntax<a name="aws-properties-ecs-taskdefinition-runtimeplatform-syntax"></a>
 
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 `CpuArchitecture`  <a name="cfn-ecs-taskdefinition-runtimeplatform-cpuarchitecture"></a>
 The CPU architecture\.  
-You can run your Linux tasks on an ARM\-based platform by setting the value to `ARM64`\. This option is avaiable for tasks that run on Linuc Amazon EC2 instance or Linux containers on Fargate\.  
+You can run your Linux tasks on an ARM\-based platform by setting the value to `ARM64`\. This option is available for tasks that run on Linux Amazon EC2 instances or Linux containers on Fargate\.  
 *Required*: No  
 *Type*: String  
 *Allowed values*: `ARM64 | X86_64`  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes typos in AWS::ECS::TaskDefinition RuntimePlatform


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
