### PR TITLE
Add important ALB to Lambda configuration info to TargetGroup docs

### DIFF
--- a/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
+++ b/doc_source/aws-resource-elasticloadbalancingv2-targetgroup.md
@@ -2,7 +2,7 @@
 
 Specifies a target group for a load balancer\.
 
-Before you register a Lambda function as a target, you must create a `AWS::Lambda::Permission` resource that grants the Elastic Load Balancing service principal permission to invoke the Lambda function\.
+Before you register a Lambda function as a target, you must create a `AWS::Lambda::Permission` resource that grants the Elastic Load Balancing service principal permission to invoke the Lambda function and most users should set the target group attribute `lambda.multi_value_headers.enabled` to `true` to ensure that web request inputs are handled properly.
 
 ## Syntax<a name="aws-resource-elasticloadbalancingv2-targetgroup-syntax"></a>
 


### PR DESCRIPTION
I recently lost a couple of hours debugging ALB to Lambda requests that were not being handled properly before finally finding documentation about the `lambda.multi_value_headers.enabled` target group attribute in https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-targetgroup-targetgroupattribute.html. This changes mentions that target group attribute in the target group page to help users find the setting faster.

*Issue #, if available:* https://github.com/awslabs/aws-serverless-java-container/issues/315

*Description of changes:* Add documentation about `lambda.multi_value_headers.enabled` target group attribute to target group documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
