### PR TITLE
Update apigatewayv2 route examples to remove invalid property.

### DIFF
--- a/doc_source/aws-resource-apigatewayv2-route.md
+++ b/doc_source/aws-resource-apigatewayv2-route.md
@@ -185,9 +185,6 @@ The following example creates a `route` resource called `MyRoute` for a WebSocke
 {
     "MyRoute": {
         "Type": "AWS::ApiGatewayV2::Route",
-        "DependsOn": [
-            "MyIntegration"
-        ],
         "Properties": {
             "ApiId": {
                 "Ref": "MyApi"
@@ -215,8 +212,6 @@ The following example creates a `route` resource called `MyRoute` for a WebSocke
 ```
 MyRoute:
   Type: 'AWS::ApiGatewayV2::Route'
-  DependsOn:
-    - MyIntegration
   Properties:
     ApiId: !Ref MyApi
     RouteKey: routekey1


### PR DESCRIPTION
Removes "DependsOn" as a property from JSON and YAML WebSocket Examples. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-route.html This is not a valid property of an APIGatewayV2 route, as per the docs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
