### PR TITLE
Fix an error in rate expression

### DIFF
--- a/doc_source/aws-resource-scheduler-schedule.md
+++ b/doc_source/aws-resource-scheduler-schedule.md
@@ -88,7 +88,7 @@ The name of the schedule\.
 `ScheduleExpression`  <a name="cfn-scheduler-schedule-scheduleexpression"></a>
  The expression that defines when the schedule runs\. The following formats are supported\.   
 +  `at` expression \- `at(yyyy-mm-ddThh:mm:ss)` 
-+  `rate` expression \- `rate(unit value)` 
++  `rate` expression \- `rate(value unit)` 
 +  `cron` expression \- `cron(fields)` 
  You can use `at` expressions to create one\-time schedules that invoke a target once, at the time and in the time zone, that you specify\. You can use `rate` and `cron` expressions to create recurring schedules\. Rate\-based schedules are useful when you want to invoke a target at regular intervals, such as every 15 minutes or every five days\. Cron\-based schedules are useful when you want to invoke a target periodically at a specific time, such as at 8:00 am \(UTC\+0\) every 1st day of the month\.   
  A `cron` expression consists of six fields separated by white spaces: `(minutes hours day_of_month month day_of_week year)`\.   


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
rate expression should be `rate(value unit)` instead of `rate(unit value)`
