### PR TITLE
Update aws-resource-kinesisanalyticsv2-application.md

### DIFF
--- a/doc_source/aws-resource-kinesisanalyticsv2-application.md
+++ b/doc_source/aws-resource-kinesisanalyticsv2-application.md
@@ -406,9 +406,9 @@ Resources:
           CustomArtifactsConfiguration:
             - ArtifactType: DEPENDENCY_JAR
               MavenReference:
-                GroupId: software.amazon.kinesis
-                ArtifactId: amazon-kinesis-sql-connector-flink
-                Version: 2.0.3
+                GroupId: org.apache.flink
+                ArtifactId: flink-sql-connector-kinesis_2.12
+                Version: 1.13.2
             - ArtifactType: DEPENDENCY_JAR
               MavenReference:
                 GroupId: org.apache.flink


### PR DESCRIPTION
The original artifact dictated for the kinesis connector results in a CFN error "found unsupported maven references in CustomArtifactsConfiguration". Changed to what works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
