### PR TITLE
Update aws-resource-wafv2-loggingconfiguration.md

### DIFF
--- a/doc_source/aws-resource-wafv2-loggingconfiguration.md
+++ b/doc_source/aws-resource-wafv2-loggingconfiguration.md
@@ -51,6 +51,7 @@ Properties:
 `LogDestinationConfigs`  <a name="cfn-wafv2-loggingconfiguration-logdestinationconfigs"></a>
 The logging destination configuration that you want to associate with the web ACL\.  
 You can associate one logging destination to a web ACL\.
+If logging destination target is a CloudWatch Log Group, it is required that the reference Log Group's name begin with the prefix 'aws-waf-logs-'\.
 *Required*: Yes  
 *Type*: List of String  
 *Maximum*: `100`  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add helpful information about the required naming prefix of a CloudWatch Log Group if used as the Log Destination.

The current error message returned from CloudFormation when a Log Group without this prefix is referenced for the LogDestinationConfigs is misleading and unhelpful `(Error: Resource handler returned message: "Error reason: The ARN isn't valid. A valid ARN begins with arn: and includes other information separated by colons or slashes., field: LOG_DESTINATION, parameter: .....HandlerErrorCode: InvalidRequest) `   In our case, we were using the intrinsic !GetAtt function to reference a newly created LogGroup within the same stack, so the ARN is correct/valid - the error was appearing because the LogGroup did not follow this naming convention that does not appear to be in the CloudFormation documentation here currently.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
