### PR TITLE
Correct required propeties of `FunctionCode` and `FunctionConfig` of AWS::CloudFront::Function

### DIFF
--- a/doc_source/aws-resource-cloudfront-function.md
+++ b/doc_source/aws-resource-cloudfront-function.md
@@ -50,13 +50,13 @@ A flag that determines whether to automatically publish the function to the `LIV
 
 `FunctionCode`  <a name="cfn-cloudfront-function-functioncode"></a>
 The function code\. For more information about writing a CloudFront function, see [Writing function code for CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/writing-function-code.html) in the *Amazon CloudFront Developer Guide*\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `FunctionConfig`  <a name="cfn-cloudfront-function-functionconfig"></a>
 Contains configuration information about a CloudFront function\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: [FunctionConfig](aws-properties-cloudfront-function-functionconfig.md)  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
They both are required based on this https://docs.aws.amazon.com/ja_jp/cloudfront/latest/APIReference/API_CreateFunction.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
