### PR TITLE
Update WAFv2.LoggingConfiguration documentation

### DIFF
--- a/doc_source/aws-resource-wafv2-loggingconfiguration.md
+++ b/doc_source/aws-resource-wafv2-loggingconfiguration.md
@@ -3,7 +3,7 @@
 Defines an association between logging destinations and a web ACL resource, for logging from AWS WAF\. As part of the association, you can specify parts of the standard logging fields to keep out of the logs and you can specify filters so that you log only a subset of the logging records\. 
 
 **Note**  
-You can define one logging destination per web ACL\.
+You can define one logging destination per web ACL\. Log group names and bucket names used as logging destinations <b>must be prefixed with 'aws-waf-logs-</b>'\.
 
 You can access information about the traffic that AWS WAF inspects using the following steps:
 


### PR DESCRIPTION
Added to the note for AWS::WAFv2::LoggingConfiguration to indicate that destination logging configuration resource names (log group name and bucket name) must be prefixed with 'aws-waf-logs-' for it to work.

Documentation for Log Group Name for WAF log support: https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html#logging-cw-logs-naming

Documentation for S3 Bucket Name for WAF log support: https://docs.aws.amazon.com/waf/latest/developerguide/logging-s3.html#logging-s3-naming

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
