### PR TITLE
Note/maintenance window targets

### DIFF
--- a/doc_source/aws-properties-ssm-maintenancewindowtarget-targets.md
+++ b/doc_source/aws-properties-ssm-maintenancewindowtarget-targets.md
@@ -21,26 +21,26 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 ```
   [Key](#cfn-ssm-maintenancewindowtarget-targets-key): String
-  [Values](#cfn-ssm-maintenancewindowtarget-targets-values): 
+  [Values](#cfn-ssm-maintenancewindowtarget-targets-values):
     - String
 ```
 
 ## Properties<a name="aws-properties-ssm-maintenancewindowtarget-targets-properties"></a>
 
 `Key`  <a name="cfn-ssm-maintenancewindowtarget-targets-key"></a>
-User\-defined criteria for sending commands that target managed nodes that meet the criteria\.  
-*Required*: Yes  
-*Type*: String  
-*Minimum*: `1`  
-*Maximum*: `163`  
-*Pattern*: `^[\p{L}\p{Z}\p{N}_.:/=\-@]*$|resource-groups:ResourceTypeFilters|resource-groups:Name`  
+User\-defined criteria for sending commands that target managed nodes that meet the criteria\.
+*Required*: Yes
+*Type*: String
+*Minimum*: `1`
+*Maximum*: `163`
+*Pattern*: `^[\p{L}\p{Z}\p{N}_.:/=\-@]*$|resource-groups:ResourceTypeFilters|resource-groups:Name`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Values`  <a name="cfn-ssm-maintenancewindowtarget-targets-values"></a>
-User\-defined criteria that maps to `Key`\. For example, if you specified `tag:ServerRole`, you could specify `value:WebServer` to run a command on instances that include EC2 tags of `ServerRole,WebServer`\.   
-Depending on the type of target, the maximum number of values for a key might be lower than the global maximum of 50\.  
+User\-defined criteria that maps to `Key`\. For example, if you specified `tag:ServerRole`, you could specify `value:WebServer` to run a command on instances that include EC2 tags of `ServerRole,WebServer`\.
+Depending on the type of target, the maximum number of values for a key might be lower than the global maximum of 50\.
 You can target all values of a particular key by specifying a `*` for `Values`\.
-*Required*: Yes  
-*Type*: List of String  
-*Maximum*: `50`  
+*Required*: Yes
+*Type*: List of String
+*Maximum*: `50`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/doc_source/aws-properties-ssm-maintenancewindowtarget-targets.md
+++ b/doc_source/aws-properties-ssm-maintenancewindowtarget-targets.md
@@ -39,6 +39,7 @@ User\-defined criteria for sending commands that target managed nodes that meet 
 `Values`  <a name="cfn-ssm-maintenancewindowtarget-targets-values"></a>
 User\-defined criteria that maps to `Key`\. For example, if you specified `tag:ServerRole`, you could specify `value:WebServer` to run a command on instances that include EC2 tags of `ServerRole,WebServer`\.   
 Depending on the type of target, the maximum number of values for a key might be lower than the global maximum of 50\.  
+You can target all values of a particular key by specifying a `*` for `Values`\.
 *Required*: Yes  
 *Type*: List of String  
 *Maximum*: `50`  

--- a/doc_source/aws-properties-ssm-maintenancewindowtarget-targets.md
+++ b/doc_source/aws-properties-ssm-maintenancewindowtarget-targets.md
@@ -39,7 +39,7 @@ User\-defined criteria for sending commands that target managed nodes that meet 
 `Values`  <a name="cfn-ssm-maintenancewindowtarget-targets-values"></a>
 User\-defined criteria that maps to `Key`\. For example, if you specified `tag:ServerRole`, you could specify `value:WebServer` to run a command on instances that include EC2 tags of `ServerRole,WebServer`\.
 Depending on the type of target, the maximum number of values for a key might be lower than the global maximum of 50\.
-You can target all values of a particular key by specifying a `*` for `Values`\.
+You can target all values of a particular key by specifying `Key=tag-key` and `Values=Name,Instance-Type,CostCenter`, where `Name`, `Instance-Type`, and `CostCenter` could be the Tag Keys assigned to the EC2 instances,
 *Required*: Yes
 *Type*: List of String
 *Maximum*: `50`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- [OUTDATED THIS DOES NOT HAVE THE INTENDED EFFECT REFER TO LATEST COMMENT in PR FOR WORKING EXAMPLE] Add note on how to target all `Values` for a particular `Key`. This is achieved by specifying `Values` with a `*`. In the console, `Values` is `Optional` but in CloudFormation, `Values` is a `Required` attribute and we cannot pass in an empty string. To replicate the console behaviour, we must specify a `*`. Mentioning this in the documentation could be useful for those who would like to target all `Values` for a particular `Key`

![image](https://user-images.githubusercontent.com/31919569/158852836-1ac536c1-e498-4351-b15b-d3e741611069.png)

- Style fixes by removing trailing whitespaces
 
Console reference:

- The input box shows `Tag value (optional)`
    <img width="695" alt="image" src="https://user-images.githubusercontent.com/31919569/157892221-3c33ab2c-cf4c-4192-b730-89f580a45ff4.png">
- Upon clicking `Add`, we see `Name: (All values)`
    <img width="690" alt="image" src="https://user-images.githubusercontent.com/31919569/157892252-0b25db4d-f025-4c93-a37d-ee8166525fb0.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
