### PR TITLE
Fix markdown of some examples for AWS::MSK::Cluster resource

### DIFF
--- a/doc_source/aws-resource-msk-cluster.md
+++ b/doc_source/aws-resource-msk-cluster.md
@@ -175,12 +175,27 @@ Resources:
 #### <a name="aws-resource-msk-cluster--examples--Create_an_MSK_Cluster_Where_You_Only_Specify_Values_for_the_Required_Properties--JSON"></a>
 
 ```
-{ "Description": "MSK Cluster with required properties.",
-                "Resources": { "TestCluster": { "Type": "AWS::MSK::Cluster", "Properties": {
-                "ClusterName": "ClusterWithRequiredProperties", "KafkaVersion": "2.2.1",
-                "NumberOfBrokerNodes": 3, "BrokerNodeGroupInfo": { "InstanceType": "kafka.m5.large",
-                "ClientSubnets": [ "ReplaceWithSubnetId1", "ReplaceWithSubnetId2",
-                "ReplaceWithSubnetId3" ] } } } } }
+{
+  "Description": "MSK Cluster with required properties.",
+  "Resources": {
+    "TestCluster": {
+      "Type": "AWS::MSK::Cluster",
+      "Properties": {
+        "ClusterName": "ClusterWithRequiredProperties",
+        "KafkaVersion": "2.2.1",
+        "NumberOfBrokerNodes": 3,
+        "BrokerNodeGroupInfo": {
+          "InstanceType": "kafka.m5.large",
+          "ClientSubnets": [
+            "ReplaceWithSubnetId1",
+            "ReplaceWithSubnetId2",
+            "ReplaceWithSubnetId3"
+          ]
+        }
+      }
+    }
+  }
+}
 ```
 
 ### Create an MSK Cluster Where You Explicitly Set All Properties<a name="aws-resource-msk-cluster--examples--Create_an_MSK_Cluster_Where_You_Explicitly_Set_All_Properties"></a>
@@ -188,39 +203,115 @@ Resources:
 #### YAML<a name="aws-resource-msk-cluster--examples--Create_an_MSK_Cluster_Where_You_Explicitly_Set_All_Properties--yaml"></a>
 
 ```
-Description: MSK Cluster with all properties Resources:
-                TestCluster: Type: 'AWS::MSK::Cluster' Properties: ClusterName:
-                ClusterWithAllProperties KafkaVersion: 2.2.1 NumberOfBrokerNodes: 3
-                EnhancedMonitoring: PER_BROKER EncryptionInfo: EncryptionAtRest: DataVolumeKMSKeyId:
-                ReplaceWithKmsKeyArn EncryptionInTransit: ClientBroker: TLS InCluster: true
-                OpenMonitoring: Prometheus: JmxExporter: EnabledInBroker: "true" NodeExporter:
-                EnabledInBroker: "true" ConfigurationInfo: Arn: ReplaceWithConfigurationArn
-                Revision: 1 ClientAuthentication: Tls: CertificateAuthorityArnList: -
-                ReplaceWithCAArn Tags: Environment: Test Owner: QATeam BrokerNodeGroupInfo:
-                BrokerAZDistribution: DEFAULT InstanceType: kafka.m5.large SecurityGroups: -
-                ReplaceWithSecurityGroupId StorageInfo: EBSStorageInfo: VolumeSize: 100
-                ClientSubnets: - ReplaceWithSubnetId1 - ReplaceWithSubnetId2 -
-                ReplaceWithSubnetId3
+Description: MSK Cluster with all properties
+Resources:
+  TestCluster:
+    Type: 'AWS::MSK::Cluster'
+    Properties:
+      ClusterName: ClusterWithAllProperties
+      KafkaVersion: 2.2.1
+      NumberOfBrokerNodes: 3
+      EnhancedMonitoring: PER_BROKER
+      EncryptionInfo:
+        EncryptionAtRest:
+          DataVolumeKMSKeyId: ReplaceWithKmsKeyArn
+          EncryptionInTransit:
+            ClientBroker: TLS
+            InCluster: true
+      OpenMonitoring:
+        Prometheus:
+          JmxExporter:
+            EnabledInBroker: "true"
+          NodeExporter:
+            EnabledInBroker: "true"
+      ConfigurationInfo:
+        Arn: ReplaceWithConfigurationArn
+        Revision: 1
+      ClientAuthentication:
+        Tls:
+          CertificateAuthorityArnList:
+            - ReplaceWithCAArn
+      Tags:
+        Environment: Test
+        Owner: QATeam
+      BrokerNodeGroupInfo:
+        BrokerAZDistribution: DEFAULT
+        InstanceType: kafka.m5.large
+        SecurityGroups:
+          - ReplaceWithSecurityGroupId
+        StorageInfo:
+          EBSStorageInfo:
+            VolumeSize: 100
+        ClientSubnets:
+          - ReplaceWithSubnetId1
+          - ReplaceWithSubnetId2
+          - ReplaceWithSubnetId3
 ```
 
 #### <a name="aws-resource-msk-cluster--examples--Create_an_MSK_Cluster_Where_You_Explicitly_Set_All_Properties--JSON"></a>
 
 ```
-{ "Description": "MSK Cluster with all properties",
-                "Resources": { "TestCluster": { "Type": "AWS::MSK::Cluster", "Properties": {
-                "ClusterName": "ClusterWithAllProperties", "KafkaVersion": "2.2.1",
-                "NumberOfBrokerNodes": 3, "EnhancedMonitoring": "PER_BROKER", "EncryptionInfo": {
-                "EncryptionAtRest": { "DataVolumeKMSKeyId": "ReplaceWithKmsKeyArn" },
-                "EncryptionInTransit": { "ClientBroker": "TLS", "InCluster": true } },
-                "OpenMonitoring": { "Prometheus": { "JmxExporter": { "EnabledInBroker": "true" }
-                "NodeExporter": { "EnabledInBroker": "true" } } }, "ConfigurationInfo": { "Arn":
-                "ReplaceWithConfigurationArn", "Revision": 1 }, "ClientAuthentication": { "Tls": {
-                "CertificateAuthorityArnList": [ "ReplaceWithCAArn" ] } }, "Tags": { "Environment":
-                "Test", "Owner" : "QATeam" }, "BrokerNodeGroupInfo": { "BrokerAZDistribution":
-                "DEFAULT", "InstanceType": "kafka.m5.large", "SecurityGroups": [
-                "ReplaceWithSecurityGroupId" ], "StorageInfo": { "EBSStorageInfo": { "VolumeSize":
-                100 } }, "ClientSubnets": [ "ReplaceWithSubnetId1", "ReplaceWithSubnetId2",
-                "ReplaceWithSubnetId3" ] } } } } }
+{
+  "Description": "MSK Cluster with all properties",
+  "Resources": {
+    "TestCluster": {
+      "Type": "AWS::MSK::Cluster",
+      "Properties": {
+        "ClusterName": "ClusterWithAllProperties",
+        "KafkaVersion": "2.2.1",
+        "NumberOfBrokerNodes": 3,
+        "EnhancedMonitoring": "PER_BROKER",
+        "EncryptionInfo": {
+          "EncryptionAtRest": {
+            "DataVolumeKMSKeyId": "ReplaceWithKmsKeyArn"
+          },
+          "EncryptionInTransit": {
+            "ClientBroker": "TLS",
+            "InCluster": true
+          }
+        },
+        "OpenMonitoring": {
+          "Prometheus": {
+            "JmxExporter": {
+              "EnabledInBroker": "true"
+            }
+            "NodeExporter": {
+              "EnabledInBroker": "true"
+            }
+          }
+        },
+        "ConfigurationInfo": {
+          "Arn": "ReplaceWithConfigurationArn",
+          "Revision": 1
+        },
+        "ClientAuthentication": {
+          "Tls": {
+            "CertificateAuthorityArnList": [ "ReplaceWithCAArn" ]
+          }
+        },
+        "Tags": {
+          "Environment": "Test",
+          "Owner": "QATeam"
+        },
+        "BrokerNodeGroupInfo": {
+          "BrokerAZDistribution": "DEFAULT",
+          "InstanceType": "kafka.m5.large",
+          "SecurityGroups": [ "ReplaceWithSecurityGroupId" ],
+          "StorageInfo": {
+            "EBSStorageInfo": {
+              "VolumeSize": 100
+            }
+          },
+          "ClientSubnets": [
+            "ReplaceWithSubnetId1",
+            "ReplaceWithSubnetId2",
+            "ReplaceWithSubnetId3"
+          ]
+        }
+      }
+    }
+  }
+}
 ```
 
 ### Get Started With Amazon MSK<a name="aws-resource-msk-cluster--examples--Get_Started_With_Amazon_MSK"></a>

--- a/doc_source/aws-resource-msk-cluster.md
+++ b/doc_source/aws-resource-msk-cluster.md
@@ -156,11 +156,20 @@ In the following examples you can find the YAML for each template, followed by t
 #### YAML<a name="aws-resource-msk-cluster--examples--Create_an_MSK_Cluster_Where_You_Only_Specify_Values_for_the_Required_Properties--yaml"></a>
 
 ```
-Description: MSK Cluster with required properties. Resources:
-                TestCluster: Type: 'AWS::MSK::Cluster' Properties: ClusterName:
-                ClusterWithRequiredProperties KafkaVersion: 2.2.1 NumberOfBrokerNodes: 3
-                BrokerNodeGroupInfo: InstanceType: kafka.m5.large ClientSubnets: -
-                ReplaceWithSubnetId1 - ReplaceWithSubnetId2 - ReplaceWithSubnetId3
+Description: MSK Cluster with required properties.
+Resources:
+  TestCluster:
+    Type: 'AWS::MSK::Cluster'
+    Properties:
+      ClusterName: ClusterWithRequiredProperties
+      KafkaVersion: 2.2.1
+      NumberOfBrokerNodes: 3
+      BrokerNodeGroupInfo:
+        InstanceType: kafka.m5.large
+        ClientSubnets:
+          - ReplaceWithSubnetId1
+          - ReplaceWithSubnetId2
+          - ReplaceWithSubnetId3
 ```
 
 #### <a name="aws-resource-msk-cluster--examples--Create_an_MSK_Cluster_Where_You_Only_Specify_Values_for_the_Required_Properties--JSON"></a>


### PR DESCRIPTION
Examples for AWS::MSK::Cluster resource are wrong structured. The first two (YAML and JSON) were fixed.