### PR TITLE
Update aws-resource-codestarnotifications-notificationrule.md

### DIFF
--- a/doc_source/aws-resource-codestarnotifications-notificationrule.md
+++ b/doc_source/aws-resource-codestarnotifications-notificationrule.md
@@ -82,7 +82,7 @@ The name for the notification rule\. Notification rule names must be unique in y
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Resource`  <a name="cfn-codestarnotifications-notificationrule-resource"></a>
-The Amazon Resource Name \(ARN\) of the resource to associate with the notification rule\. Supported resources include pipelines in AWS CodePipeline, repositories in AWS CodeCommit, and build projects in AWS CodeBuild\.  
+The Amazon Resource Name \(ARN\) of the resource to associate with the notification rule\. Supported resources include pipelines in AWS CodePipeline, repositories in AWS CodeCommit, build projects in AWS CodeBuild, and applications in AWS CodeDeploy\.  
 *Required*: Yes  
 *Type*: String  
 *Pattern*: `^arn:aws[^:\s]*:[^:\s]*:[^:\s]*:[0-9]{12}:[^\s]+$`  


### PR DESCRIPTION
*Description of changes:*

Updated the documentation to include CodeBuild applications as a supported resource type.

I tested creating a CodeBuild notification today and it worked as expected. Example resource:

```
CodeDeployNotification:
    Type: 'AWS::CodeStarNotifications::NotificationRule'
    Properties:
      Name: 'CodeDeployNotification'
      DetailType: FULL
      Resource:
        Fn::Join:
          - ":"
          - - "arn"
            - Fn::FindInMap:
              - PartitionMap
              - Ref: AWS::Region
              - partition
            - "codedeploy"
            - Ref: AWS::Region
            - Ref: AWS::AccountId
            - "application"
            - Ref: CodeDeployApp
      EventTypeIds: 
        - codedeploy-application-deployment-started
        - codedeploy-application-deployment-succeeded
        - codedeploy-application-deployment-failed
      Targets: 
        - TargetType: SNS 
          TargetAddress: !Ref CodeDeployNotificationsTopic
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
