### PR TITLE
Update aws-properties-cloudfront-distribution-s3originconfig.md

### DIFF
--- a/doc_source/aws-properties-cloudfront-distribution-s3originconfig.md
+++ b/doc_source/aws-properties-cloudfront-distribution-s3originconfig.md
@@ -27,6 +27,7 @@ The CloudFront origin access identity to associate with the origin\. Use an orig
 origin\-access\-identity/cloudfront/*ID\-of\-origin\-access\-identity*   
 where ` ID-of-origin-access-identity ` is the value that CloudFront returned in the `ID` element when you created the origin access identity\.  
 If you want viewers to be able to access objects using either the CloudFront URL or the Amazon S3 URL, specify an empty `OriginAccessIdentity` element\.  
+If you want to use origin access control rather than origin access identity, specify an empty String for the `OriginAccessIdentity` element\.  
 To delete the origin access identity from an existing distribution, update the distribution configuration and include an empty `OriginAccessIdentity` element\.  
 To replace the origin access identity, update the distribution configuration and specify the new origin access identity\.  
 For more information about the origin access identity, see [Serving Private Content through CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html) in the *Amazon CloudFront Developer Guide*\.  


### PR DESCRIPTION
Added missing (yet critical) information on how to configure Origin Access Control

*Issue #, if available:*

Added missing paragraph.  The new Origin Access Control feature is strongly recommended, yet the documentation does not specify how one must provide an empty OAI value to use it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
