### PR TITLE
Fn::Equals requires a list of 2 string parameters

### DIFF
--- a/doc_source/intrinsic-function-reference-conditions.md
+++ b/doc_source/intrinsic-function-reference-conditions.md
@@ -203,7 +203,7 @@ Syntax for the short form:
 ### Parameters<a name="w11259ab1c31c28c21c19b7"></a>
 
 `value`  
-A value of any type that you want to compare\.
+A value of `String` type that you want to compare\.
 
 ### Example<a name="w11259ab1c31c28c21c19b9"></a>
 


### PR DESCRIPTION
*Issue #, if available:*
A type issue in Fn::Equals doc

*Description of changes:*
I have ran into an error `Template error: every Fn::Equals object requires a list of 2 string parameters.`
which is conflicted with the doc `A value of any type that you want to compare.`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
