### PR TITLE
Updated AWSConfigRole => AWS_ConfigRole

### DIFF
--- a/doc_source/aws-resource-config-aggregationauthorization.md
+++ b/doc_source/aws-resource-config-aggregationauthorization.md
@@ -294,7 +294,7 @@ The following example enables AWS Config and creates an AWS Config rule, an aggr
                 },
                 "Path": "/",
                 "ManagedPolicyArns": [
-                    "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
+                    "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
                 ]
             }
         },
@@ -498,7 +498,7 @@ Resources:
               - sts:AssumeRole
       Path: /
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSConfigRole
+        - arn:aws:iam::aws:policy/service-role/AWS_ConfigRole
 
   ConfigRecorder:
     Type: AWS::Config::ConfigurationRecorder


### PR DESCRIPTION
As per the [service announcement made last year](https://aws.amazon.com/blogs/mt/service-notice-upcoming-changes-required-for-aws-config/), the managed policy ```AWSConfigRole``` is being deprecated, and replace with ```AWS_ConfigRole```.

This PR updates the YAML and JSON cloudformation examples to use the new role, and not the deprecated one.
(Trying to use the cloudformation template as-is will result in error).