### PR TITLE
Corrected the case of dependsOn in examples.

### DIFF
--- a/doc_source/aws-resource-ecs-taskdefinition.md
+++ b/doc_source/aws-resource-ecs-taskdefinition.md
@@ -394,7 +394,7 @@ The following example defines an Amazon ECS task definition that specifies EC2 a
                             "/bin/sh -c \"while true; do /bin/date > /var/www/my-vol/date; sleep 1; done\""
                         ],
                         "Essential": false,
-                        "DependsOn": [
+                        "dependsOn": [
                             {
                                 "ContainerName": "my-app",
                                 "Condition": "START"
@@ -457,7 +457,7 @@ Resources:
           Command: 
             - "/bin/sh -c \"while true; do /bin/date > /var/www/my-vol/date; sleep 1; done\""
           Essential: false
-          DependsOn:
+          dependsOn:
             - ContainerName: my-app
               Condition: START
           VolumesFrom: 


### PR DESCRIPTION
Corrected the two examples provided which indicated that `dependsOn` should have been upper camel case instead of lower camel case. Using upper camel case and `DependsOn` results in:
```
Parameter validation failed:
Unknown parameter in containerDefinitions[0]: "DependsOn", must be one of: name, image, repositoryCredentials, cpu, memory, memoryReservation, links, portMappings, essential, entryPoint, command, environment, environmentFiles, mountPoints, volumesFrom, linuxParameters, secrets, dependsOn, startTimeout, stopTimeout, hostname, user, workingDirectory, disableNetworking, privileged, readonlyRootFilesystem, dnsServers, dnsSearchDomains, extraHosts, dockerSecurityOptions, interactive, pseudoTerminal, dockerLabels, ulimits, logConfiguration, healthCheck, systemControls, resourceRequirements, firelensConfiguration
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
