### PR TITLE
AWS::Logs::ResourcePolicy GovCloud

### DIFF
--- a/doc_source/aws-resource-logs-resourcepolicy.md
+++ b/doc_source/aws-resource-logs-resourcepolicy.md
@@ -2,6 +2,9 @@
 
 Creates or updates a resource policy that allows other AWS services to put log events to this account\. An account can have up to 10 resource policies per AWS Region\.
 
+**Important**
+This resource type is not supported in GovCloud Regions as of 2022-10-20.
+
 ## Syntax<a name="aws-resource-logs-resourcepolicy-syntax"></a>
 
 To declare this entity in your AWS CloudFormation template, use the following syntax:


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Using this resource in GovCloud results in the following: 
`Template format error: Unrecognized resource types: [AWS::Logs::ResourcePolicy]`

Can we please add a disclaimer indicating this in the actual reference material?

If we have to change the format of it, or it needs to be rewritten, I don't care. But this information needs to be available and loud in the source reference. 

Related: 
- https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/351
- https://github.com/aws/aws-cdk/issues/5343#issuecomment-1207030757


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
