### PR TITLE
Update stack-failure-options

### DIFF
--- a/doc_source/stack-failure-options.md
+++ b/doc_source/stack-failure-options.md
@@ -132,7 +132,7 @@ Specify the `disable-rollback` option or `on-failure DO_NOTHING` enumeration dur
 1. Provide a stack name and template to the `create-stack` command with the `disable-rollback` option\.
 
    ```
-   aws cloudformation create-stack --stack-name myteststack --template-body file://DOC-EXAMPLE-BUCKET.json -–disable-rollback
+   aws cloudformation create-stack --stack-name myteststack --template-body file://DOC-EXAMPLE-BUCKET.json --disable-rollback
    ```
 
    The command returns the following output\.
@@ -245,7 +245,7 @@ Specify the `disable-rollback` option or `on-failure DO_NOTHING` enumeration dur
 1. Initiate the change set with `disable-rollback` option\.
 
    ```
-   aws cloudformation execute-change-set --stack-name myteststack --change-set-name my-change-set -–disable-rollback
+   aws cloudformation execute-change-set --stack-name myteststack --change-set-name my-change-set --disable-rollback
    ```
 
 1. Determine the status of the stack using either the `describe-stacks` or `describe-stack-events` option\.


### PR DESCRIPTION
fix roll back dashes

*Description of changes:*

aws cli is not accepting the one posted on the webpage.

-–disable-rollback is not a valid option
--disable-rollback is the correct form


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
