### PR TITLE
Update aws-resource-iot-resourcespecificlogging.md

### DIFF
--- a/doc_source/aws-resource-iot-resourcespecificlogging.md
+++ b/doc_source/aws-resource-iot-resourcespecificlogging.md
@@ -44,7 +44,7 @@ The target name\.
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `TargetType`  <a name="cfn-iot-resourcespecificlogging-targettype"></a>
-The target type\. Valid Values: `DEFAULT | THING_GROUP`  
+The target type\. Valid Values: `THING_GROUP | CLIENT_ID | SOURCE_IP | PRINCIPAL_ID`  
 *Required*: Yes  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
`AWS::IoT::ResourceSpecificLogging` has updated the arguments that are used. They are no longer `DEFAULT` and `THING_GROUP`, they are now `THING_GROUP`, `CLIENT_ID`, `SOURCE_IP`, and `PRINCIPAL_ID`

These can be checked and validated against the CloudFormation schema registry for `AWS::IoT::ResourceSpecificLogging`
https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/registry/public-extensions/details/schema?arn=arn%3Aaws%3Acloudformation%3Aus-east-1%3A%3Atype%2Fresource%2FAWS-IoT-ResourceSpecificLogging

*Issue #, if available:*
NA

*Description of changes:*

Update arguments from `DEFAULT | THING_GROUP` to `THING_GROUP | CLIENT_ID | SOURCE_IP | PRINCIPAL_ID` to match current CloudFormation schema.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
