### PR TITLE
[`Fn::Sub`] Relax documented restrictions on `String` parameter

### DIFF
--- a/doc_source/intrinsic-function-reference-sub.md
+++ b/doc_source/intrinsic-function-reference-sub.md
@@ -153,7 +153,8 @@ UserData:
 
 ## Supported functions<a name="w11339ab1c31c28c59c13"></a>
 
-For the `String` parameter, you can't use any functions\. You must specify a string value\.
+For the `String` parameter, you can use the following functions\. You must specify a string value\:
++ `Fn::Transform`
 
 For the `VarName` and `VarValue` parameters, you can use the following functions:
 + `Fn::Base64`


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-cloudformation/cfn-lint/issues/2587

*Description of changes:*

Clarify the ability to use an `Fn::Transform` in the `String` parameter of an `Fn::Sub`.

### Discussion

Looking for feedback on how to better integrate the use of `Fn::Transform` into the documentation as a whole. I think one way to do this is to relax some of the strict statements around the section I am editing here. If there is a better doc writer out there that wants to help me wordsmith the docs here, I am completely open to that.

I feel that `Fn::Transform` is a bit more of an advanced CFN tool, and thus we may need to balance detail vs the need for simple documentation for more common features. However, I do strongly believe that the docs should not make strict claims about what is or is not possible in CFN. Meaning, the docs should maintain technical correctness.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
