### PR TITLE
Fix GetAtt IAM::Role RoleId example

### DIFF
--- a/doc_source/aws-resource-iam-role.md
+++ b/doc_source/aws-resource-iam-role.md
@@ -149,7 +149,7 @@ Returns the Amazon Resource Name \(ARN\) for the role\. For example:
 This will return a value such as `arn:aws:iam::1234567890:role/MyRole-AJJHDSKSDF`\.
 
 `RoleId`  <a name="RoleId-fn::getatt"></a>
-Returns the stable and unique string identifying the role\. For example, `AIDAJQABLZS4A3QDU576Q`\.  
+Returns the stable and unique string identifying the role\. For example, `AROAJQABLZS4A3QDU576Q`\.  
 For more information about IDs, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html) in the *IAM User Guide*\.
 
 ## Examples<a name="aws-resource-iam-role--examples"></a>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I found this a little confusing, since I was looking to get an AROA ID of a Role in a S3 Bucket policy. If it was returning an AIDA, it wasn't clear what user the AIDA would be for. Turns out this does work and returns an AROA, but the doc example was ever so slightly misleading. 

GetAtt RoleId on Type: IAM::Role returns a prefix of AROA not a AIDA as per https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
