### PR TITLE
Correct Redis Authtoken password constraints

### DIFF
--- a/doc_source/aws-resource-elasticache-replicationgroup.md
+++ b/doc_source/aws-resource-elasticache-replicationgroup.md
@@ -125,7 +125,7 @@ For HIPAA compliance, you must specify `TransitEncryptionEnabled` as `true`, an 
 Password constraints:  
 + Must be only printable ASCII characters\.
 + Must be at least 16 characters and no more than 128 characters in length\.
-+ Cannot contain any of the following characters: '/', '"', or '@'\. 
++ Nonalphanumeric characters are restricted to (!, &, #, $, ^, <, >, -)\.
 For more information, see [AUTH password](http://redis.io/commands/AUTH) at http://redis\.io/commands/AUTH\.  
 *Required*: No  
 *Type*: String  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The documented Authtoken constraints don't match the requirements specified in the Elasticache Auth Overview documentation and result in 'Invalid AuthToken provided' errors
correct requirements copied from the [auth-overview](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html#auth-overviewl) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
