### PR TITLE
Reference API docs for policy data syntax

### DIFF
--- a/doc_source/aws-resource-fms-policy.md
+++ b/doc_source/aws-resource-fms-policy.md
@@ -155,7 +155,7 @@ An array of `ResourceType` objects\. Use this only to specify multiple resource 
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `SecurityServicePolicyData`  <a name="cfn-fms-policy-securityservicepolicydata"></a>
-Details about the security service that is being used to protect the resources\.  
+Details about the security service that is being used to protect the resources\. Refer to [API Reference](https://docs.aws.amazon.com/fms/2018-01-01/APIReference/API_SecurityServicePolicyData.html) for details on the syntax. 
 This contains the following settings:   
 + Type \- Indicates the service type that the policy uses to protect the resource\. For security group policies, Firewall Manager supports one security group for each common policy and for each content audit policy\. This is an adjustable limit that you can increase by contacting AWS Support\. 
 


### PR DESCRIPTION
*Issue #, if available*:
Unknown

*Description of changes*:
Add a link to the API documentation which describes the syntax of the SecurityServicePolicyData property. I just ran into the use-case of needing to add a rule to the excludeRules element and had to chance down the details of the property. Hopefully this will save someone in the future the trouble..

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
