### PR TITLE
Fix/maintenance window task regex

### DIFF
--- a/doc_source/aws-resource-ssm-maintenancewindowtask.md
+++ b/doc_source/aws-resource-ssm-maintenancewindowtask.md
@@ -95,9 +95,9 @@ Although this element is listed as "Required: No", a value can be omitted only w
 For maintenance window tasks without a target specified, you can't supply a value for this option\. Instead, the system inserts a placeholder value of `1`\. This value doesn't affect the running of your task\.
 *Required*: No  
 *Type*: String  
-*Minimum*: `1`  
-*Maximum*: `7`  
-*Pattern*: `^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$`  
+*Minimum*: `0`
+*Maximum*: `7`
+*Pattern*: `^([0-7]|[1-9][0-9]%|[0-9]%|100%)$`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Name`  <a name="cfn-ssm-maintenancewindowtask-name"></a>

--- a/doc_source/aws-resource-ssm-maintenancewindowtask.md
+++ b/doc_source/aws-resource-ssm-maintenancewindowtask.md
@@ -86,7 +86,7 @@ For maintenance window tasks without a target specified, you can't supply a valu
 *Type*: String  
 *Minimum*: `1`  
 *Maximum*: `7`  
-*Pattern*: `^([1-9][0-9]*|[1-9][0-9]%|[1-9]%|100%)$`  
+*Pattern*: `^([1-7]|[1-9][0-9]%|[1-9]%|100%)$`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `MaxErrors`  <a name="cfn-ssm-maintenancewindowtask-maxerrors"></a>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix Regex Patterns for `MaxConcurrency` and `MaxErrors` to correctly reflect what is allowed on the console.
- `MaxConcurrency`
    1. Allows a Percentage from 1 to 100%
    2. Minimum Value: 1
    3. Maximum Value: 7
- `MaxErrors`
    1. Allows a Percentage from 0 to 100%
    2. Minimum Value: 0
    3. Maximum Value: 7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
