### PR TITLE
Patch 1

### DIFF
--- a/doc_source/rules-section-structure.md
+++ b/doc_source/rules-section-structure.md
@@ -953,8 +953,8 @@ Rules:
   SubnetsInVPC:
     Assertions:
       - Assert:
-          Fn::EachMemberEquals:
-            - Fn::ValueOf:
+          'Fn::EachMemberEquals':
+            - 'Fn::ValueOf':
                 - Subnets
                 - VpcId
             - Ref: VpcId

--- a/doc_source/rules-section-structure.md
+++ b/doc_source/rules-section-structure.md
@@ -296,16 +296,16 @@ You will be billed for the AWS resources used if you create a stack from this te
             "Assertions": [
                 {
                     "Assert": {
-                        "Fn::EachMemberIn": [
-                            {
-                                "Fn::ValueOfAll": [
-                                    "AWS::EC2::Subnet::Id",
-                                    "VpcId"
-                                ]
-                            },
-                            {
-                                "Fn::RefAll": "AWS::EC2::VPC::Id"
-                            }
+                        "Fn::EachMemberEquals": [
+                          {
+                            "Fn::ValueOf": [
+                              "Subnets",
+                              "VpcId"
+                            ]
+                          },
+                          {
+                            "Ref": "VpcId"
+                          }
                         ]
                     },
                     "AssertDescription": "All subnets must in the VPC"
@@ -953,11 +953,11 @@ Rules:
   SubnetsInVPC:
     Assertions:
       - Assert:
-          'Fn::EachMemberIn':
-            - 'Fn::ValueOfAll':
-                - 'AWS::EC2::Subnet::Id'
+          Fn::EachMemberEquals:
+            - Fn::ValueOf:
+                - Subnets
                 - VpcId
-            - 'Fn::RefAll': 'AWS::EC2::VPC::Id'
+            - Ref: VpcId
         AssertDescription: All subnets must in the VPC
   ValidateHostedZone:
     RuleCondition: !Equals 

--- a/doc_source/rules-section-structure.md
+++ b/doc_source/rules-section-structure.md
@@ -297,15 +297,15 @@ You will be billed for the AWS resources used if you create a stack from this te
                 {
                     "Assert": {
                         "Fn::EachMemberEquals": [
-                          {
-                            "Fn::ValueOf": [
-                              "Subnets",
-                              "VpcId"
-                            ]
-                          },
-                          {
-                            "Ref": "VpcId"
-                          }
+                            {
+                                "Fn::ValueOf": [
+                                    "Subnets",
+                                    "VpcId"
+                                ]
+                            },
+                            {
+                                "Ref": "VpcId"
+                            }
                         ]
                     },
                     "AssertDescription": "All subnets must in the VPC"


### PR DESCRIPTION
Description of changes:
In the example CloudFormation template containing assert statement with description "All subnets must be in the selected VPC", the implementation seems erroneous.  It seems to check that all subnets in a stack's region are associated with a VPC from that same region which I believe is always true (except maybe for EC2 classic).  I believe I implemented what was actually intended but please verify as I'm just getting started with CloudFormation Rules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.