### PR TITLE
Add details about limitations of `templateURL`

### DIFF
--- a/doc_source/cfn-console-create-stacks-quick-create-links.md
+++ b/doc_source/cfn-console-create-stacks-quick-create-links.md
@@ -9,6 +9,8 @@ CloudFormation supports the following URL query parameters:
 `templateURL`  
 Required\. Specifies the URL of the stack template\. URL encoding is supported, but it isn't required\.
 
+The URL must point to a template with a maximum size of 1 MB that is stored in an S3 bucket that you have read permissions to and that is located in the same region as the stack\. The URL can be a maximum of 1024 characters long\.
+
 `stackName`  
 Optional\. Specifies the stack name\. A stack name can contain only alphanumeric characters \(case\-sensitive\) and hyphens\. It must start with an alphabetic character and can't be longer than 128 characters\.
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Before accepting this pull request please confirm that my change is correct because I am still not sure if my correction to the docs is correct.

The reason I am making this pull request is that I am seeing limitations about the url that can be provided for the templateURL option and [on another page](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-template.html), it mentions this limitation about a template url for creating a stack. My assumption is that this limitation is also true for the `templateURL`. Is my assumption correct?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
