### PR TITLE
Update CW Composite Alarm yaml example to match json

### DIFF
--- a/doc_source/aws-resource-cloudwatch-compositealarm.md
+++ b/doc_source/aws-resource-cloudwatch-compositealarm.md
@@ -209,7 +209,7 @@ Resources:
     Type: AWS::CloudWatch::CompositeAlarm
     Properties:
       AlarmName: DeploymentInProgress
-      AlarmRule: 
+      AlarmRule: "FALSE"
       AlarmDescription: Manually updated to TRUE/FALSE to disable other alarms
   HighCPUUsage: 
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
*Description of changes:*

The yaml example does not contain AlarmRule value for DeploymentInProgress that is false in json example.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
