### PR TITLE
Adds CUR allowed compression type, format, and time period values

### DIFF
--- a/doc_source/aws-resource-cur-reportdefinition.md
+++ b/doc_source/aws-resource-cur-reportdefinition.md
@@ -124,6 +124,7 @@ The Region of the S3 bucket that Amazon Web Services delivers the report into\.
 The granularity of the line items in the report\.  
 *Required*: Yes  
 *Type*: String  
+*Allowed values*: `HOURLY | DAILY | MONTHLY`  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 ## Return values<a name="aws-resource-cur-reportdefinition-return-values"></a>

--- a/doc_source/aws-resource-cur-reportdefinition.md
+++ b/doc_source/aws-resource-cur-reportdefinition.md
@@ -80,6 +80,7 @@ The compression format that Amazon Web Services uses for the report\.
 The format that Amazon Web Services saves the report in\.  
 *Required*: Yes  
 *Type*: String  
+*Allowed values*: `textORcsv | Parquet`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `RefreshClosedReports`  <a name="cfn-cur-reportdefinition-refreshclosedreports"></a>

--- a/doc_source/aws-resource-cur-reportdefinition.md
+++ b/doc_source/aws-resource-cur-reportdefinition.md
@@ -73,6 +73,7 @@ The Amazon Resource Name \(ARN\) of the billing view\. You can get this value by
 The compression format that Amazon Web Services uses for the report\.  
 *Required*: Yes  
 *Type*: String  
+*Allowed values*: `ZIP | GZIP | Parquet`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Format`  <a name="cfn-cur-reportdefinition-format"></a>


### PR DESCRIPTION
*Description of changes:*
Docs do not currently list valid compression types, report formats, or time values for CUR definitions. Based on the SDK docs for the [compression type](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/costandusagereportservice@v1.11.0/types#CompressionFormat), [report format](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/costandusagereportservice@v1.11.0/types#ReportFormat), and [time format](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/costandusagereportservice@v1.11.0/types#TimeUnit), this PR adds the allowed values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
