### PR TITLE
Update aws-resource-config-deliverychannel.md

### DIFF
--- a/doc_source/aws-resource-config-deliverychannel.md
+++ b/doc_source/aws-resource-config-deliverychannel.md
@@ -75,7 +75,7 @@ If you specify a bucket that belongs to another AWS account, that bucket must ha
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `S3KeyPrefix`  <a name="cfn-config-deliverychannel-s3keyprefix"></a>
-The prefix for the specified Amazon S3 bucket\.  
+The prefix for the specified Amazon S3 bucket\.  Do not include 'AWSLogs/' in your value as it is prepended automatically.
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
@@ -132,8 +132,6 @@ DeliveryChannel:
   Properties: 
     ConfigSnapshotDeliveryProperties: 
       DeliveryFrequency: "Six_Hours"
-    S3BucketName: 
-      Ref: ConfigBucket
-    SnsTopicARN: 
-      Ref: ConfigTopic
+    S3BucketName: !Ref ConfigBucket
+    SnsTopicARN: !Ref ConfigTopic
 ```

--- a/doc_source/aws-resource-config-deliverychannel.md
+++ b/doc_source/aws-resource-config-deliverychannel.md
@@ -75,7 +75,7 @@ If you specify a bucket that belongs to another AWS account, that bucket must ha
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `S3KeyPrefix`  <a name="cfn-config-deliverychannel-s3keyprefix"></a>
-The prefix for the specified Amazon S3 bucket\.  Do not include 'AWSLogs/' in your value as it is prepended automatically.
+The prefix for the specified Amazon S3 bucket\.  Do not include 'AWSLogs/' in your value as it is prepended automatically\. Ex: BucketName/S3KeyPrefix/AWSLogs/sourceAccountID/Config/Region\.  
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
I have been writing a cloudformation template to create an AWS Config recorder, delivery channel, bucket, rules, and service role. I encountered a few issues with the documentation when creating a template that could help others when creating their own AWS Config + Delivery Channel template.

I am not sure how to express this, however this was a struggle for me when using the documentation. If someone can add this to the help text it would help:
- Both the AWS Config Recorder and the AWS Config Delivery Channel need to be in the same cloudformation template, without depending on each other. Adding DependsOn to the DeliveryChannel for the Config Recorder will fail as the Config Recorder will try to start before sending a Completed signal.

*Description of changes:*
- S3KeyPrefix must not include 'AWSLogs/' in value. Cloudformation will throw an error if that is included.
- When adding s3 bucket policy, prefix is located before '/AWSLogs': arn:aws:s3:::targetBucketName/[optional] prefix/AWSLogs/sourceAccountID/Config/*
- YAML example should include shorthand syntax. Have tested and deployed successfully with shorthand '!Ref' for DeliveryChannel properties.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
