### PR TITLE
Fix broken link to DocumentationPart

### DIFF
--- a/doc_source/aws-properties-apigateway-documentationpart-location.md
+++ b/doc_source/aws-properties-apigateway-documentationpart-location.md
@@ -64,5 +64,4 @@ The type of API entity that the documentation content applies to\.
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 ## See also<a name="aws-properties-apigateway-documentationpart-location--seealso"></a>
-+ [DocumentationPart](https://docs.aws.amazon.com/apigateway/api-reference/resource/documentation-part/) in the *Amazon API Gateway REST API Reference*
-
++ [DocumentationPart](https://docs.aws.amazon.com/apigateway/latest/api/API_DocumentationPart.html) in the *Amazon API Gateway API Reference*


### PR DESCRIPTION
*Issue #, if available:*

The link to the DocumentationPart is broken.

*Description of changes:*

Update the link to an existing target and update the link text to match the name of the document site.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
