### PR TITLE
Update aws-properties-dynamodb-globaltable-ssespecification.md

### DIFF
--- a/doc_source/aws-properties-dynamodb-globaltable-ssespecification.md
+++ b/doc_source/aws-properties-dynamodb-globaltable-ssespecification.md
@@ -35,5 +35,5 @@ Server\-side encryption type\. The only supported value is:
 +  `KMS` \- Server\-side encryption that uses AWS Key Management Service\. The key is stored in your account and is managed by AWS KMS \(AWS KMS charges apply\)\.
 *Required*: No  
 *Type*: String  
-*Allowed values*: `AES256 | KMS`  
+*Allowed values*: `KMS`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
"Invalid request provided: The only valid SSEType is KMS"

AES256 is unsupported

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
