### PR TITLE
Document allowed values for MediaPackage HlsEncryption

### DIFF
--- a/doc_source/aws-properties-mediapackage-packagingconfiguration-hlsencryption.md
+++ b/doc_source/aws-properties-mediapackage-packagingconfiguration-hlsencryption.md
@@ -37,7 +37,7 @@ A 128\-bit, 16\-byte hex value represented by a 32\-character string, used with 
 HLS encryption type\.   
 *Required*: No  
 *Type*: String  
-*Allowed values*: `AES_128 | SAMPLE_AES`
+*Allowed values*: `AES_128 | SAMPLE_AES`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `SpekeKeyProvider`  <a name="cfn-mediapackage-packagingconfiguration-hlsencryption-spekekeyprovider"></a>

--- a/doc_source/aws-properties-mediapackage-packagingconfiguration-hlsencryption.md
+++ b/doc_source/aws-properties-mediapackage-packagingconfiguration-hlsencryption.md
@@ -37,6 +37,7 @@ A 128\-bit, 16\-byte hex value represented by a 32\-character string, used with 
 HLS encryption type\.   
 *Required*: No  
 *Type*: String  
+*Allowed values*: `AES_128 | SAMPLE_AES`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `SpekeKeyProvider`  <a name="cfn-mediapackage-packagingconfiguration-hlsencryption-spekekeyprovider"></a>


### PR DESCRIPTION
*Issue #, if available:*
The `MediaPackage` `PackagingConfiguration` for Hls (`HlsEncryption`) is missing how to configure the `EncryptionMethod` (whether to use `AES 128-bit` or `Sample AES`).

*Description of changes:*
I was working on a Cloudformation stack to create new PackagingConfiguration for HLS when I got this error:

<img width="1474" alt="image" src="https://user-images.githubusercontent.com/7445123/164874930-82aea2bf-1801-4a3e-9f78-0cac3580e9ff.png">

I didn't find any mention in the documentation of an enum or allowed values for the EncryptionMethod. Hence, I tinkered around with Chrome Devtools and React Debugger and found these allowed values:

![image](https://user-images.githubusercontent.com/7445123/164875131-afe91df2-4bb5-4d98-9d4f-0ff8d1fd61d8.png)

![image](https://user-images.githubusercontent.com/7445123/164875291-4f6acaf3-e7fb-4b07-9f27-0ec14ed1725a.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
