### PR TITLE
Update aws-properties-ec2-launchtemplate-networkinterface

### DIFF
--- a/doc_source/aws-properties-ec2-launchtemplate-networkinterface.md
+++ b/doc_source/aws-properties-ec2-launchtemplate-networkinterface.md
@@ -82,7 +82,7 @@ A description for the network interface\.
 
 `DeviceIndex`  <a name="cfn-ec2-launchtemplate-networkinterface-deviceindex"></a>
 The device index for the network interface attachment\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: Integer  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
DeviceIndex seems required for cfn-ec2-launchtemplate-networkinterface

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
