### PR TITLE
fix: Correct ResolutionStrategy string values

### DIFF
--- a/doc_source/aws-properties-lex-bot-slotvalueselectionsetting.md
+++ b/doc_source/aws-properties-lex-bot-slotvalueselectionsetting.md
@@ -33,8 +33,8 @@ A regular expression used to validate the value of a slot\.
 
 `ResolutionStrategy`  <a name="cfn-lex-bot-slotvalueselectionsetting-resolutionstrategy"></a>
 Determines the slot resolution strategy that Amazon Lex uses to return slot type values\. The field can be set to one of the following values:  
-+ OriginalValue \- Returns the value entered by the user, if the user value is similar to a slot value\.
-+ TopResolution \- If there is a resolution list for the slot, return the first value in the resolution list as the slot type value\. If there is no resolution list, null is returned\.
++ ORIGINAL_VALUE \- Returns the value entered by the user, if the user value is similar to a slot value\.
++ TOP_RESOLUTION \- If there is a resolution list for the slot, return the first value in the resolution list as the slot type value\. If there is no resolution list, null is returned\.
 If you don't specify the valueSelectionStrategy, the default is OriginalValue\.  
 *Required*: Yes  
 *Type*: String  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When deploying with CDK, the string "OriginalValue" threw and error.  

```
Properties validation failed for resource LexchimeLexBot2A96F463 with message:
#/BotLocales/0/SlotTypes/0/ValueSelectionSetting/ResolutionStrategy: #: only 1 subschema matches out of 2
#/BotLocales/0/SlotTypes/0/ValueSelectionSetting/ResolutionStrategy: failed validation constraint for keyword [enum]
```

Changing to "ORIGINAL_VALUE" in the CDK resolved this error.

```typescript
      botLocales: [
        {
          localeId: 'en_US',
          nluConfidenceThreshold: 0.4,
          voiceSettings: {
            voiceId: 'Kimberly',
          },
          description: 'English_US',
          slotTypes: [
            {
              name: 'Departments',
              description: 'Possible Departments',
              valueSelectionSetting: {
                resolutionStrategy: 'ORIGINAL_VALUE',
              },
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
