### PR TITLE
Updated verbiage to mimic AWS documentation

### DIFF
--- a/doc_source/aws-resource-sns-subscription.md
+++ b/doc_source/aws-resource-sns-subscription.md
@@ -1,6 +1,6 @@
 # AWS::SNS::Subscription<a name="aws-resource-sns-subscription"></a>
 
-The `AWS::SNS::Subscription` resource subscribes an endpoint to an Amazon SNS topic\. For a subscription to be created, the owner of the endpoint must confirm the subscription\.
+The `AWS::SNS::Subscription` resource subscribes an endpoint to an Amazon SNS topic\. If the endpoint type is HTTP/S or email, or if the endpoint and the topic are not in the same Amazon Web Services account, the owner of the endpoint must confirm the subscription\.
 
 ## Syntax<a name="aws-resource-sns-subscription-syntax"></a>
 


### PR DESCRIPTION
The verbiage was not clear that if you have a topic and a queue in the same aws account you don't need to confirm the subscription.

The wording was taken from https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html

*Issue #, if available:* #1139

*Description of changes:* Changed the first sentance's wording to match closer the wording of the SNS API's documentation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
