### PR TITLE
Update aws-properties-dynamodb-table-ssespecification.md

### DIFF
--- a/doc_source/aws-properties-dynamodb-table-ssespecification.md
+++ b/doc_source/aws-properties-dynamodb-table-ssespecification.md
@@ -41,6 +41,6 @@ Indicates whether server\-side encryption is done using an AWS managed key or an
 `SSEType`  <a name="cfn-dynamodb-table-ssespecification-ssetype"></a>
 Server\-side encryption type\. The only supported value is:  
 +  `KMS` \- Server\-side encryption that uses AWS Key Management Service\. The key is stored in your account and is managed by AWS KMS \(AWS KMS charges apply\)\.
-*Required*: No  
+*Required*: Yes (_SSEType KMS is required if KMSMasterKeyId is specified_)  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/doc_source/aws-properties-dynamodb-table-ssespecification.md
+++ b/doc_source/aws-properties-dynamodb-table-ssespecification.md
@@ -41,6 +41,6 @@ Indicates whether server\-side encryption is done using an AWS managed key or an
 `SSEType`  <a name="cfn-dynamodb-table-ssespecification-ssetype"></a>
 Server\-side encryption type\. The only supported value is:  
 +  `KMS` \- Server\-side encryption that uses AWS Key Management Service\. The key is stored in your account and is managed by AWS KMS \(AWS KMS charges apply\)\.
-*Required*: Yes (SSEType KMS is required if KMSMasterKeyId is specified)  
+*Required*: Yes, If KMSMasterKeyId is specified  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/doc_source/aws-properties-dynamodb-table-ssespecification.md
+++ b/doc_source/aws-properties-dynamodb-table-ssespecification.md
@@ -41,6 +41,7 @@ Indicates whether server\-side encryption is done using an AWS managed key or an
 `SSEType`  <a name="cfn-dynamodb-table-ssespecification-ssetype"></a>
 Server\-side encryption type\. The only supported value is:  
 +  `KMS` \- Server\-side encryption that uses AWS Key Management Service\. The key is stored in your account and is managed by AWS KMS \(AWS KMS charges apply\)\.
+
 *Required*: Yes, If KMSMasterKeyId is specified  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/doc_source/aws-properties-dynamodb-table-ssespecification.md
+++ b/doc_source/aws-properties-dynamodb-table-ssespecification.md
@@ -41,6 +41,6 @@ Indicates whether server\-side encryption is done using an AWS managed key or an
 `SSEType`  <a name="cfn-dynamodb-table-ssespecification-ssetype"></a>
 Server\-side encryption type\. The only supported value is:  
 +  `KMS` \- Server\-side encryption that uses AWS Key Management Service\. The key is stored in your account and is managed by AWS KMS \(AWS KMS charges apply\)\.
-*Required*: Yes (_SSEType KMS is required if KMSMasterKeyId is specified_)  
+*Required*: Yes (SSEType KMS is required if KMSMasterKeyId is specified)  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Specifying that `SSEType` is required if KMSMasterKeyId is specified
If that was not done, then you would receive an error `SSEType KMS is required if KMSMasterKeyId is specified`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
