### PR TITLE
Update aws-resource-apigatewayv2-authorizer.md

### DIFF
--- a/doc_source/aws-resource-apigatewayv2-authorizer.md
+++ b/doc_source/aws-resource-apigatewayv2-authorizer.md
@@ -159,6 +159,9 @@ The following example creates a Lambda `authorizer` resource for the `MyApi` API
                             "Ref": "AWS::Region"
                         },
                         ":lambda:path/2015-03-31/functions/",
+                        {
+                            "Fn::GetAtt", ["MyCustomAuthorizer", "Arn"]
+                        },
                         "/invocations"
                     ]
                 ]
@@ -189,6 +192,7 @@ Authorizer:
         - ':apigateway:'
         - !Ref 'AWS::Region'
         - ':lambda:path/2015-03-31/functions/'
+        - !GetAtt MyCustomAuthorizer.Arn
         - /invocations
     AuthorizerResultTtlInSeconds: 500
     IdentitySource:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Add a  missing `!GetAtt MyCustomAuthorizer.Arn` for YAML, and likewise for JSON.  Here `MyCustomAuthorizer` is intended as a stand-in for the resource whose type is `AWS::Lambda::Function` (or some moral equivalent, depending on the transform(s) used).  That function should implement the custom authorization logic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
