### PR TITLE
Remove wording about requiring a space and colon

### DIFF
--- a/doc_source/outputs-section-structure.md
+++ b/doc_source/outputs-section-structure.md
@@ -8,7 +8,7 @@ Output values are available after the stack operation is complete\. Stack output
 
 ## Syntax<a name="outputs-section-syntax"></a>
 
-The `Outputs` section consists of the key name `Outputs`, followed by a space and a single colon\. You can declare a maximum of 200 outputs in a template\.
+The `Outputs` section consists of the key name `Outputs`\. You can declare a maximum of 200 outputs in a template\.
 
 The following example demonstrates the structure of the `Outputs` section\.
 


### PR DESCRIPTION
This is somewhat confusing language that doesn't seem to be present for the other top-level keys within the template. In YAML, it would even be odd to include such a space and it isn't necessary in JSON.

*Issue #, if available:*

*Description of changes:*

Removed a section of a sentence to make the documentation of the `Outputs` section match that for other sections such as `Mappings` and `Resources`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
