### PR TITLE
Update eventbridge-events.md

### DIFF
--- a/doc_source/eventbridge-events.md
+++ b/doc_source/eventbridge-events.md
@@ -471,7 +471,7 @@ The following is an example response for StackSet stack instance status event\.
 }
 ```
 
-## StackSet operation status event schema<a name="schema-stackset-stack-instance-status"></a>
+## StackSet operation status event schema<a name="schema-stackset-stack-operation-status"></a>
 
 The following schema is the structure for a StackSet operation status event\.
 
@@ -532,7 +532,7 @@ The unique ID that's associated with the StackSet operation\.
 `status`  
 The StackSet operation status\. StackSet operation statuses can be `RUNNING`, `SUCCEEDED`, `FAILED`, `STOPPING`, `STOPPED`, or `QUEUED`\.
 
-**Example StackSet operation status event**  <a name="schema-stackset-stack-instance-status.example"></a>
+**Example StackSet operation status event**  <a name="schema-stackset-stack-operation-status.example"></a>
 The following is an example response for StackSet operation status event\.  
 
 ```


### PR DESCRIPTION
Rename schema-stackset-stack-instance-status to schema-stackset-stack-operation-status for StackSet operation status event schema header.

Issue #, if available: None

Description of changes:
In the AWS CloudFormation documentation page (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/eventbridge-events.html#schema-stackset-stack-instance-status), there is a discrepancy in the hyperlink for the StackSet operation status event schema. The hyperlink for schema-stackset-stack-instance-status is duplicated for both StackSet instance status event schema and StackSet operation status event schema headers. This PR renames the schema-stackset-stack-instance-status to schema-stackset-stack-operation-status for the StackSet operation status event schema header, so that each event schema header has its own unique hyperlink.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.