### PR TITLE
fix/missing-link-backup-framework-ControlScope

### DIFF
--- a/doc_source/aws-properties-backup-framework-frameworkcontrol.md
+++ b/doc_source/aws-properties-backup-framework-frameworkcontrol.md
@@ -19,7 +19,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML<a name="aws-properties-backup-framework-frameworkcontrol-syntax.yaml"></a>
 
 ```
-  [ControlInputParameters](#cfn-backup-framework-frameworkcontrol-controlinputparameters): 
+  [ControlInputParameters](#cfn-backup-framework-frameworkcontrol-controlinputparameters):
     - ControlInputParameter
   [ControlName](#cfn-backup-framework-frameworkcontrol-controlname): String
   [ControlScope](#cfn-backup-framework-frameworkcontrol-controlscope): Json
@@ -28,15 +28,15 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-backup-framework-frameworkcontrol-properties"></a>
 
 `ControlInputParameters`  <a name="cfn-backup-framework-frameworkcontrol-controlinputparameters"></a>
-A list of `ParameterName` and `ParameterValue` pairs\.  
-*Required*: No  
-*Type*: List of [ControlInputParameter](aws-properties-backup-framework-controlinputparameter.md)  
+A list of `ParameterName` and `ParameterValue` pairs\.
+*Required*: No
+*Type*: List of [ControlInputParameter](aws-properties-backup-framework-controlinputparameter.md)
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `ControlName`  <a name="cfn-backup-framework-frameworkcontrol-controlname"></a>
-The name of a control\. This name is between 1 and 256 characters\.  
-*Required*: Yes  
-*Type*: String  
+The name of a control\. This name is between 1 and 256 characters\.
+*Required*: Yes
+*Type*: String
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `ControlScope`  <a name="cfn-backup-framework-frameworkcontrol-controlscope"></a>

--- a/doc_source/aws-properties-backup-framework-frameworkcontrol.md
+++ b/doc_source/aws-properties-backup-framework-frameworkcontrol.md
@@ -40,7 +40,7 @@ The name of a control\. This name is between 1 and 256 characters\.
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `ControlScope`  <a name="cfn-backup-framework-frameworkcontrol-controlscope"></a>
-The scope of a control\. The control scope defines what the control will evaluate\. Three examples of control scopes are: a specific backup plan, all backup plans with a specific tag, or all backup plans\. For more information, see `ControlScope`\.  
-*Required*: No  
-*Type*: Json  
+The scope of a control\. The control scope defines what the control will evaluate\. Three examples of control scopes are: a specific backup plan, all backup plans with a specific tag, or all backup plans\. For more information, see [ControlScope](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_ControlScope.html)\.
+*Required*: No
+*Type*: Json
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Description of changes:*

Add link to ControlScope for Backup Framework CloudFormation documentation. Screenshot of missing link:

![image](https://user-images.githubusercontent.com/31919569/153715996-08f267a8-f1b2-4252-ae51-206f2329912f.png)

ControlScope link: https://docs.aws.amazon.com/aws-backup/latest/devguide/API_ControlScope.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
