### PR TITLE
Update AutoScalingGroupArn description

### DIFF
--- a/doc_source/aws-properties-ecs-capacityprovider-autoscalinggroupprovider.md
+++ b/doc_source/aws-properties-ecs-capacityprovider-autoscalinggroupprovider.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ## Properties<a name="aws-properties-ecs-capacityprovider-autoscalinggroupprovider-properties"></a>
 
 `AutoScalingGroupArn`  <a name="cfn-ecs-capacityprovider-autoscalinggroupprovider-autoscalinggrouparn"></a>
-The Amazon Resource Name \(ARN\) that identifies the Auto Scaling group\.  
+The Amazon Resource Name \(ARN\) that identifies the Auto Scaling group\. You can also provide only the resource name for the Auto Scaling group instead of the full ARN.
 *Required*: Yes  
 *Type*: String  
 *Update requires*: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
*Description of changes:*

The `AutoScalingGroupArn` property for `AutoScalingGroupProvider` within the `AWS::ECS::CapacityProvider` does not mention that you can also pass an Auto Scaling Group resource name instead of a full ARN. This is important for readers to know because `AWS::AutoScaling::AutoScalingGroup` does not have a return value for ARN, you can only receive its resource name via the `Ref` Intrinsic Function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
