### PR TITLE
Striving for clarity and simplicity

### DIFF
--- a/doc_source/template-custom-resources.md
+++ b/doc_source/template-custom-resources.md
@@ -27,7 +27,9 @@ Owns the custom resource and determines how to handle and respond to requests fr
 AWS CloudFormation  
 During a stack operation, sends a request to a service token that is specified in the template, and then waits for a response before proceeding with the stack operation\.
 
-The template developer and custom resource provider can be the same person or entity, but the process is the same\. The following steps describe the general process:
+The template developer and custom resource provider can be the same person or entity\. 
+
+The following steps describe the general process of creating a custom resource:
 
 1. The template developer defines a custom resource in their template, which includes a service token and any input data parameters\. Depending on the custom resource, the input data might be required; however, the service token is always required\.
 


### PR DESCRIPTION
Removing a non-contradictory "but" statement. Perhaps nitpicking but the part Im removing sounds off to me since the first part is not opposite, in my mind its like saying "the day is nice but the sky is pretty". The part about the process being the same doesnt seem to match the subject or context of the first part of the sentence (before the comma), which process is the same?

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
