### PR TITLE
Update aws-resource-billingconductor-billinggroup.md

### DIFF
--- a/doc_source/aws-resource-billingconductor-billinggroup.md
+++ b/doc_source/aws-resource-billingconductor-billinggroup.md
@@ -109,7 +109,7 @@ The following example is a billing group that takes a list of linked account IDs
 {
   "Parameters": {
       "LinkedAccountIds": {
-      "Type": "ListNumber"
+          "Type": "List<Number>"
       },
       "PrimaryAccountId": {
           "Type": "Number"
@@ -145,18 +145,18 @@ The following example is a billing group that takes a list of linked account IDs
 ```
 Parameters:
   LinkedAccountIds:
-  Type: ListNumber
+    Type: List<Number>
   PrimaryAccountId:
-      Type: Number
+    Type: Number
 Resources:
   TestBillingGroup:
-      Type: 'AWS::BillingConductor::BillingGroup'
-      Properties:
-        Name: 'TestBillingGroup'
-        Description: 'Test billing group created through CloudFormation with 1 linked account. The linked account is also the primary account.'
-        PrimaryAccountId: !Ref PrimaryAccountId
-        AccountGrouping:
-            LinkedAccountIds: !Ref LinkedAccountIds
-        ComputationPreference:
-            PricingPlanArn: !GetAtt TestPricingPlan.Arn
+    Type: 'AWS::BillingConductor::BillingGroup'
+    Properties:
+      Name: 'TestBillingGroup'
+      Description: 'Test billing group created through CloudFormation with 1 linked account. The linked account is also the primary account.'
+      PrimaryAccountId: !Ref PrimaryAccountId
+      AccountGrouping:
+        LinkedAccountIds: !Ref LinkedAccountIds
+      ComputationPreference:
+        PricingPlanArn: !GetAtt TestPricingPlan.Arn
 ```


### PR DESCRIPTION
Added missing angle brackets around `Types` in both JSON and YAML examples.
Fixed malformed indentation for Parameters in both JSON and YAML examples.

*Issue #, if available:*

*Description of changes:*
Added missing angle brackets around `Types` in both JSON and YAML examples.
Fixed malformed indentation for Parameters in both JSON and YAML examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
