### PR TITLE
Added quotes to version of LexRuntimeRolePolicy

### DIFF
--- a/doc_source/aws-resource-lex-bot.md
+++ b/doc_source/aws-resource-lex-bot.md
@@ -162,7 +162,7 @@ Resources:
       Policies:
         - PolicyName: LexRuntimeRolePolicy
           PolicyDocument:
-            Version: 2012-10-17
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:


### PR DESCRIPTION
YAML to JSON converters, detect this as date and convert the value to "2012-10-17T00:00:00.000Z", when used without quotes.
As a result, couldformation template is corrupted and "Error Code: MalformedPolicyDocument;" is returned by AWS cloudformation.

Verified because it worked fine for AssumeRolePolicyDocument version which is in quotes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
