### PR TITLE
Update Quicksight Dataset Required Fields

### DIFF
--- a/doc_source/aws-resource-quicksight-datasource.md
+++ b/doc_source/aws-resource-quicksight-datasource.md
@@ -66,7 +66,7 @@ A set of alternate data source parameters that you want to share for the credent
 
 `AwsAccountId`  <a name="cfn-quicksight-datasource-awsaccountid"></a>
 The AWS account ID\.  
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Minimum*: `12`  
 *Maximum*: `12`  
@@ -81,7 +81,7 @@ The credentials Amazon QuickSight that uses to connect to your underlying source
 
 `DataSourceId`  <a name="cfn-quicksight-datasource-datasourceid"></a>
 An ID for the data source\. This ID is unique per AWS Region for each AWS account\.   
-*Required*: No  
+*Required*: Yes  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
These two fields are required by Cloudformation for deployment. 

If AwsAccountId is missing the error returned is: "Unable to marshall request to JSON: Parameter 'AwsAccountId' must not be null"
If DataSourceId is missing the error returned is: "1 validation error detected: Value null at 'dataSourceId' failed to satisfy constraint: Member must not be null"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
