### PR TITLE
Update aws-resource-codeartifact-repository.md

### DIFF
--- a/doc_source/aws-resource-codeartifact-repository.md
+++ b/doc_source/aws-resource-codeartifact-repository.md
@@ -71,7 +71,7 @@ Properties:
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 `ExternalConnections`  <a name="cfn-codeartifact-repository-externalconnections"></a>
- An array of external connections associated with the repository\.   
+ An array of external connections associated with the repository. Currently only one external connection is allowed per repository.\.   
 *Required*: No  
 *Type*: List of String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:* 1263

*Description of changes:*
Updated documentation to highlight that only one external connection is allowed per repository, through the resource property type is a list of strings. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
