### PR TITLE
Update AWS-PatchInstanceWithRollback example

### DIFF
--- a/doc_source/aws-resource-ssm-maintenancewindowtask.md
+++ b/doc_source/aws-resource-ssm-maintenancewindowtask.md
@@ -486,7 +486,11 @@ The following example creates a Systems Manager maintenance window task that use
                 "TaskInvocationParameters": {
                     "MaintenanceWindowAutomationParameters": {
                         "DocumentVersion": "1",
-                        "Parameters": '{ \"instanceId\": \"{{RESOURCE_ID}}\" }'
+                        "Parameters": {
+                            "instanceId": [
+                                "{{RESOURCE_ID}}"
+                            ]
+                        }
                     }
                 },
                 "Priority": 1,
@@ -518,8 +522,10 @@ Resources:
       TaskType: AUTOMATION
       TaskInvocationParameters:
         MaintenanceWindowAutomationParameters:
-    DocumentVersion: 1
-    Parameters: '{ \"instanceId\": \"{{RESOURCE_ID}}\" }'
+          DocumentVersion: 1
+          Parameters:
+            instanceId:
+              - '{{RESOURCE_ID}}'
       Priority: 1
       MaxConcurrency: 5
       MaxErrors: 5


### PR DESCRIPTION
Update the Task-invocation Parameters in the example to match the correct syntax found here: https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_RegisterTaskWithMaintenanceWindow.html#API_RegisterTaskWithMaintenanceWindow_Examples

*Issue #, if available:*

*Description of changes:*
Changed the parameter value from {"string": "string"} to {"string": ["string"]}, so that the specific example is usable as is by someone following through the documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
