### PR TITLE
Fix route53 Resolver Rule missing double quote

### DIFF
--- a/doc_source/aws-resource-route53resolver-resolverrule.md
+++ b/doc_source/aws-resource-route53resolver-resolverrule.md
@@ -150,7 +150,7 @@ The following example creates an Amazon Route 53 outbound resolver rule\.
         "Port" : "53"
       },
       {
-        "Ip" : "192.0.2.99,
+        "Ip" : "192.0.2.99",
         "Port" : "53"
       }
     ]


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awsdocs/aws-cloudformation-user-guide/issues/1207

*Description of changes:*
Missing double quote in the JSON example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
