### PR TITLE
Add "FilterPolicyScope" to SNS Subscription Docs

### DIFF
--- a/doc_source/aws-resource-sns-subscription.md
+++ b/doc_source/aws-resource-sns-subscription.md
@@ -15,6 +15,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
       "[DeliveryPolicy](#cfn-sns-subscription-deliverypolicy)" : Json,
       "[Endpoint](#cfn-sns-endpoint)" : String,
       "[FilterPolicy](#cfn-sns-subscription-filterpolicy)" : Json,
+      "[FilterPolicyScope](#cfn-sns-subscription-filterpolicyscope)" : String,
       "[Protocol](#cfn-sns-protocol)" : String,
       "[RawMessageDelivery](#cfn-sns-subscription-rawmessagedelivery)" : Boolean,
       "[RedrivePolicy](#cfn-sns-subscription-redrivepolicy)" : Json,
@@ -33,6 +34,7 @@ Properties:
   [DeliveryPolicy](#cfn-sns-subscription-deliverypolicy): Json
   [Endpoint](#cfn-sns-endpoint): String
   [FilterPolicy](#cfn-sns-subscription-filterpolicy): Json
+  [FilterPolicyScope](#cfn-sns-subscription-filterpolicyscope): String
   [Protocol](#cfn-sns-protocol): String
   [RawMessageDelivery](#cfn-sns-subscription-rawmessagedelivery): Boolean
   [RedrivePolicy](#cfn-sns-subscription-redrivepolicy): Json
@@ -59,6 +61,12 @@ The subscription's endpoint\. The endpoint value depends on the protocol that yo
 The filter policy JSON assigned to the subscription\. Enables the subscriber to filter out unwanted messages\. For more information, see ` [GetSubscriptionAttributes](https://docs.aws.amazon.com/sns/latest/api/API_GetSubscriptionAttributes.html) ` in the *Amazon SNS API Reference* and [Message filtering](https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html) in the *Amazon SNS Developer Guide*\.  
 *Required*: No  
 *Type*: Json  
+*Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+`FilterPolicyScope`  <a name="cfn-sns-subscription-filterpolicyscope"></a>
+The filter policy scope assigned to the subscription, defaults to `MessageAttributes`\. Accepts either `MessageAttributes` or `MessageBody`\. For more information, see ` [GetSubscriptionAttributes](https://docs.aws.amazon.com/sns/latest/api/API_GetSubscriptionAttributes.html) ` in the *Amazon SNS API Reference* and [Message filtering](https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html) in the *Amazon SNS Developer Guide*\.  
+*Required*: No  
+*Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 `Protocol`  <a name="cfn-sns-protocol"></a>


### PR DESCRIPTION
*Issue #, if available:* #1288

*Description of changes:* The SNS Subscription `FilterPolicyScope` is undocumented in the CloudFormation docs for SNS. In the AWS SNS examples, [there is a example of this attribute being used](https://github.com/aws-samples/aws-sns-samples/blob/e2144907411cd3edbb63bcf72f4f52916e0386fc/templates/SNS-Payload-Based-Filtering-SAM.template#L57)

This commit adds documentation for the missing attribute.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
