### PR TITLE
Update VpcId parameters

### DIFF
--- a/doc_source/aws-properties-ec2-security-group.md
+++ b/doc_source/aws-properties-ec2-security-group.md
@@ -82,8 +82,8 @@ Any tags assigned to the security group\.
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `VpcId`  <a name="cfn-ec2-securitygroup-vpcid"></a>
-\[VPC only\] The ID of the VPC for the security group\.  
-*Required*: No  
+\[VPC only\] The ID of the VPC for the security group\. Your default VPC ID will be used if you do not define the VpcId here\. Furthermore\, VpcId is required if you specify SecurityGroupEgress rules\.  
+*Required*: Conditional  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 


### PR DESCRIPTION
YOU CANNOT CREATE A SECURITY GROUP WITHOUT A VPC. In case you do not define VpcId here, CloudFormation uses the default VPC. However, explicitly providing VPC is necessary if you specify SecurityGroupEgress rules. If you do not, you get the error- CREATE_FAILED	SecurityGroupEgress cannot be specified without VpcId

So in essence, VpcId is a conditional field.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
