### PR TITLE
Update aws-properties-codedeploy-deploymentgroup-deployment-revision.md

### DIFF
--- a/doc_source/aws-properties-codedeploy-deploymentgroup-deployment-revision.md
+++ b/doc_source/aws-properties-codedeploy-deploymentgroup-deployment-revision.md
@@ -45,6 +45,9 @@ The type of application revision:
 *Allowed values*: `AppSpecContent | GitHub | S3 | String`  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
+**Note** 
+CloudFormation currently does not support `AppSpecContent` and `String` properties
+
 `S3Location`  <a name="cfn-properties-codedeploy-deploymentgroup-deployment-revision-s3location"></a>
 Information about the location of a revision stored in Amazon S3\.   
 *Required*: No  


### PR DESCRIPTION
RevisionType supporting "AppSpecContent" and "String" values has created customer confusion, frustration and has lead to the creation of support cases since revision type accept these values but there is no way on how to add these values. A note specifying that this is not supported (or the removal of the values entirely) will aid in removing customer confusion

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
