### PR TITLE
Fixing bad quotes in JSON example

### DIFF
--- a/doc_source/aws-resource-logs-querydefinition.md
+++ b/doc_source/aws-resource-logs-querydefinition.md
@@ -82,9 +82,9 @@ The following example creates a query definition\.
 "myQueryDefinition": {
   "Type": "AWS::Logs:: QueryDefinition",
   "Properties": {
-    "name": “myQueryName”
-    “QueryString”: “fields @timestamp, @message | sort @timestamp desc | limit 20”
-    }
+    "Name": "myQueryName",
+    "QueryString": "fields @timestamp, @message | sort @timestamp desc | limit 20"
+  }
 }
 ```
 


### PR DESCRIPTION
Replacing invalid quotation marks and fix incorrect syntax in the JSON example

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
