### PR TITLE
Update AWS::CloudFront::Function Name description with non-updable important information

### DIFF
--- a/doc_source/aws-resource-cloudfront-function.md
+++ b/doc_source/aws-resource-cloudfront-function.md
@@ -67,7 +67,9 @@ A name to identify the function\.
 *Minimum*: `1`  
 *Maximum*: `64`  
 *Pattern*: `^[a-zA-Z0-9-_]{1,64}$`  
-*Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+**Important**
+You can't perform an update on an existing Function's Name\. If you must update the name, specify a new LogicalID for this resource\.
 
 ## Return values<a name="aws-resource-cloudfront-function-return-values"></a>
 


### PR DESCRIPTION
*Description of changes:*

A Cloudfront Function `Name` property is required  and cannot be updated after resource creation.
This behavior was spotted in https://github.com/getlift/lift/issues/247

Changing the name requires changing resource LogicalID to trigger old resource deletion and new resource creation.
Unlike common `name` property whose behavior is described in https://github.com/awsdocs/aws-cloudformation-user-guide/blob/main/doc_source/aws-properties-name.md, Cloudformation cannot handle name generation for this resource type and cannot handle resource replacement.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
