### PR TITLE
fix(efs): Fix docs for lifecycle policies

### DIFF
--- a/doc_source/aws-properties-efs-filesystem-lifecyclepolicy.md
+++ b/doc_source/aws-properties-efs-filesystem-lifecyclepolicy.md
@@ -9,17 +9,21 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### JSON<a name="aws-properties-efs-filesystem-lifecyclepolicy-syntax.json"></a>
 
 ```
-{
-  "[TransitionToIA](#cfn-efs-filesystem-lifecyclepolicy-transitiontoia)" : String,
-  "[TransitionToPrimaryStorageClass](#cfn-efs-filesystem-lifecyclepolicy-transitiontoprimarystorageclass)" : String
+[
+  {
+    "[TransitionToIA](#cfn-efs-filesystem-lifecyclepolicy-transitiontoia)" : String
+  },
+  {
+    "[TransitionToPrimaryStorageClass](#cfn-efs-filesystem-lifecyclepolicy-transitiontoprimarystorageclass)" : String
+  }
 }
 ```
 
 ### YAML<a name="aws-properties-efs-filesystem-lifecyclepolicy-syntax.yaml"></a>
 
 ```
-  [TransitionToIA](#cfn-efs-filesystem-lifecyclepolicy-transitiontoia): String
-  [TransitionToPrimaryStorageClass](#cfn-efs-filesystem-lifecyclepolicy-transitiontoprimarystorageclass): String
+  - [TransitionToIA](#cfn-efs-filesystem-lifecyclepolicy-transitiontoia): String
+  - [TransitionToPrimaryStorageClass](#cfn-efs-filesystem-lifecyclepolicy-transitiontoprimarystorageclass): String
 ```
 
 ## Properties<a name="aws-properties-efs-filesystem-lifecyclepolicy-properties"></a>


### PR DESCRIPTION
*Issue #, if available:*

CDK https://github.com/aws/aws-cdk/issues/19058 

*Description of changes:*

Current docs for `LifecyclePolicies` is not accurate. `LifecyclePolicies` expects up to two lists containing a single `LifecyclePolicy`.

See: https://docs.aws.amazon.com/efs/latest/ug/API_PutLifecycleConfiguration.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
