### PR TITLE
Update Allowed Values for CloudWatchEncryption, JobBookmarksEncryption, and S3Encryption

### DIFF
--- a/doc_source/aws-properties-glue-securityconfiguration-cloudwatchencryption.md
+++ b/doc_source/aws-properties-glue-securityconfiguration-cloudwatchencryption.md
@@ -28,6 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 The encryption mode to use for CloudWatch data\.  
 *Required*: No  
 *Type*: String  
+*Allowed Values*: `DISABLED | SSE-KMS`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `KmsKeyArn`  <a name="cfn-glue-securityconfiguration-cloudwatchencryption-kmskeyarn"></a>

--- a/doc_source/aws-properties-glue-securityconfiguration-jobbookmarksencryption.md
+++ b/doc_source/aws-properties-glue-securityconfiguration-jobbookmarksencryption.md
@@ -28,6 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 The encryption mode to use for job bookmarks data\.  
 *Required*: No  
 *Type*: String  
+*Allowed Values*: `DISABLED | CSE-KMS`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `KmsKeyArn`  <a name="cfn-glue-securityconfiguration-jobbookmarksencryption-kmskeyarn"></a>

--- a/doc_source/aws-properties-glue-securityconfiguration-s3encryption.md
+++ b/doc_source/aws-properties-glue-securityconfiguration-s3encryption.md
@@ -34,4 +34,5 @@ The Amazon Resource Name \(ARN\) of the KMS key to be used to encrypt the data\.
 The encryption mode to use for Amazon S3 data\.  
 *Required*: No  
 *Type*: String  
+*Allowed Values*: `DISABLED | SSE-KMS | SSE-S3`
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Description of changes:*
Add allowed values to the S3EncryptionMode in S3Encryption, JobBookmarksEncryptionMode in JobBookmarksEncryption, and CloudWatchEncryptionMode in CloudWatchEncryption.
The values are sourced from API documentation for [S3Encryption](https://docs.aws.amazon.com/glue/latest/webapi/API_S3Encryption.html), [JobBookmarksEncryption](https://docs.aws.amazon.com/glue/latest/webapi/API_JobBookmarksEncryption.html), and [CloudWatchEncryption](https://docs.aws.amazon.com/glue/latest/webapi/API_CloudWatchEncryption.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
