### PR TITLE
Fix missing newlines in examples

### DIFF
--- a/doc_source/cfn-init.md
+++ b/doc_source/cfn-init.md
@@ -74,8 +74,8 @@ To include the latest version, add `yum install -y aws-cfn-bootstrap` to the `Us
                 "",
                 [
                     "#!/bin/bash -xe\n",
-                    "",
-                    "yum install -y aws-cfn-bootstrap",
+                    "\n",
+                    "yum install -y aws-cfn-bootstrap\n",
                     "/opt/aws/bin/cfn-init -v ",
                     "         --stack ",
                     {
@@ -105,8 +105,8 @@ UserData: !Base64
     - ''
     - - |
         #!/bin/bash -xe
-      - ''
-      - yum install -y aws-cfn-bootstrap
+      - "\n"
+      - "yum install -y aws-cfn-bootstrap\n"
       - '/opt/aws/bin/cfn-init -v '
       - '         --stack '
       - !Ref 'AWS::StackName'


### PR DESCRIPTION
Add missing newline signs in code examples. Without it the resulting UserData bash script contained invalid lines.

*Issue #, if available:*

*Description of changes:*

Fixed YAML and JSON templates to produce correct bash scripts. The original code would create a line starting with: `yum install -y aws-cfn-bootstrap/opt/aws/bin/cfn-init -v ...`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
