### PR TITLE
Update aws-resource-dynamodb-table.md

### DIFF
--- a/doc_source/aws-resource-dynamodb-table.md
+++ b/doc_source/aws-resource-dynamodb-table.md
@@ -152,7 +152,7 @@ If you set `BillingMode` as `PROVISIONED`, you must specify this property\. If y
 Specifies the settings to enable server\-side encryption\.  
 *Required*: No  
 *Type*: [SSESpecification](aws-properties-dynamodb-table-ssespecification.md)  
-*Update requires*: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt)
+*Update requires*: [No interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt)
 
 `StreamSpecification`  <a name="cfn-dynamodb-table-streamspecification"></a>
 The settings for the DynamoDB table stream, which capture changes to items stored in the table\.  


### PR DESCRIPTION
There is a conflict in the SSESpecification update behavior. It's mentioned in AWS::DynamoDB::Table [page](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-ssespecification) that updating SSESpecification requires some interruption. While going through the SSESpecification documentation page [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html), there is no attribute that requires some interruption.

Additionally, according to the DynamoDB documentation the process of  changing SSE encryption settings  seamless and does not require downtime or degrade service [link](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption.usagenotes.html).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
