### PR TITLE
Update `RefreshTokenValidity` measurement unit

### DIFF
--- a/doc_source/aws-resource-cognito-userpoolclient.md
+++ b/doc_source/aws-resource-cognito-userpoolclient.md
@@ -206,7 +206,7 @@ The time limit, in days, after which the refresh token is no longer valid and ca
 *Required*: No  
 *Type*: Integer  
 *Minimum*: `0`  
-*Maximum*: `315360000`  
+*Maximum*: `3650`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `SupportedIdentityProviders`  <a name="cfn-cognito-userpoolclient-supportedidentityproviders"></a>


### PR DESCRIPTION
It seems that are seconds and not days from the max limit value (315360000)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
