### PR TITLE
Linux, not Linuc

### DIFF
--- a/doc_source/aws-properties-ecs-taskdefinition-runtimeplatform.md
+++ b/doc_source/aws-properties-ecs-taskdefinition-runtimeplatform.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 `CpuArchitecture`  <a name="cfn-ecs-taskdefinition-runtimeplatform-cpuarchitecture"></a>
 The CPU architecture\.  
-You can run your Linux tasks on an ARM\-based platform by setting the value to `ARM64`\. This option is avaiable for tasks that run on Linuc Amazon EC2 instance or Linux containers on Fargate\.  
+You can run your Linux tasks on an ARM\-based platform by setting the value to `ARM64`\. This option is avaiable for tasks that run on Linux Amazon EC2 instance or Linux containers on Fargate\.
 *Required*: No  
 *Type*: String  
 *Allowed values*: `ARM64 | X86_64`  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes a typo - `Linuc` to `Linux`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
