### PR TITLE
Removed unwanted part from AWS ECR Cloudformation Documentation

### DIFF
--- a/doc_source/aws-properties-ecr-repository-lifecyclepolicy.md
+++ b/doc_source/aws-properties-ecr-repository-lifecyclepolicy.md
@@ -33,7 +33,7 @@ The JSON repository policy text to apply to the repository\.
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `RegistryId`  <a name="cfn-ecr-repository-lifecyclepolicy-registryid"></a>
-The AWS account ID associated with the registry that contains the repository\. If you do  not specify a registry, the default registry is assumed\.  
+The AWS account ID associated with the registry that contains the repository\. If you do not specify a registry, the default registry is assumed\.  
 *Required*: No  
 *Type*: String  
 *Pattern*: `[0-9]{12}`  


### PR DESCRIPTION
*Description of changes:*

Removed unwanted small text part which is affecting on [AWS Cloudformation Documentation for ECR Repository](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecr-repository-lifecyclepolicy.html).

As we can see below in the screenshot, 


![image](https://user-images.githubusercontent.com/53929423/197144142-58005c4e-56ca-4e9b-9a87-56337ae6ba99.png)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
