### PR TITLE
Update aws-resource-eventschemas-registrypolicy.md

### DIFF
--- a/doc_source/aws-resource-eventschemas-registrypolicy.md
+++ b/doc_source/aws-resource-eventschemas-registrypolicy.md
@@ -86,8 +86,8 @@ Resources:
           Principal:
             AWS: arn:aws:iam::012345678901:user/TestAccountForRegistryPolicy
           Action:
-            - schemas:DescribeRegistry
-            - schemas:CreateSchema
+            - schema:DescribeRegistry
+            - schema:CreateSchema
           Resource: registryArn
 ```
 
@@ -107,7 +107,7 @@ Resources:
           - Sid: 'Test'
             Effect: 'Allow'
             Action:
-              - 'schemas:*'
+              - 'schema:*'
             Principal:
               AWS:
                 - '109876543210'
@@ -134,7 +134,7 @@ Resources:
               "Sid": "Test",
               "Effect": "Allow",
               "Action": [
-                "schemas:*"
+                "schema:*"
               ],
               "Principal": {
                 "AWS": [


### PR DESCRIPTION
`AWS::EventSchemas::RegistryPolicy` Policy Statement Action prefixes should be `schema` not `schemas`. I tried to deploy a CloudFormation temple with a `AWS::EventSchemas::RegistryPolicy` similar to the examples in the documentation. Prefixing Policy Statement Actions with `schemas` yielded the following error:

```
Resource handler returned message: "Error occurred during operation 'CreateRegistryPolicy'." (RequestToken: <some-token>, HandlerErrorCode: GeneralServiceException)
```

I had to dig into the CloudTrail Event History to diagnose the problem.

*Issue #, if available:*

n/a

*Description of changes:*

Change examples of AWS::EventSchemas::RegistryPolicy Policy Statement Action prefixes from `schema` to `schemas`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
